### PR TITLE
feat(stjm): auto-generate NuGet release notes from conventional commits

### DIFF
--- a/Egil.SystemTextJson.Migration/scripts/generate-release-notes.ps1
+++ b/Egil.SystemTextJson.Migration/scripts/generate-release-notes.ps1
@@ -1,0 +1,117 @@
+<#
+.SYNOPSIS
+    Generates plain-text release notes from conventional commits since the last tag.
+
+.DESCRIPTION
+    Finds the latest git tag matching the given prefix, collects commits since
+    that tag (filtered to the project directory), parses conventional commit
+    messages, and outputs categorised plain-text release notes suitable for
+    NuGet PackageReleaseNotes (which does not support markdown).
+
+.PARAMETER TagPrefix
+    Tag name prefix used to find the latest release tag.
+    Default: "egil-systemtextjson-migration/v"
+
+.PARAMETER ProjectPath
+    Project directory path relative to the repository root.
+    Only commits touching files under this path are included.
+    Default: "Egil.SystemTextJson.Migration/"
+
+.EXAMPLE
+    ./scripts/generate-release-notes.ps1
+    ./scripts/generate-release-notes.ps1 -TagPrefix "my-project/v" -ProjectPath "MyProject/"
+#>
+[CmdletBinding()]
+param(
+    [string]$TagPrefix = "egil-systemtextjson-migration/v",
+    [string]$ProjectPath = "Egil.SystemTextJson.Migration/"
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Verify we are inside a git repository.
+$gitDir = git rev-parse --git-dir 2>&1
+if ($LASTEXITCODE -ne 0) {
+    # Not a git repo – silently produce no output so the build is not broken.
+    exit 0
+}
+
+# Find the latest tag that matches the prefix.
+$latestTag = git tag -l "${TagPrefix}*" --sort=-v:refname | Select-Object -First 1
+
+if ($latestTag) {
+    $range = "${latestTag}..HEAD"
+}
+else {
+    $range = "HEAD"
+}
+
+# Collect one-line commit subjects touching the project directory.
+# --no-merges skips merge commits (whose messages are noise like "Merge PR #N")
+# but still traverses merged branches so feature/fix commits are included.
+$commitArgs = @('log', $range, '--format=%s', '--no-merges', '--', $ProjectPath)
+$subjects = & git @commitArgs
+
+if (-not $subjects -or $subjects.Count -eq 0) {
+    # No commits since last tag – nothing to report.
+    exit 0
+}
+
+# Parse conventional commit subjects into categorised lists.
+$breaking = [System.Collections.Generic.List[string]]::new()
+$features = [System.Collections.Generic.List[string]]::new()
+$fixes = [System.Collections.Generic.List[string]]::new()
+$perf = [System.Collections.Generic.List[string]]::new()
+
+# Types that are not interesting for end-user release notes.
+$skipTypes = @('release', 'build', 'ci', 'chore', 'docs', 'style', 'refactor', 'test')
+
+foreach ($subject in $subjects) {
+    # Match: type(scope)!: description   or   type!: description   or   type: description
+    if ($subject -match '^(?<type>\w+)(?:\([^)]*\))?(?<bang>!)?:\s*(?<desc>.+)$') {
+        $type = $Matches['type'].ToLowerInvariant()
+        $desc = $Matches['desc'].Trim()
+        $isBreaking = $Matches['bang'] -eq '!'
+
+        if ($isBreaking) {
+            $breaking.Add($desc)
+        }
+        elseif ($type -eq 'feat') {
+            $features.Add($desc)
+        }
+        elseif ($type -eq 'fix') {
+            $fixes.Add($desc)
+        }
+        elseif ($type -eq 'perf') {
+            $perf.Add($desc)
+        }
+        elseif ($type -in $skipTypes) {
+            continue
+        }
+        # Unknown types are silently skipped to keep notes clean.
+    }
+    # Non-conventional commits are silently skipped.
+}
+
+# Build plain-text output (no markdown – NuGet does not render it).
+$sections = [System.Collections.Generic.List[string]]::new()
+
+function Add-Section([string]$heading, [System.Collections.Generic.List[string]]$items) {
+    if ($items.Count -eq 0) { return }
+    $sections.Add($heading)
+    foreach ($item in $items) {
+        $sections.Add("- $item")
+    }
+}
+
+Add-Section "BREAKING CHANGES:" $breaking
+Add-Section "New Features:" $features
+Add-Section "Bug Fixes:" $fixes
+Add-Section "Performance:" $perf
+
+if ($sections.Count -eq 0) {
+    exit 0
+}
+
+# Write to stdout – MSBuild ConsoleToMSBuild will capture this.
+$sections -join "`n"

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Egil.SystemTextJson.Migration.csproj
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Egil.SystemTextJson.Migration.csproj
@@ -70,4 +70,20 @@
     <Exec Command="git checkout -- README.md" WorkingDirectory="$(_ProjectRoot)" />
   </Target>
 
+  <!-- Generate plain-text release notes from conventional commits since the
+       last release tag and inject them into the NuGet package. -->
+  <Target Name="_GenerateReleaseNotes" BeforeTargets="GenerateNuspec"
+          Condition="'$(Configuration)' == 'Release' and '$(SkipReleaseNotes)' != 'true'">
+    <Exec Command="pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(_ProjectRoot)/scripts/generate-release-notes.ps1&quot;"
+          WorkingDirectory="$(_ProjectRoot)/.."
+          ConsoleToMSBuild="true"
+          StandardOutputImportance="low"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" ItemName="_ReleaseNoteLines" />
+    </Exec>
+    <CreateProperty Value="@(_ReleaseNoteLines, '%0a')">
+      <Output TaskParameter="Value" PropertyName="PackageReleaseNotes" />
+    </CreateProperty>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Motivation

The Egil.SystemTextJson.Migration NuGet package ships without release notes. NuGet consumers have no way to see what changed between versions without visiting the repository. Adding release notes derived from the commit history gives users a quick summary of new features, bug fixes, and performance improvements directly on nuget.org and in the VS Package Manager.

## Approach

Rather than adding an external tool (git-cliff, conventional-changelog, etc.), this uses a lightweight PowerShell script that integrates into the existing `dotnet pack` pipeline with zero new dependencies:

- **`scripts/generate-release-notes.ps1`** -- finds the latest `egil-systemtextjson-migration/v*` tag, collects commits since then (filtered to the project directory), parses conventional commit prefixes, and outputs plain-text sections. NuGet does not render markdown, so the output is intentionally plain text.
- **MSBuild target `_GenerateReleaseNotes`** in the `.csproj` -- runs `BeforeTargets="GenerateNuspec"` during `dotnet pack -c Release`, captures the script's stdout via `ConsoleToMSBuild`, and sets `PackageReleaseNotes`. Works with `--no-build`. Can be skipped with `/p:SkipReleaseNotes=true`.

No CI workflow changes are needed -- the target fires automatically during the existing `dotnet pack` step.

## Release notes sections

| Conventional commit type | Section heading | Included? |
|---|---|---|
| `feat` | New Features | Yes |
| `fix` | Bug Fixes | Yes |
| `perf` | Performance | Yes |
| `!` (breaking marker) | BREAKING CHANGES | Yes |
| `release`, `build`, `ci`, `chore`, `docs`, `style`, `refactor`, `test` | -- | Skipped |

Example output (simulated with full history):

```
New Features:
- add OTel-compatible migration counter
- implement System.Text.Json migration library
Bug Fixes:
- add nbgv tool to local tool manifest
- update benchmark docs, add test
Performance:
- zero-allocation discriminator matching in hot path
- bypass GetReaderScopedToNextValue via direct converter.Read()
- added plain polymorphic benchmarks for comparison
```

## Notes

- The script is parameterized (`-TagPrefix`, `-ProjectPath`) so it can be reused by other projects in this repo.
- If the repo is not a git checkout (e.g. building from a source archive), the script exits silently and no release notes are set.