### PR TITLE
feat(stjm): include commit body text in release notes

### DIFF
--- a/Egil.SystemTextJson.Migration/AGENTS.md
+++ b/Egil.SystemTextJson.Migration/AGENTS.md
@@ -77,7 +77,27 @@ Do not mix unrelated commit types in a single commit. Ensure Conventional Commit
 Tests that validate a `feat` or `fix` must be included in the same commit as that `feat`/`fix` (use the `feat` or `fix` type).
 Use `test(...)` commits only for test-only changes, such as adding coverage for existing behavior without production-code changes.
 Refactoring changes go into one commit, fixes into another commit, etc.
-Include a concise summary of decisions and chat log context in the commit message body.
+
+**Commit body text is included in package release notes and changelogs.** The subject line is the terse entry heading; the body provides the detail that package consumers read. Write the body as clear, user-facing prose that explains *what* changed and *why* it matters. Avoid internal-only context (chat logs, agent session IDs, implementation minutiae) — focus on information that is valuable in a changelog.
+
+For breaking changes, add a `BREAKING CHANGE: <description>` footer in the body (per the Conventional Commits spec) in addition to — or instead of — the `!` suffix on the subject.
+
+To exclude a commit from release notes (for example, build tooling or infrastructure changes that use `feat`/`fix` types but are not relevant to package consumers), add `[skip notes]` anywhere in the subject or body.
+
+Example of a well-structured commit message:
+
+```
+feat(stjm): support migration from non-object JSON payloads
+
+Migrators can now handle source documents whose top-level JSON token
+is an array, string, number, or boolean — not only objects. This
+removes the previous restriction that forced callers to wrap
+primitives before migration.
+
+BREAKING CHANGE: IMigrate<TFrom,TTo>.Migrate now receives a
+JsonElement instead of a JsonObject, so existing migrators that
+call JsonObject-specific APIs will need adjustment.
+```
 
 Keep commits small and focused. For PRs, include:
 - What changed and why.

--- a/Egil.SystemTextJson.Migration/scripts/generate-release-notes.ps1
+++ b/Egil.SystemTextJson.Migration/scripts/generate-release-notes.ps1
@@ -5,8 +5,18 @@
 .DESCRIPTION
     Finds the latest git tag matching the given prefix, collects commits since
     that tag (filtered to the project directory), parses conventional commit
-    messages, and outputs categorised plain-text release notes suitable for
-    NuGet PackageReleaseNotes (which does not support markdown).
+    messages (subject and body), and outputs categorised plain-text release notes
+    suitable for NuGet PackageReleaseNotes (which does not support markdown).
+
+    Commit body text is included as indented detail under each entry to provide
+    richer context in the changelog. BREAKING CHANGE footers in the body are
+    detected and promoted to the breaking changes section per the Conventional
+    Commits specification. Git trailers (Co-authored-by, Signed-off-by, etc.)
+    are stripped from the body before inclusion.
+
+    Individual commits can be excluded by adding [skip notes] anywhere in the
+    subject or body (useful for build/infra/tooling changes that carry a feat
+    or fix type but are not relevant to package consumers).
 
 .PARAMETER TagPrefix
     Tag name prefix used to find the latest release tag.
@@ -46,44 +56,82 @@ else {
     $range = "HEAD"
 }
 
-# Collect one-line commit subjects touching the project directory.
+# Collect commit subjects and bodies touching the project directory.
+# A unique separator delimits each commit so subject and body can be parsed.
 # --no-merges skips merge commits (whose messages are noise like "Merge PR #N")
 # but still traverses merged branches so feature/fix commits are included.
-$commitArgs = @('log', $range, '--format=%s', '--no-merges', '--', $ProjectPath)
-$subjects = & git @commitArgs
+$commitSeparator = '---commit-8a3f9b2e---'
+$commitArgs = @('log', $range, "--format=${commitSeparator}%n%s%n%b", '--no-merges', '--', $ProjectPath)
+$raw = (& git @commitArgs) -join "`n"
 
