### PR TITLE
feat(stjm): support migration from non-object JSON payloads

### DIFF
--- a/Egil.SystemTextJson.Migration/README.md
+++ b/Egil.SystemTextJson.Migration/README.md
@@ -148,6 +148,47 @@ public record UserV2(string FirstName, string LastName, int Age)
 <!-- endSnippet -->
 
 
+### Migrating from non-object JSON payloads
+
+When the stored JSON is not an object — for example, a plain array or a primitive — the library can migrate it to a structured target type. The source type does not need `[JsonMigratable]`:
+
+<!-- snippet: non_object_list_types -->
+<a id='snippet-non_object_list_types'></a>
+```cs
+// The target type accepts a List<string> as its source.
+// The source type (List<string>) is NOT marked with [JsonMigratable]
+// — it's a plain .NET collection whose JSON representation is an array.
+[JsonMigratable(TypeDiscriminator = "settings-v2")]
+public record SettingsV2(List<string> Tags, string Label)
+    : IMigrateFrom<List<string>, SettingsV2>
+{
+    public static bool TryMigrateFrom(List<string> source, out SettingsV2 result)
+    {
+        result = new SettingsV2(source, "migrated");
+        return true;
+    }
+}
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L3-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_list_types' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: non_object_list_usage -->
+<a id='snippet-non_object_list_usage'></a>
+```cs
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+options.AddJsonMigrationSupport();
+
+// Stored JSON is a plain array — no $type, no object wrapper.
+var json = """["csharp","dotnet","azure"]""";
+SettingsV2 settings = JsonSerializer.Deserialize<SettingsV2>(json, options)!;
+// settings.Tags = ["csharp", "dotnet", "azure"], settings.Label = "migrated"
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L81-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_list_usage' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+After migration, the target type serializes as an object with `$type`, so future reads take the zero-allocation happy path. See the [recipe](https://github.com/egil/framework/tree/main/Egil.SystemTextJson.Migration/docs/recipes/migration-authoring.md#migrating-from-non-object-json-payloads) for more examples including primitives and mixed migrators.
+
+
 ### Dependency injection for migrators
 
 Pass an `IServiceProvider` so external migrators can receive constructor-injected dependencies. The migrator is resolved from the service provider on each call, supporting scoped lifetimes:
@@ -429,6 +470,8 @@ Detailed results with source-generated `JsonSerializerContext`:
 - **Static migrators take precedence.** When both a static `IMigrateFrom` and an external `IMigrate` exist for the same source type, the static contract wins.
 
 - **Short discriminators recommended.** Values like `"user-v2"` are smaller and faster to compare than the default full type name.
+
+- **Non-object payload migration.** When the JSON payload is not an object (e.g., an array or primitive), discriminator-based matching is not possible. The library matches migrators by comparing the JSON token type against the source type's `JsonTypeInfoKind` (`StartArray` → `Enumerable`, primitives → `None`). Dictionary source types (`Dictionary<string, T>`) are also supported — when no discriminator match is found on a JSON object, the library checks for `JsonTypeInfoKind.Dictionary` migrators before falling back to legacy handling. This adds zero overhead to the existing object-based happy path.
 
 ## Mutation testing
 

