### PR TITLE
Generate clean NuGet README via mdsnippets --omit-snippet-links

### DIFF
--- a/.github/workflows/egil-systemtextjson-migration-ci.yml
+++ b/.github/workflows/egil-systemtextjson-migration-ci.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: Egil.SystemTextJson.Migration
         run: |
           dotnet tool restore
-          dotnet mdsnippets
+          dotnet mdsnippets --convention InPlaceOverwrite --write-header false
           git diff --exit-code -- '*.md'
 
   release:

--- a/Egil.SystemTextJson.Migration/mdsnippets.json
+++ b/Egil.SystemTextJson.Migration/mdsnippets.json
@@ -1,6 +1,0 @@
-{
-  "Convention": "InPlaceOverwrite",
-  "WriteHeader": false,
-  "OmitSnippetLinks": false,
-  "LinkFormat": "GitHub"
-}

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Egil.SystemTextJson.Migration.csproj
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Egil.SystemTextJson.Migration.csproj
@@ -46,4 +46,28 @@
     </None>
   </ItemGroup>
 
+  <!-- Before pack: rewrite README.md to a NuGet-friendly version by running
+       mdsnippets with OmitSnippetLinks (strips <a id> anchors and <sup> source
+       links) and removing the NuGet badge (redundant on nuget.org).
+       After pack: restore README.md via git checkout. -->
+  <PropertyGroup>
+    <_ReadmePath>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../README.md'))</_ReadmePath>
+    <_ProjectRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../..'))</_ProjectRoot>
+  </PropertyGroup>
+
+  <Target Name="_PrepareNuGetReadme" BeforeTargets="GenerateNuspec">
+    <Exec Command="dotnet tool restore" WorkingDirectory="$(_ProjectRoot)" />
+    <Exec Command="dotnet mdsnippets --convention InPlaceOverwrite --write-header false --omit-snippet-links true --exclude-markdown-directories docs"
+          WorkingDirectory="$(_ProjectRoot)" />
+    <!-- Remove the NuGet badge line (redundant when viewing on nuget.org) -->
+    <WriteLinesToFile File="$(_ReadmePath)" Overwrite="true"
+                     Lines="$([System.Text.RegularExpressions.Regex]::Replace(
+                       $([System.IO.File]::ReadAllText('$(_ReadmePath)')),
+                       '(?m)^\[!\[NuGet\].*\r?\n\r?\n', ''))" />
+  </Target>
+
+  <Target Name="_RestoreReadmeAfterPack" AfterTargets="Pack">
+    <Exec Command="git checkout -- README.md" WorkingDirectory="$(_ProjectRoot)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Why

The `Egil.SystemTextJson.Migration` README uses mdsnippets to inject code snippets from source files. On nuget.org, the generated HTML artifacts -- `<a id='snippet-...'>` anchors, `<sup>snippet source | anchor</sup>` links, and the NuGet badge -- render as ugly visible elements with broken relative links. See the [current nuget.org page](https://www.nuget.org/packages/Egil.SystemTextJson.Migration) for examples.

## Approach

Instead of maintaining a separate NuGet README file, this uses mdsnippets' own `--omit-snippet-links` flag to regenerate `README.md` in-place before pack, then restores it via `git checkout` after pack:

1. **Before pack** (`_PrepareNuGetReadme` MSBuild target): runs `dotnet mdsnippets --omit-snippet-links true` which strips both `<a id>` anchors and `<sup>` source links at generation time. Also strips the NuGet badge line (redundant on nuget.org).
2. **Pack** uses the now-clean `README.md` -- no separate file to maintain.
3. **After pack** (`_RestoreReadmeAfterPack` target): `git checkout -- README.md` restores the original with full links for GitHub.

Additionally, the `mdsnippets.json` config file is removed. All settings are now passed as explicit CLI arguments, which avoids the "cannot be defined in both config and CLI" conflict that mdsnippets enforces.

## Changes

- **Deleted `mdsnippets.json`** -- settings moved to CLI args
- **`Egil.SystemTextJson.Migration.csproj`** -- added `_PrepareNuGetReadme` and `_RestoreReadmeAfterPack` MSBuild targets
- **CI workflow** -- updated `dotnet mdsnippets` invocation to pass `--convention InPlaceOverwrite --write-header false` explicitly