-if (-not $subjects -or $subjects.Count -eq 0) {
+if (-not $raw -or $raw.Trim().Length -eq 0) {
     # No commits since last tag – nothing to report.
     exit 0
 }
 
+$commitBlocks = $raw -split [regex]::Escape($commitSeparator) | Where-Object { $_.Trim() }
+
+if (-not $commitBlocks -or @($commitBlocks).Count -eq 0) {
+    exit 0
+}
+
+# Regex to strip common git trailers from the body.
+$trailerPattern = '(?m)^(Co-authored-by|Signed-off-by|Reviewed-by|Acked-by|Tested-by|Reported-by|Helped-by|Cc|Change-Id):\s.*$'
+
 # Parse conventional commit subjects into categorised lists.
-$breaking = [System.Collections.Generic.List[string]]::new()
-$features = [System.Collections.Generic.List[string]]::new()
-$fixes = [System.Collections.Generic.List[string]]::new()
-$perf = [System.Collections.Generic.List[string]]::new()
+# Each entry is a hashtable with Description (subject text) and Body (cleaned body text).
+$breaking = [System.Collections.Generic.List[hashtable]]::new()
+$features = [System.Collections.Generic.List[hashtable]]::new()
+$fixes = [System.Collections.Generic.List[hashtable]]::new()
+$perf = [System.Collections.Generic.List[hashtable]]::new()
 
 # Types that are not interesting for end-user release notes.
 $skipTypes = @('release', 'build', 'ci', 'chore', 'docs', 'style', 'refactor', 'test')
 
-foreach ($subject in $subjects) {
+foreach ($block in $commitBlocks) {
+    $lines = $block.Trim() -split "`n"
+    $subject = $lines[0].Trim()
+    $body = ''
+    if ($lines.Count -gt 1) {
+        $body = ($lines[1..($lines.Count - 1)] -join "`n").Trim()
+    }
+
+    # Allow individual commits to opt out of release notes.
+    $fullMessage = "$subject`n$body"
+    if ($fullMessage -match '\[skip notes\]') {
+        continue
+    }
+
     # Match: type(scope)!: description   or   type!: description   or   type: description
     if ($subject -match '^(?<type>\w+)(?:\([^)]*\))?(?<bang>!)?:\s*(?<desc>.+)$') {
         $type = $Matches['type'].ToLowerInvariant()
         $desc = $Matches['desc'].Trim()
         $isBreaking = $Matches['bang'] -eq '!'
 
+        # Detect BREAKING CHANGE footer in body (per Conventional Commits spec).
+        if ($body -match '(?m)^BREAKING[- ]CHANGE:\s*(?<bcdesc>.+)') {
+            $isBreaking = $true
+        }
+
+        # Clean body: strip BREAKING CHANGE footers and git trailers.
+        $cleanBody = $body -replace '(?m)^BREAKING[- ]CHANGE:\s*.*$', ''
+        $cleanBody = $cleanBody -replace $trailerPattern, ''
+        # Collapse runs of blank lines and trim.
+        $cleanBody = ($cleanBody -replace '(\r?\n){3,}', "`n`n").Trim()
+
+        $entry = @{ Description = $desc; Body = $cleanBody }
+
         if ($isBreaking) {
-            $breaking.Add($desc)
+            $breaking.Add($entry)
         }
         elseif ($type -eq 'feat') {
-            $features.Add($desc)
+            $features.Add($entry)
         }
         elseif ($type -eq 'fix') {
-            $fixes.Add($desc)
+            $fixes.Add($entry)
         }
         elseif ($type -eq 'perf') {
-            $perf.Add($desc)
+            $perf.Add($entry)
         }
         elseif ($type -in $skipTypes) {
             continue
@@ -96,11 +144,17 @@ foreach ($subject in $subjects) {
 # Build plain-text output (no markdown – NuGet does not render it).
 $sections = [System.Collections.Generic.List[string]]::new()
 
-function Add-Section([string]$heading, [System.Collections.Generic.List[string]]$items) {
+function Add-Section([string]$heading, [System.Collections.Generic.List[hashtable]]$items) {
     if ($items.Count -eq 0) { return }
     $sections.Add($heading)
     foreach ($item in $items) {
-        $sections.Add("- $item")
+        $sections.Add("- $($item.Description)")
+        if ($item.Body) {
+            $bodyLines = $item.Body -split "`n"
+            foreach ($line in $bodyLines) {
+                $sections.Add("  $line")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Why

The release notes script (`generate-release-notes.ps1`) only used commit subject lines (`--format=%s`), discarding body text entirely. This meant valuable context written by contributors -- explaining *what* changed and *why* -- was lost from the changelog embedded in NuGet packages.

## What changed

**`generate-release-notes.ps1`** now captures both subject and body for each commit:

- Uses a per-commit separator format instead of `--format=%s` to parse subject and body separately.
- Body text appears as indented detail under each release note entry, producing richer plain-text output suitable for NuGet's `PackageReleaseNotes`.
- `BREAKING CHANGE:` / `BREAKING-CHANGE:` footers in the body are detected and promote the commit to the breaking changes section (per the Conventional Commits spec).
- Git trailers (`Co-authored-by`, `Signed-off-by`, etc.) are stripped from body text before inclusion.
- A `[skip notes]` marker anywhere in the subject or body excludes a commit from release notes -- useful for build/infra/tooling changes that carry a `feat` or `fix` type but are not relevant to package consumers.

**`AGENTS.md`** commit guidelines updated to:

- Explicitly state that commit body text feeds into package release notes and changelogs.
- Require body text to be written as clear, user-facing prose valuable in a changelog.
- Document the `[skip notes]` opt-out marker.
- Document `BREAKING CHANGE:` body footers.
- Include a concrete example of a well-structured commit message.

## Example output

```
New Features:
- support migration from non-object JSON payloads
  Enable migrating from non-object JSON payloads (arrays, primitives,
  dictionaries) to [JsonMigratable] target types via IMigrateFrom and
  IMigrate contracts.
  ...
```

Commits marked with `[skip notes]` (like this PR's own commit and the earlier tooling commit) are correctly excluded.