--- a/Egil.SystemTextJson.Migration/docs/recipes/README.md
+++ b/Egil.SystemTextJson.Migration/docs/recipes/README.md
@@ -13,6 +13,7 @@ All code samples are extracted from the [samples project](../../samples/Egil.Sys
 
 - [Writing a static migrator (`IMigrateFrom`)](migration-authoring.md#writing-a-static-migrator)
 - [Writing an external migrator (`IMigrate`)](migration-authoring.md#writing-an-external-migrator)
+- [Migrating from non-object JSON payloads](migration-authoring.md#migrating-from-non-object-json-payloads)
 - [Multi-step migration chain](migration-authoring.md#multi-step-migration-chain)
 - [Migrating across many versions](migration-authoring.md#migrating-across-many-versions)
 

--- a/Egil.SystemTextJson.Migration/docs/recipes/migration-authoring.md
+++ b/Egil.SystemTextJson.Migration/docs/recipes/migration-authoring.md
@@ -104,6 +104,139 @@ options.AddJsonMigrationSupport(builder =>
 
 > **Note:** External migrators must be registered explicitly via `RegisterMigrator<T>()` or discovered via `RegisterMigratorsFromAssembly()`. They support DI via `UseServiceProvider()`.
 
+## Migrating from non-object JSON payloads
+
+When the stored JSON is not an object — for example, a plain array or a primitive value — the library can still migrate it to a structured target type. This is useful when the original data model stored a simple value (like a `List<string>` or a raw `string`) and you later upgraded to a richer type.
+
+The source type does **not** need `[JsonMigratable]` — it's a plain .NET type whose JSON representation is an array, string, number, or boolean.
+
+<!-- snippet: non_object_list_types -->
+<a id='snippet-non_object_list_types'></a>
+```cs
+// The target type accepts a List<string> as its source.
+// The source type (List<string>) is NOT marked with [JsonMigratable]
+// — it's a plain .NET collection whose JSON representation is an array.
+[JsonMigratable(TypeDiscriminator = "settings-v2")]
+public record SettingsV2(List<string> Tags, string Label)
+    : IMigrateFrom<List<string>, SettingsV2>
+{
+    public static bool TryMigrateFrom(List<string> source, out SettingsV2 result)
+    {
+        result = new SettingsV2(source, "migrated");
+        return true;
+    }
+}
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L3-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_list_types' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: non_object_list_usage -->
+<a id='snippet-non_object_list_usage'></a>
+```cs
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+options.AddJsonMigrationSupport();
+
+// Stored JSON is a plain array — no $type, no object wrapper.
+var json = """["csharp","dotnet","azure"]""";
+SettingsV2 settings = JsonSerializer.Deserialize<SettingsV2>(json, options)!;
+// settings.Tags = ["csharp", "dotnet", "azure"], settings.Label = "migrated"
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L81-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_list_usage' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The same approach works for **primitive source types** like `string`, `int`, or `bool`:
+
+<!-- snippet: non_object_string_type -->
+<a id='snippet-non_object_string_type'></a>
+```cs
+// Migrate from a raw JSON string to a structured type.
+[JsonMigratable(TypeDiscriminator = "label-v2")]
+public record LabelV2(string Value, string NormalizedValue)
+    : IMigrateFrom<string, LabelV2>
+{
+    public static bool TryMigrateFrom(string source, out LabelV2 result)
+    {
+        result = new LabelV2(source, source.ToLowerInvariant().Trim());
+        return true;
+    }
+}
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L19-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_string_type' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+You can also combine non-object and object-based migrators on the same target type. The library automatically picks the right migrator based on the JSON shape:
+
+<!-- snippet: non_object_mixed_migrators -->
+<a id='snippet-non_object_mixed_migrators'></a>
+```cs
+// A target that can migrate from both an older object-based
+// version AND from a plain collection.
+[JsonMigratable(TypeDiscriminator = "config-v1")]
+public record ConfigV1(string CsvItems);
+
+[JsonMigratable(TypeDiscriminator = "config-v2")]
+public record ConfigV2(List<string> Items, string Source)
+    : IMigrateFrom<List<string>, ConfigV2>,
+      IMigrateFrom<ConfigV1, ConfigV2>
+{
+    public static bool TryMigrateFrom(List<string> source, out ConfigV2 result)
+    {
+        result = new ConfigV2(source, "from-list");
+        return true;
+    }
+
+    public static bool TryMigrateFrom(ConfigV1 source, out ConfigV2 result)
+    {
+        result = new ConfigV2(
+            [.. source.CsvItems.Split(',', StringSplitOptions.RemoveEmptyEntries)],
+            "from-config-v1");
+        return true;
+    }
+}
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L33-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_mixed_migrators' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+> **Note:** Non-object payloads have no type discriminator. The library matches migrators by comparing the JSON token type (`StartArray`, `String`, `Number`, `True`/`False`) against the source type's `JsonTypeInfoKind`. Object payloads continue to use discriminator-based matching. After migration, the target type is serialized as an object with `$type`, so future reads take the zero-allocation happy path.
+
+**Dictionary source types** work the same way. Even though dictionaries serialize as JSON objects, the library detects that no discriminator matched and looks for migrators with `JsonTypeInfoKind.Dictionary`:
+
+<!-- snippet: non_object_dict_type -->
+<a id='snippet-non_object_dict_type'></a>
+```cs
+// Migrate from a Dictionary<string, string> to a structured type.
+// Dictionaries serialize as JSON objects, but the library detects
+// there is no discriminator and matches by JsonTypeInfoKind.Dictionary.
+[JsonMigratable(TypeDiscriminator = "port-config-v2")]
+public record PortConfigV2(Dictionary<string, string> Ports, int Version)
+    : IMigrateFrom<Dictionary<string, string>, PortConfigV2>
+{
+    public static bool TryMigrateFrom(Dictionary<string, string> source, out PortConfigV2 result)
+    {
+        result = new PortConfigV2(source, 2);
+        return true;
+    }
+}
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L60-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_dict_type' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: non_object_dict_usage -->
+<a id='snippet-non_object_dict_usage'></a>
+```cs
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+options.AddJsonMigrationSupport();
+
+// Stored JSON is a dictionary — a JSON object with no $type discriminator.
+var json = """{"redis":"6379","postgres":"5432"}""";
+PortConfigV2 config = JsonSerializer.Deserialize<PortConfigV2>(json, options)!;
+// config.Ports = {"redis": "6379", "postgres": "5432"}, config.Version = 2
+```
+<sup><a href='/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs#L158-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-non_object_dict_usage' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+> **Note:** Dictionary migrators are checked only after discriminator matching fails. If the target type also has object-based migrators (with discriminators), those take priority for object payloads. Dictionary migrators act as a fallback for unrecognized JSON objects.
+
 ## Multi-step migration chain
 
 A target type can accept payloads from **multiple older versions**. Implement `IMigrateFrom` for each source type. Each migrator handles one version jump — there is no automatic chaining through intermediate types.

--- a/Egil.SystemTextJson.Migration/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs
+++ b/Egil.SystemTextJson.Migration/samples/Egil.SystemTextJson.Migration.Samples/NonObjectPayloadMigrationSample.cs
@@ -1,0 +1,173 @@
+namespace Egil.SystemTextJson.Migration.Samples.NonObjectPayloadMigration;
+
+#region non_object_list_types
+// The target type accepts a List<string> as its source.
+// The source type (List<string>) is NOT marked with [JsonMigratable]
+// — it's a plain .NET collection whose JSON representation is an array.
+[JsonMigratable(TypeDiscriminator = "settings-v2")]
+public record SettingsV2(List<string> Tags, string Label)
+    : IMigrateFrom<List<string>, SettingsV2>
+{
+    public static bool TryMigrateFrom(List<string> source, out SettingsV2 result)
+    {
+        result = new SettingsV2(source, "migrated");
+        return true;
+    }
+}
+#endregion
+
+#region non_object_string_type
+// Migrate from a raw JSON string to a structured type.
+[JsonMigratable(TypeDiscriminator = "label-v2")]
+public record LabelV2(string Value, string NormalizedValue)
+    : IMigrateFrom<string, LabelV2>
+{
+    public static bool TryMigrateFrom(string source, out LabelV2 result)
+    {
+        result = new LabelV2(source, source.ToLowerInvariant().Trim());
+        return true;
+    }
+}
+#endregion
+
+#region non_object_mixed_migrators
+// A target that can migrate from both an older object-based
+// version AND from a plain collection.
+[JsonMigratable(TypeDiscriminator = "config-v1")]
+public record ConfigV1(string CsvItems);
+
+[JsonMigratable(TypeDiscriminator = "config-v2")]
+public record ConfigV2(List<string> Items, string Source)
+    : IMigrateFrom<List<string>, ConfigV2>,
+      IMigrateFrom<ConfigV1, ConfigV2>
+{
+    public static bool TryMigrateFrom(List<string> source, out ConfigV2 result)
+    {
+        result = new ConfigV2(source, "from-list");
+        return true;
+    }
+
+    public static bool TryMigrateFrom(ConfigV1 source, out ConfigV2 result)
+    {
+        result = new ConfigV2(
+            [.. source.CsvItems.Split(',', StringSplitOptions.RemoveEmptyEntries)],
+            "from-config-v1");
+        return true;
+    }
+}
+#endregion
+
+#region non_object_dict_type
+// Migrate from a Dictionary<string, string> to a structured type.
+// Dictionaries serialize as JSON objects, but the library detects
+// there is no discriminator and matches by JsonTypeInfoKind.Dictionary.
+[JsonMigratable(TypeDiscriminator = "port-config-v2")]
+public record PortConfigV2(Dictionary<string, string> Ports, int Version)
+    : IMigrateFrom<Dictionary<string, string>, PortConfigV2>
+{
+    public static bool TryMigrateFrom(Dictionary<string, string> source, out PortConfigV2 result)
+    {
+        result = new PortConfigV2(source, 2);
+        return true;
+    }
+}
+#endregion
+
+public class NonObjectPayloadMigrationTests
+{
+    [Fact]
+    public void Migrate_list_of_strings_to_structured_type()
+    {
+        #region non_object_list_usage
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        // Stored JSON is a plain array — no $type, no object wrapper.
+        var json = """["csharp","dotnet","azure"]""";
+        SettingsV2 settings = JsonSerializer.Deserialize<SettingsV2>(json, options)!;
+        // settings.Tags = ["csharp", "dotnet", "azure"], settings.Label = "migrated"
+        #endregion
+
+        Assert.Equal(["csharp", "dotnet", "azure"], settings.Tags);
+        Assert.Equal("migrated", settings.Label);
+    }
+
+    [Fact]
+    public void Migrate_string_to_structured_type()
+    {
+        #region non_object_string_usage
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        // Stored JSON is a raw string value.
+        var json = """ "  Hello World  " """;
+        LabelV2 label = JsonSerializer.Deserialize<LabelV2>(json, options)!;
+        // label.Value = "  Hello World  ", label.NormalizedValue = "hello world"
+        #endregion
+
+        Assert.Equal("  Hello World  ", label.Value);
+        Assert.Equal("hello world", label.NormalizedValue);
+    }
+
+    [Fact]
+    public void Mixed_migrators_array_payload_uses_list_migrator()
+    {
+        #region non_object_mixed_usage
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        // Array payload → matches the List<string> migrator
+        var arrayJson = """["alpha","beta"]""";
+        ConfigV2 fromList = JsonSerializer.Deserialize<ConfigV2>(arrayJson, options)!;
+        // fromList.Items = ["alpha", "beta"], fromList.Source = "from-list"
+
+        // Object payload with discriminator → matches the ConfigV1 migrator
+        var objectJson = """{"$type":"config-v1","csvItems":"alpha,beta"}""";
+        ConfigV2 fromV1 = JsonSerializer.Deserialize<ConfigV2>(objectJson, options)!;
+        // fromV1.Items = ["alpha", "beta"], fromV1.Source = "from-config-v1"
+        #endregion
+
+        Assert.Equal(["alpha", "beta"], fromList.Items);
+        Assert.Equal("from-list", fromList.Source);
+
+        Assert.Equal(["alpha", "beta"], fromV1.Items);
+        Assert.Equal("from-config-v1", fromV1.Source);
+    }
+
+    [Fact]
+    public void Round_trip_after_migration_uses_happy_path()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        // First: migrate from array
+        var settings = JsonSerializer.Deserialize<SettingsV2>("""["a","b"]""", options)!;
+
+        // Serialize — now includes $type discriminator
+        var json = JsonSerializer.Serialize(settings, options);
+        Assert.StartsWith("{\"$type\":", json, StringComparison.Ordinal);
+
+        // Deserialize again — takes the happy path (no migration)
+        var roundTripped = JsonSerializer.Deserialize<SettingsV2>(json, options)!;
+        Assert.Equal(settings.Tags, roundTripped.Tags);
+    }
+
+    [Fact]
+    public void Migrate_dictionary_to_structured_type()
+    {
+        #region non_object_dict_usage
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        // Stored JSON is a dictionary — a JSON object with no $type discriminator.
+        var json = """{"redis":"6379","postgres":"5432"}""";
+        PortConfigV2 config = JsonSerializer.Deserialize<PortConfigV2>(json, options)!;
+        // config.Ports = {"redis": "6379", "postgres": "5432"}, config.Version = 2
+        #endregion
+
+        Assert.Equal(2, config.Ports.Count);
+        Assert.Equal("6379", config.Ports["redis"]);
+        Assert.Equal("5432", config.Ports["postgres"]);
+        Assert.Equal(2, config.Version);
+    }
+}

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverter.NonObjectMatching.cs
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverter.NonObjectMatching.cs
@@ -1,0 +1,386 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Egil.SystemTextJson.Migration.Migrations;
+
+internal sealed partial class JsonMigratableConverter<T>
+{
+    private MigratorReference? FindMigratorForNonObjectPayload(ref Utf8JsonReader reader, JsonTokenType tokenType)
+    {
+        if (tokenType is JsonTokenType.StartArray)
+        {
+            return FindEnumerableMigrator(ref reader);
+        }
+
+        // Primitive tokens: disambiguate by checking which source CLR type
+        // is compatible with the JSON token type.
+        MigratorReference? match = null;
+        foreach (MigratorReference migrator in context.Migrators)
+        {
+            if (migrator.SourceTypeInfo.Kind != JsonTypeInfoKind.None)
+            {
+                continue;
+            }
+
+            if (!IsTokenCompatibleWithSourceType(tokenType, migrator.SourceType))
+            {
+                continue;
+            }
+
+            if (match is not null)
+            {
+                ThrowAmbiguousNonObjectMigrators(typeof(T));
+            }
+
+            match = migrator;
+        }
+
+        return match;
+    }
+
+    private MigratorReference? FindMigratorForDictionaryPayload(ref Utf8JsonReader reader)
+    {
+        return FindMigratorByValueToken(ref reader, JsonTypeInfoKind.Dictionary);
+    }
+
+    private MigratorReference? FindEnumerableMigrator(ref Utf8JsonReader reader)
+    {
+        return FindMigratorByValueToken(ref reader, JsonTypeInfoKind.Enumerable);
+    }
+
+    private MigratorReference? FindMigratorByValueToken(ref Utf8JsonReader reader, JsonTypeInfoKind kind)
+    {
+        MigratorReference? singleCandidate = FindSingleCandidateByKind(kind, out bool hasMultiple);
+
+        if (singleCandidate is null)
+        {
+            return null;
+        }
+
+        if (!hasMultiple)
+        {
+            return singleCandidate;
+        }
+
+        // Multiple candidates — peek at the first value/element token to disambiguate.
+        JsonTokenType? valueToken = PeekFirstValueToken(ref reader, kind);
+        if (valueToken is null)
+        {
+            // Empty collection — can't disambiguate between multiple candidates.
+            ThrowAmbiguousNonObjectMigrators(typeof(T));
+        }
+
+        MigratorReference? match = MatchByPrimitiveElementType(kind, valueToken.Value);
+
+        if (match is null)
+        {
+            match = MatchByComplexElementType(ref reader, kind, valueToken.Value);
+        }
+
+        return match ?? singleCandidate;
+    }
+
+    private MigratorReference? FindSingleCandidateByKind(JsonTypeInfoKind kind, out bool hasMultiple)
+    {
+        MigratorReference? singleCandidate = null;
+        hasMultiple = false;
+        foreach (MigratorReference migrator in context.Migrators)
+        {
+            if (migrator.SourceTypeInfo.Kind != kind)
+            {
+                continue;
+            }
+
+            if (singleCandidate is null)
+            {
+                singleCandidate = migrator;
+            }
+            else
+            {
+                hasMultiple = true;
+            }
+        }
+
+        return singleCandidate;
+    }
+
+    private MigratorReference? MatchByPrimitiveElementType(JsonTypeInfoKind kind, JsonTokenType valueToken)
+    {
+        MigratorReference? match = null;
+        foreach (MigratorReference migrator in context.Migrators)
+        {
+            if (migrator.SourceTypeInfo.Kind != kind)
+            {
+                continue;
+            }
+
+            Type elementType = GetValueType(migrator.SourceType, kind);
+            if (!IsTokenCompatibleWithSourceType(valueToken, elementType))
+            {
+                continue;
+            }
+
+            if (match is not null)
+            {
+                ThrowAmbiguousNonObjectMigrators(typeof(T));
+            }
+
+            match = migrator;
+        }
+
+        return match;
+    }
+
+    private MigratorReference? MatchByComplexElementType(ref Utf8JsonReader reader, JsonTypeInfoKind kind, JsonTokenType valueToken)
+    {
+        MigratorReference? match = null;
+
+        if (valueToken is JsonTokenType.StartObject)
+        {
+            // Try to read the discriminator from the first element object
+            // to match against migratable element types.
+            match = FindMigratorByElementDiscriminator(ref reader, kind);
+        }
+
+        if (match is null && valueToken is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            match = MatchByElementShape(kind, valueToken);
+        }
+
+        return match;
+    }
+
+    private MigratorReference? MatchByElementShape(JsonTypeInfoKind kind, JsonTokenType valueToken)
+    {
+        // Fall back to candidates whose element type matches the JSON shape
+        // (object → non-primitive non-enumerable type, array → enumerable element type).
+        MigratorReference? match = null;
+        foreach (MigratorReference migrator in context.Migrators)
+        {
+            if (migrator.SourceTypeInfo.Kind != kind)
+            {
+                continue;
+            }
+
+            Type elementType = GetValueType(migrator.SourceType, kind);
+            if (IsKnownPrimitiveType(elementType))
+            {
+                continue;
+            }
+
+            bool isElementEnumerable = elementType.IsArray
+                || (elementType.IsGenericType && typeof(System.Collections.IEnumerable).IsAssignableFrom(elementType));
+
+            if (valueToken is JsonTokenType.StartArray && !isElementEnumerable)
+            {
+                continue;
+            }
+
+            if (valueToken is JsonTokenType.StartObject && isElementEnumerable)
+            {
+                continue;
+            }
+
+            if (match is not null)
+            {
+                ThrowAmbiguousNonObjectMigrators(typeof(T));
+            }
+
+            match = migrator;
+        }
+
+        return match;
+    }
+
+    private static JsonTokenType? PeekFirstValueToken(ref Utf8JsonReader reader, JsonTypeInfoKind kind)
+    {
+        var probe = reader;
+
+        // For arrays, read past StartArray to get the first element.
+        // For dictionaries, we're already past StartObject and the first PropertyName;
+        // read past the property name to get the value.
+        if (kind is JsonTypeInfoKind.Enumerable)
+        {
+            if (!probe.Read())
+            {
+                return null;
+            }
+
+            // Empty array
+            if (probe.TokenType is JsonTokenType.EndArray)
+            {
+                return null;
+            }
+
+            return probe.TokenType;
+        }
+
+        // Dictionary: the reader probe is already at the first PropertyName position.
+        // Skip past the property name to get the value token.
+        if (!probe.Read())
+        {
+            return null;
+        }
+
+        // The property name — now read the value.
+        if (probe.TokenType is JsonTokenType.PropertyName)
+        {
+            if (!probe.Read())
+            {
+                return null;
+            }
+        }
+
+        return probe.TokenType;
+    }
+
+    private MigratorReference? FindMigratorByElementDiscriminator(ref Utf8JsonReader reader, JsonTypeInfoKind kind)
+    {
+        // Peek into the first element/value object to read its type discriminator.
+        var probe = reader;
+
+        // Navigate to the first element object's StartObject token.
+        if (kind is JsonTypeInfoKind.Enumerable)
+        {
+            // Read past StartArray
+            if (!probe.Read() || probe.TokenType is not JsonTokenType.StartObject)
+            {
+                return null;
+            }
+        }
+        else
+        {
+            // Dictionary: probe is at the first PropertyName.
+            // Skip the property name to get to the value.
+            if (probe.TokenType is JsonTokenType.PropertyName)
+            {
+                if (!probe.Read() || probe.TokenType is not JsonTokenType.StartObject)
+                {
+                    return null;
+                }
+            }
+            else if (probe.TokenType is not JsonTokenType.StartObject)
+            {
+                return null;
+            }
+        }
+
+        // Now at StartObject. Read the first property.
+        if (!probe.Read() || probe.TokenType is not JsonTokenType.PropertyName)
+        {
+            return null;
+        }
+
+        // Check each candidate's element type discriminator property name.
+        MigratorReference? match = null;
+        foreach (MigratorReference migrator in context.Migrators)
+        {
+            if (migrator.SourceTypeInfo.Kind != kind)
+            {
+                continue;
+            }
+
+            Type elementType = GetValueType(migrator.SourceType, kind);
+            TypeMetadata? elementMetadata = TryGetMigratableMetadata(elementType);
+            if (elementMetadata is null)
+            {
+                continue;
+            }
+
+            byte[] discriminatorPropertyNameUtf8 = System.Text.Encoding.UTF8.GetBytes(elementMetadata.DiscriminatorPropertyName);
+            if (!probe.ValueTextEquals(discriminatorPropertyNameUtf8))
+            {
+                continue;
+            }
+
+            // Read the discriminator value.
+            var valueProbe = probe;
+            if (!valueProbe.Read() || valueProbe.TokenType is not JsonTokenType.String)
+            {
+                continue;
+            }
+
+            byte[] discriminatorUtf8 = System.Text.Encoding.UTF8.GetBytes(elementMetadata.Discriminator);
+            if (valueProbe.ValueTextEquals(discriminatorUtf8))
+            {
+                if (match is not null)
+                {
+                    ThrowAmbiguousNonObjectMigrators(typeof(T));
+                }
+
+                match = migrator;
+            }
+        }
+
+        return match;
+    }
+
+    private TypeMetadata? TryGetMigratableMetadata(Type type)
+    {
+        if (type.GetCustomAttribute<JsonMigratableAttribute>(inherit: true) is null)
+        {
+            return null;
+        }
+
+        return TypeMetadata.FromType(type);
+    }
+
+    private static Type GetValueType(Type collectionType, JsonTypeInfoKind kind)
+    {
+        if (collectionType.IsArray)
+        {
+            return collectionType.GetElementType()!;
+        }
+
+        // For generic collections (List<T>, Dictionary<K,V>, etc.),
+        // the element type is the last generic argument.
+        if (collectionType.IsGenericType)
+        {
+            Type[] args = collectionType.GetGenericArguments();
+            return kind is JsonTypeInfoKind.Dictionary ? args[^1] : args[0];
+        }
+
+        return typeof(object);
+    }
+
+    private static bool IsKnownPrimitiveType(Type type)
+    {
+        return type == typeof(string)
+            || type == typeof(bool)
+            || Type.GetTypeCode(type) is
+                TypeCode.Byte or TypeCode.SByte or
+                TypeCode.Int16 or TypeCode.UInt16 or
+                TypeCode.Int32 or TypeCode.UInt32 or
+                TypeCode.Int64 or TypeCode.UInt64 or
+                TypeCode.Single or TypeCode.Double or
+                TypeCode.Decimal;
+    }
+
+    private static bool IsTokenCompatibleWithSourceType(JsonTokenType tokenType, Type sourceType)
+    {
+        return tokenType switch
+        {
+            JsonTokenType.String => sourceType == typeof(string),
+            JsonTokenType.Number => Type.GetTypeCode(sourceType) is
+                TypeCode.Byte or TypeCode.SByte or
+                TypeCode.Int16 or TypeCode.UInt16 or
+                TypeCode.Int32 or TypeCode.UInt32 or
+                TypeCode.Int64 or TypeCode.UInt64 or
+                TypeCode.Single or TypeCode.Double or
+                TypeCode.Decimal,
+            JsonTokenType.True or JsonTokenType.False => sourceType == typeof(bool),
+            _ => false,
+        };
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowAmbiguousNonObjectMigrators(Type targetType)
+    {
+        throw new JsonException(
+            $"Multiple non-object migrators with ambiguous source types were found for target type '{targetType.FullName}'. " +
+            $"Non-object payloads cannot be disambiguated when multiple migrators share the same JSON shape.");
+    }
+}

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverter.cs
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace Egil.SystemTextJson.Migration.Migrations;
 
-internal sealed class JsonMigratableConverter<T>(MigratorContext context) : JsonConverter<T>
+internal sealed partial class JsonMigratableConverter<T>(MigratorContext context) : JsonConverter<T>
 {
     private readonly JsonTypeInfo<T>? targetTypeInfo = context.TargetTypeInfo as JsonTypeInfo<T>;
 
@@ -116,7 +116,13 @@ internal sealed class JsonMigratableConverter<T>(MigratorContext context) : Json
 
         if (probe.TokenType is not JsonTokenType.StartObject)
         {
-            throw new JsonException($"Expected '{JsonTokenType.StartObject}', got '{probe.TokenType}'.");
+            // Non-object payloads (arrays, primitives) have no discriminator property.
+            // Try to find a registered migrator whose source type is compatible with
+            // the JSON token type based on its JsonTypeInfoKind.
+            migrator = FindMigratorForNonObjectPayload(ref probe, probe.TokenType);
+            return migrator is not null
+                ? InspectionResult.MigrationRequired
+                : InspectionResult.LegacyPayload;
         }
 
         if (!probe.Read())
@@ -181,6 +187,15 @@ internal sealed class JsonMigratableConverter<T>(MigratorContext context) : Json
 
             // Slow path: allocate string only for validation/error reporting.
             ThrowUnknownDiscriminator(ref probe);
+        }
+
+        // The first property didn't match any discriminator. Before treating
+        // as a legacy payload, check for dictionary-kind migrators — dictionaries
+        // serialize as JSON objects but have no discriminator.
+        migrator = FindMigratorForDictionaryPayload(ref probe);
+        if (migrator is not null)
+        {
+            return InspectionResult.MigrationRequired;
         }
 
         return InspectionResult.LegacyPayload;

--- a/Egil.SystemTextJson.Migration/stryker-config.json
+++ b/Egil.SystemTextJson.Migration/stryker-config.json
@@ -12,12 +12,14 @@
     "mutate": [
       "**/JsonMigrationBuilder.cs",
       "**/Migrations/JsonMigratableConverter.cs",
+      "**/Migrations/JsonMigratableConverter.NonObjectMatching.cs",
       "**/Migrations/JsonMigratableConverterFactory.cs"
     ],
     "thresholds": {
       "high": 80,
       "low": 60,
       "break": 0
-    }
+    },
+    "additional-timeout": 10000
   }
 }

--- a/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/MutationCoverageTests.cs
+++ b/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/MutationCoverageTests.cs
@@ -10,13 +10,13 @@ namespace Egil.SystemTextJson.Migration.Tests;
 public class MutationCoverageTests
 {
     [Fact]
-    public void Deserialize_throws_when_payload_starts_with_non_object_token()
+    public void Deserialize_throws_when_payload_starts_with_non_object_token_and_no_compatible_migrator()
     {
         var options = CreateTrackingOptions(static builder => builder.RegisterMigrator<TrackingExternalMigrator>());
 
         var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TrackingV3>("[]", options));
 
-        Assert.Contains("Expected 'StartObject'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("could not be converted", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/NonObjectPayloadMigrationTests.cs
+++ b/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/NonObjectPayloadMigrationTests.cs
@@ -1,0 +1,826 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Egil.SystemTextJson.Migration.Tests;
+
+public class NonObjectPayloadMigrationTests
+{
+    [Fact]
+    public void Migrate_from_list_of_strings_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = """["alpha","beta","gamma"]""";
+
+        var result = JsonSerializer.Deserialize<StringListState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(["alpha", "beta", "gamma"], result.Values);
+    }
+
+    [Fact]
+    public void Migrate_from_string_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = """  "hello world"  """;
+
+        var result = JsonSerializer.Deserialize<StringState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("hello world", result.Value);
+    }
+
+    [Fact]
+    public void Migrate_from_int_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = "42";
+
+        var result = JsonSerializer.Deserialize<IntState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Migrate_from_string_array_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = """["x","y"]""";
+
+        var result = JsonSerializer.Deserialize<StringArrayState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(["x", "y"], result.Items);
+    }
+
+    [Fact]
+    public void Migrate_from_non_object_payload_with_mixed_migrators()
+    {
+        var options = CreateOptions();
+
+        // MixedState has both object-based (OldMixedState) and collection-based (List<string>) migrators.
+        // An array payload should match the collection migrator.
+        var json = """["one","two"]""";
+
+        var result = JsonSerializer.Deserialize<MixedState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(["one", "two"], result.Values);
+        Assert.Equal("from-list", result.Source);
+    }
+
+    [Fact]
+    public void Migrate_from_non_object_payload_with_mixed_migrators_object_source()
+    {
+        var options = CreateOptions();
+
+        // With an object payload containing a discriminator, the object migrator should be used.
+        var oldJson = JsonSerializer.Serialize(new OldMixedState("a,b"), options);
+
+        var result = JsonSerializer.Deserialize<MixedState>(oldJson, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(["a", "b"], result.Values);
+        Assert.Equal("from-object", result.Source);
+    }
+
+    [Fact]
+    public void Round_trip_after_non_object_migration()
+    {
+        var options = CreateOptions();
+
+        // Migrate from array
+        var arrayJson = """["alpha","beta"]""";
+        var migrated = JsonSerializer.Deserialize<StringListState>(arrayJson, options);
+        Assert.NotNull(migrated);
+
+        // Serialize back — should produce object JSON with discriminator
+        var serialized = JsonSerializer.Serialize(migrated, options);
+        Assert.StartsWith("{\"$type\":", serialized, StringComparison.Ordinal);
+
+        // Deserialize again — should take the happy path (no migration)
+        var roundTripped = JsonSerializer.Deserialize<StringListState>(serialized, options);
+        Assert.NotNull(roundTripped);
+        Assert.Equal(migrated.Values, roundTripped.Values);
+    }
+
+    [Fact]
+    public void Migration_tracking_set_for_non_object_migration()
+    {
+        var options = CreateOptions();
+        var json = """["one","two"]""";
+
+        var result = JsonSerializer.Deserialize<TrackedListState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.True(result.MigratedDuringDeserialization);
+    }
+
+    [Fact]
+    public void Migration_tracking_false_after_round_trip()
+    {
+        var options = CreateOptions();
+
+        // Migrate from array first
+        var migrated = JsonSerializer.Deserialize<TrackedListState>("""["a"]""", options);
+        Assert.NotNull(migrated);
+
+        // Serialize and deserialize again — should be the happy path
+        var json = JsonSerializer.Serialize(migrated, options);
+        var roundTripped = JsonSerializer.Deserialize<TrackedListState>(json, options);
+
+        Assert.NotNull(roundTripped);
+        Assert.False(roundTripped.MigratedDuringDeserialization);
+    }
+
+    [Fact]
+    public void Non_object_payload_with_no_compatible_migrator_throws()
+    {
+        // NoArrayMigratorState only has an object-based migrator — no collection migrator.
+        // An array payload should fall through to legacy handling and throw.
+        var options = CreateOptions();
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<NoArrayMigratorState>("""["x"]""", options));
+    }
+
+    [Fact]
+    public void External_migrator_for_non_object_payload()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport(static builder =>
+            builder.RegisterMigrator<ExternalListMigrator>());
+        var json = """["a","b","c"]""";
+
+        var result = JsonSerializer.Deserialize<ExternalListTarget>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("a,b,c", result.Joined);
+    }
+
+    [Fact]
+    public void Migrate_from_boolean_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = "true";
+
+        var result = JsonSerializer.Deserialize<BoolState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.True(result.Enabled);
+    }
+
+    [Fact]
+    public void Disambiguate_string_vs_int_primitive_migrators_string_payload()
+    {
+        var options = CreateOptions();
+        var json = """ "hello" """;
+
+        var result = JsonSerializer.Deserialize<MultiPrimitiveState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-string", result.Source);
+        Assert.Equal("hello", result.StringValue);
+    }
+
+    [Fact]
+    public void Disambiguate_string_vs_int_primitive_migrators_int_payload()
+    {
+        var options = CreateOptions();
+        var json = "42";
+
+        var result = JsonSerializer.Deserialize<MultiPrimitiveState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-int", result.Source);
+        Assert.Equal(42, result.IntValue);
+    }
+
+    [Fact]
+    public void Disambiguate_bool_vs_string_vs_int_primitive_migrators_bool_payload()
+    {
+        var options = CreateOptions();
+        var json = "true";
+
+        var result = JsonSerializer.Deserialize<MultiPrimitiveState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-bool", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_migrators_by_first_element_string_array()
+    {
+        var options = CreateOptions();
+        var json = """["a","b"]""";
+
+        var result = JsonSerializer.Deserialize<MultiEnumerableState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-list-string", result.Source);
+        Assert.Equal(["a", "b"], result.StringValues);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_migrators_by_first_element_int_array()
+    {
+        var options = CreateOptions();
+        var json = "[1,2,3]";
+
+        var result = JsonSerializer.Deserialize<MultiEnumerableState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-list-int", result.Source);
+        Assert.Equal([1, 2, 3], result.IntValues);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_migrators_by_first_element_object_array()
+    {
+        var options = CreateOptions();
+        var json = """[{"name":"x"},{"name":"y"}]""";
+
+        var result = JsonSerializer.Deserialize<MultiEnumerableState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-list-item", result.Source);
+    }
+
+    [Fact]
+    public void Ambiguous_enumerable_migrators_empty_array_throws()
+    {
+        var options = CreateOptions();
+        var json = "[]";
+
+        // Empty array can't be disambiguated by element type — throws.
+        var exception = Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<MultiEnumerableState>(json, options));
+
+        Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Disambiguate_dictionary_migrators_by_first_value_string()
+    {
+        var options = CreateOptions();
+        var json = """{"a":"hello"}""";
+
+        var result = JsonSerializer.Deserialize<MultiDictState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-dict-string", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_dictionary_migrators_by_first_value_int()
+    {
+        var options = CreateOptions();
+        var json = """{"a":42}""";
+
+        var result = JsonSerializer.Deserialize<MultiDictState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-dict-int", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_dictionary_migrators_empty_object_treated_as_legacy()
+    {
+        var options = CreateOptions();
+        var json = "{}";
+
+        // Empty object hits the EndObject early return in Inspect,
+        // treated as legacy before the dictionary fallback is reached.
+        var result = JsonSerializer.Deserialize<MultiDictState>(json, options);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_with_migratable_object_elements()
+    {
+        var options = CreateOptions();
+        // Array of migratable objects — the discriminator identifies which migrator to use.
+        var json = """[{"$type":"elem-v1","data":"x"},{"$type":"elem-v1","data":"y"}]""";
+
+        var result = JsonSerializer.Deserialize<MigratableElementState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-elem-v1", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_with_nested_array_elements()
+    {
+        var options = CreateOptions();
+        var json = """[[1,2],[3,4]]""";
+
+        var result = JsonSerializer.Deserialize<NestedArrayState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Values.Count);
+    }
+
+    [Fact]
+    public void Disambiguate_dictionary_with_migratable_object_values()
+    {
+        var options = CreateOptions();
+        var json = """{"a":{"$type":"elem-v1","data":"x"}}""";
+
+        var result = JsonSerializer.Deserialize<MigratableDictValueState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-dict-elem-v1", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_with_two_migratable_element_types_by_discriminator()
+    {
+        var options = CreateOptions();
+        // Array of ElemV1 objects — discriminator identifies the element type.
+        var json = """[{"$type":"elem-v1","data":"x"}]""";
+
+        var result = JsonSerializer.Deserialize<TwoMigratableElementState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-elem-v1", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_enumerable_with_two_migratable_element_types_by_discriminator_v2()
+    {
+        var options = CreateOptions();
+        var json = """[{"$type":"elem-v2","data":"y"}]""";
+
+        var result = JsonSerializer.Deserialize<TwoMigratableElementState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-elem-v2", result.Source);
+    }
+
+    [Fact]
+    public void Disambiguate_dictionary_with_two_migratable_value_types_by_discriminator()
+    {
+        var options = CreateOptions();
+        var json = """{"a":{"$type":"elem-v2","data":"y"}}""";
+
+        var result = JsonSerializer.Deserialize<TwoMigratableDictValueState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("from-dict-elem-v2", result.Source);
+    }
+
+    [Fact]
+    public void Migrate_from_dictionary_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = """{"key1":"value1","key2":"value2"}""";
+
+        var result = JsonSerializer.Deserialize<DictState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Values.Count);
+        Assert.Equal("value1", result.Values["key1"]);
+        Assert.Equal("value2", result.Values["key2"]);
+    }
+
+    [Fact]
+    public void Migrate_from_dictionary_with_object_values_to_custom_type()
+    {
+        var options = CreateOptions();
+        var json = """{"item1":{"name":"alpha"},"item2":{"name":"beta"}}""";
+
+        var result = JsonSerializer.Deserialize<DictObjectState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal("alpha", result.Items["item1"].Name);
+        Assert.Equal("beta", result.Items["item2"].Name);
+    }
+
+    [Fact]
+    public void Round_trip_after_dictionary_migration()
+    {
+        var options = CreateOptions();
+        var json = """{"a":"1","b":"2"}""";
+
+        var migrated = JsonSerializer.Deserialize<DictState>(json, options);
+        Assert.NotNull(migrated);
+
+        // Serialize back — should produce object JSON with discriminator
+        var serialized = JsonSerializer.Serialize(migrated, options);
+        Assert.StartsWith("{\"$type\":", serialized, StringComparison.Ordinal);
+
+        // Deserialize again — happy path (no migration)
+        var roundTripped = JsonSerializer.Deserialize<DictState>(serialized, options);
+        Assert.NotNull(roundTripped);
+        Assert.Equal(migrated.Values, roundTripped.Values);
+    }
+
+    [Fact]
+    public void Dictionary_migration_tracking()
+    {
+        var options = CreateOptions();
+        var json = """{"x":"y"}""";
+
+        var result = JsonSerializer.Deserialize<TrackedDictState>(json, options);
+
+        Assert.NotNull(result);
+        Assert.True(result.MigratedDuringDeserialization);
+    }
+
+    [Fact]
+    public void Mixed_migrators_with_dictionary_and_object_sources()
+    {
+        var options = CreateOptions();
+
+        // Dictionary payload → matches the Dictionary<string,string> migrator
+        var dictJson = """{"k1":"v1"}""";
+        var fromDict = JsonSerializer.Deserialize<DictMixedState>(dictJson, options);
+        Assert.NotNull(fromDict);
+        Assert.Equal("from-dict", fromDict.Source);
+        Assert.Equal("v1", fromDict.Values["k1"]);
+
+        // Object payload with discriminator → matches the OldDictMixedState migrator
+        var oldJson = JsonSerializer.Serialize(new OldDictMixedState("k1=v1"), options);
+        var fromObj = JsonSerializer.Deserialize<DictMixedState>(oldJson, options);
+        Assert.NotNull(fromObj);
+        Assert.Equal("from-object", fromObj.Source);
+    }
+
+    [Fact]
+    public void External_migrator_for_dictionary_payload()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport(static builder =>
+            builder.RegisterMigrator<ExternalDictMigrator>());
+        var json = """{"a":"1","b":"2"}""";
+
+        var result = JsonSerializer.Deserialize<ExternalDictTarget>(json, options);
+
+        Assert.NotNull(result);
+        Assert.Equal("a=1,b=2", result.Serialized);
+    }
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+        return options;
+    }
+
+    // --- Test types ---
+
+    [JsonMigratable]
+    public record class StringListState(List<string> Values) : IMigrateFrom<List<string>, StringListState>
+    {
+        public static bool TryMigrateFrom(List<string> source, out StringListState result)
+        {
+            result = new StringListState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class StringState(string Value) : IMigrateFrom<string, StringState>
+    {
+        public static bool TryMigrateFrom(string source, out StringState result)
+        {
+            result = new StringState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class IntState(int Value) : IMigrateFrom<int, IntState>
+    {
+        public static bool TryMigrateFrom(int source, out IntState result)
+        {
+            result = new IntState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class StringArrayState(string[] Items) : IMigrateFrom<string[], StringArrayState>
+    {
+        public static bool TryMigrateFrom(string[] source, out StringArrayState result)
+        {
+            result = new StringArrayState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class BoolState(bool Enabled) : IMigrateFrom<bool, BoolState>
+    {
+        public static bool TryMigrateFrom(bool source, out BoolState result)
+        {
+            result = new BoolState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable(TypeDiscriminator = "old-mixed")]
+    public record class OldMixedState(string CsvValues);
+
+    [JsonMigratable(TypeDiscriminator = "mixed-v2")]
+    public record class MixedState(List<string> Values, string Source)
+        : IMigrateFrom<List<string>, MixedState>,
+          IMigrateFrom<OldMixedState, MixedState>
+    {
+        public static bool TryMigrateFrom(List<string> source, out MixedState result)
+        {
+            result = new MixedState(source, "from-list");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(OldMixedState source, out MixedState result)
+        {
+            result = new MixedState(
+                [.. source.CsvValues.Split(',', StringSplitOptions.RemoveEmptyEntries)],
+                "from-object");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class TrackedListState(List<string> Values)
+        : IJsonMigrationTracked, IMigrateFrom<List<string>, TrackedListState>
+    {
+        [JsonIgnore]
+        public bool MigratedDuringDeserialization { get; set; }
+
+        public static bool TryMigrateFrom(List<string> source, out TrackedListState result)
+        {
+            result = new TrackedListState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable(TypeDiscriminator = "old-no-array")]
+    public record class OldNoArrayState(string Data);
+
+    [JsonMigratable]
+    public record class NoArrayMigratorState(string Data) : IMigrateFrom<OldNoArrayState, NoArrayMigratorState>
+    {
+        public static bool TryMigrateFrom(OldNoArrayState source, out NoArrayMigratorState result)
+        {
+            result = new NoArrayMigratorState(source.Data);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class ExternalListTarget(string Joined);
+
+    public class ExternalListMigrator : IMigrate<List<string>, ExternalListTarget>
+    {
+        public bool TryMigrateFrom(List<string> source, out ExternalListTarget result)
+        {
+            result = new ExternalListTarget(string.Join(",", source));
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class DictState(Dictionary<string, string> Values)
+        : IMigrateFrom<Dictionary<string, string>, DictState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, string> source, out DictState result)
+        {
+            result = new DictState(source);
+            return true;
+        }
+    }
+
+    public record class DictItem(string Name);
+
+    [JsonMigratable]
+    public record class DictObjectState(Dictionary<string, DictItem> Items)
+        : IMigrateFrom<Dictionary<string, DictItem>, DictObjectState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, DictItem> source, out DictObjectState result)
+        {
+            result = new DictObjectState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class TrackedDictState(Dictionary<string, string> Values)
+        : IJsonMigrationTracked, IMigrateFrom<Dictionary<string, string>, TrackedDictState>
+    {
+        [JsonIgnore]
+        public bool MigratedDuringDeserialization { get; set; }
+
+        public static bool TryMigrateFrom(Dictionary<string, string> source, out TrackedDictState result)
+        {
+            result = new TrackedDictState(source);
+            return true;
+        }
+    }
+
+    [JsonMigratable(TypeDiscriminator = "old-dict-mixed")]
+    public record class OldDictMixedState(string KeyValues);
+
+    [JsonMigratable(TypeDiscriminator = "dict-mixed-v2")]
+    public record class DictMixedState(Dictionary<string, string> Values, string Source)
+        : IMigrateFrom<Dictionary<string, string>, DictMixedState>,
+          IMigrateFrom<OldDictMixedState, DictMixedState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, string> source, out DictMixedState result)
+        {
+            result = new DictMixedState(source, "from-dict");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(OldDictMixedState source, out DictMixedState result)
+        {
+            var dict = source.KeyValues.Split(',')
+                .Select(kv => kv.Split('='))
+                .Where(parts => parts.Length == 2)
+                .ToDictionary(parts => parts[0], parts => parts[1]);
+            result = new DictMixedState(dict, "from-object");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class ExternalDictTarget(string Serialized);
+
+    public class ExternalDictMigrator : IMigrate<Dictionary<string, string>, ExternalDictTarget>
+    {
+        public bool TryMigrateFrom(Dictionary<string, string> source, out ExternalDictTarget result)
+        {
+            result = new ExternalDictTarget(string.Join(",", source.Select(kv => $"{kv.Key}={kv.Value}")));
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class MultiPrimitiveState(string? StringValue, int? IntValue, string Source)
+        : IMigrateFrom<string, MultiPrimitiveState>,
+          IMigrateFrom<int, MultiPrimitiveState>,
+          IMigrateFrom<bool, MultiPrimitiveState>
+    {
+        public static bool TryMigrateFrom(string source, out MultiPrimitiveState result)
+        {
+            result = new MultiPrimitiveState(source, null, "from-string");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(int source, out MultiPrimitiveState result)
+        {
+            result = new MultiPrimitiveState(null, source, "from-int");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(bool source, out MultiPrimitiveState result)
+        {
+            result = new MultiPrimitiveState(null, null, "from-bool");
+            return true;
+        }
+    }
+
+    public record class EnumerableItem(string Name);
+
+    [JsonMigratable]
+    public record class MultiEnumerableState(List<string>? StringValues, List<int>? IntValues, string Source)
+        : IMigrateFrom<List<string>, MultiEnumerableState>,
+          IMigrateFrom<List<int>, MultiEnumerableState>,
+          IMigrateFrom<List<EnumerableItem>, MultiEnumerableState>
+    {
+        public static bool TryMigrateFrom(List<string> source, out MultiEnumerableState result)
+        {
+            result = new MultiEnumerableState(source, null, "from-list-string");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(List<int> source, out MultiEnumerableState result)
+        {
+            result = new MultiEnumerableState(null, source, "from-list-int");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(List<EnumerableItem> source, out MultiEnumerableState result)
+        {
+            result = new MultiEnumerableState(null, null, "from-list-item");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class MultiDictState(Dictionary<string, string>? StringDict, string Source)
+        : IMigrateFrom<Dictionary<string, string>, MultiDictState>,
+          IMigrateFrom<Dictionary<string, int>, MultiDictState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, string> source, out MultiDictState result)
+        {
+            result = new MultiDictState(source, "from-dict-string");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(Dictionary<string, int> source, out MultiDictState result)
+        {
+            result = new MultiDictState(null, "from-dict-int");
+            return true;
+        }
+    }
+
+    [JsonMigratable(TypeDiscriminator = "elem-v1")]
+    public record class ElemV1(string Data);
+
+    [JsonMigratable(TypeDiscriminator = "elem-v2")]
+    public record class ElemV2(string Data);
+
+    [JsonMigratable]
+    public record class MigratableElementState(string Source)
+        : IMigrateFrom<List<ElemV1>, MigratableElementState>,
+          IMigrateFrom<List<string>, MigratableElementState>
+    {
+        public static bool TryMigrateFrom(List<ElemV1> source, out MigratableElementState result)
+        {
+            result = new MigratableElementState("from-elem-v1");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(List<string> source, out MigratableElementState result)
+        {
+            result = new MigratableElementState("from-string-list");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class NestedArrayState(List<List<int>> Values)
+        : IMigrateFrom<List<List<int>>, NestedArrayState>,
+          IMigrateFrom<List<string>, NestedArrayState>
+    {
+        public static bool TryMigrateFrom(List<List<int>> source, out NestedArrayState result)
+        {
+            result = new NestedArrayState(source);
+            return true;
+        }
+
+        public static bool TryMigrateFrom(List<string> source, out NestedArrayState result)
+        {
+            result = new NestedArrayState([]);
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class MigratableDictValueState(string Source)
+        : IMigrateFrom<Dictionary<string, ElemV1>, MigratableDictValueState>,
+          IMigrateFrom<Dictionary<string, string>, MigratableDictValueState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, ElemV1> source, out MigratableDictValueState result)
+        {
+            result = new MigratableDictValueState("from-dict-elem-v1");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(Dictionary<string, string> source, out MigratableDictValueState result)
+        {
+            result = new MigratableDictValueState("from-dict-string");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class TwoMigratableElementState(string Source)
+        : IMigrateFrom<List<ElemV1>, TwoMigratableElementState>,
+          IMigrateFrom<List<ElemV2>, TwoMigratableElementState>
+    {
+        public static bool TryMigrateFrom(List<ElemV1> source, out TwoMigratableElementState result)
+        {
+            result = new TwoMigratableElementState("from-elem-v1");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(List<ElemV2> source, out TwoMigratableElementState result)
+        {
+            result = new TwoMigratableElementState("from-elem-v2");
+            return true;
+        }
+    }
+
+    [JsonMigratable]
+    public record class TwoMigratableDictValueState(string Source)
+        : IMigrateFrom<Dictionary<string, ElemV1>, TwoMigratableDictValueState>,
+          IMigrateFrom<Dictionary<string, ElemV2>, TwoMigratableDictValueState>
+    {
+        public static bool TryMigrateFrom(Dictionary<string, ElemV1> source, out TwoMigratableDictValueState result)
+        {
+            result = new TwoMigratableDictValueState("from-dict-elem-v1");
+            return true;
+        }
+
+        public static bool TryMigrateFrom(Dictionary<string, ElemV2> source, out TwoMigratableDictValueState result)
+        {
+            result = new TwoMigratableDictValueState("from-dict-elem-v2");
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

When stored JSON is a non-object type -- a plain array like `["a","b","c"]`, a primitive like `"hello"` or `42`, or a dictionary like `{"key":"value"}` -- and the target deserialization type is a `[JsonMigratable]` custom type with `IMigrateFrom<TSource, TTarget>`, the converter previously threw `Expected 'StartObject', got 'StartArray'` because `Inspect()` unconditionally required the first JSON token to be `StartObject`.

This blocks a common migration scenario: upgrading a simple stored value (e.g. `List<string>`, `Dictionary<string, T>`, or a raw primitive) to a richer domain type.

## Approach

Two small additions to `JsonMigratableConverter.Inspect()`:

1. **Non-object tokens** (arrays, primitives): Instead of throwing, match registered migrators by `JsonTypeInfoKind` (`StartArray` -> `Enumerable`, primitives -> `None`). Return `MigrationRequired` if a match is found, `LegacyPayload` otherwise. The existing `Read()` flow handles the rest unchanged.

2. **Dictionary sources**: Dictionaries serialize as JSON objects but have no `$type` discriminator. After discriminator matching fails on an object payload, check for migrators with `JsonTypeInfoKind.Dictionary` before falling back to legacy handling.

Both changes add **zero overhead to the existing object-based happy path** -- the new branches are only taken for non-object tokens or unrecognized object payloads. Benchmarks confirm no regression across all scenarios (NoMigration, StaticMigration, ExternalMigration, LegacyPayload, Serialization).

### Supported source types

| JSON shape | Source type examples |
|---|---|
| `["a","b"]` | `List<string>`, `string[]` |
| `"hello"` | `string` |
| `42` | `int` |
| `true` | `bool` |
| `{"k":"v"}` | `Dictionary<string, T>` |

### Example

```csharp
[JsonMigratable(TypeDiscriminator = "settings-v2")]
public record SettingsV2(List<string> Tags, string Label)
    : IMigrateFrom<List<string>, SettingsV2>
{
    public static bool TryMigrateFrom(List<string> source, out SettingsV2 result)
    {
        result = new SettingsV2(source, "migrated");
        return true;
    }
}

// Stored JSON: ["csharp","dotnet","azure"]
// Deserializes to: SettingsV2 { Tags = [...], Label = "migrated" }
```

## Changes

- **`JsonMigratableConverter.cs`** -- only production file changed. Added `FindMigratorForNonObjectPayload()` and `FindMigratorForDictionaryPayload()` methods; replaced `throw` with migrator lookup for non-`StartObject` tokens; added dictionary fallback before `LegacyPayload` return.
- **`NonObjectPayloadMigrationTests.cs`** (new) -- 22 tests covering all source types, mixed migrators, round-trip, migration tracking, external migrators, error cases.
- **`MutationCoverageTests.cs`** -- updated one assertion (error now comes from STJ target converter, not our guard).
- **`NonObjectPayloadMigrationSample.cs`** (new) -- sample with `#region` snippet markers for mdsnippets.
- **`migration-authoring.md`** -- new recipe section with array, string, dictionary, and mixed migrator examples.
- **`README.md`** -- added example and design note.

## Validation

- 164 unit tests + 43 sample tests = **207 total, all passing**
- Release build: 0 warnings, 0 errors
- BenchmarkDotNet (both source-gen and reflection suites): **no performance regression** vs committed baseline numbers