### PR TITLE
fix: swapped log messages

### DIFF
--- a/Egil.Orleans.EventSourcing/src/Egil.Orleans.EventSourcing/AzureStorage/AppendBlobStorage/AzureAppendBlobEventStorage.cs
+++ b/Egil.Orleans.EventSourcing/src/Egil.Orleans.EventSourcing/AzureStorage/AppendBlobStorage/AzureAppendBlobEventStorage.cs
@@ -370,10 +370,10 @@ public sealed partial class AzureAppendBlobEventStorage<TEvent>(
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to apply events to log.")]
     private partial void LogFailedToApplyEvents(Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Deserialization of event {Version} from event storage returned null.")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize event {Version} from event storage.")]
     private partial void LogErrorDeserializingEvent(Exception exception, int version);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize event {Version} from event storage.")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Deserialization of event {Version} from event storage returned null.")]
     private partial void LogDeserializationReturnedNull(int version);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to read the expected payload bytes for event {Version}. Read {BytesRead} bytes of {ExpectedPayloadLength}.")]

--- a/Egil.Orleans.EventSourcing/src/Egil.Orleans.EventSourcing/AzureStorage/TableStorage/StreamstoneEventStorage.cs
+++ b/Egil.Orleans.EventSourcing/src/Egil.Orleans.EventSourcing/AzureStorage/TableStorage/StreamstoneEventStorage.cs
@@ -159,12 +159,12 @@ public sealed partial class StreamstoneEventStorage<TEvent>(
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to apply events to log.")]
     private partial void LogFailedToApplyEvents(Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize event {Version} from event storage.")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Deserialization of event {Version} from event storage returned null.")]
     private partial void LogDeserializationReturnedNull(int version);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize event {Version} from event storage. Event data not found in table row.")]
     private partial void LogDeserializationFailedMissingData(int version);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Deserialization of event {Version} from event storage returned null.")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize event {Version} from event storage.")]
     private partial void LogErrorDeserializingEvent(Exception exception, int version);
 }


### PR DESCRIPTION
## Summary
- update AzureAppendBlobEventStorage log messages
- update StreamstoneEventStorage log messages

## Testing
- `dotnet --list-sdks`
- `dotnet test Egil.Orleans.EventSourcing.sln --no-build --list-tests` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_6867f6623b38832b84ef8d19fec3bb27