### PR TITLE
docs(ot): remove custom README fixture anchor

### DIFF
--- a/Egil.Orleans.Testing/README.md
+++ b/Egil.Orleans.Testing/README.md
@@ -125,8 +125,7 @@ public sealed class OrderGrainInlineSetupTests
 <sup><a href='/samples/Egil.Orleans.Testing.Samples/GettingStartedSample.cs#L6-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme_inline_setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-<a id="orleans-test-cluster-fixture"></a>
-### 3. Reusable Fixture Or Helper Object
+### OrleansTestClusterFixture Reusable Helper
 
 When many tests share the same cluster, it is convenient to wrap the cluster and collector in a reusable object that implements `IGrainActivityWaiter`. In xUnit this could be a class fixture or collection fixture. In other frameworks it could be any shared helper with setup and teardown.
 
@@ -356,13 +355,13 @@ In xUnit, see the official docs for fixture registration options:
 
 ## Recipes
 
-See [docs/recipes](docs/recipes/README.md) for scenario-driven guides covering:
+See [docs/recipes](https://github.com/egil/framework/tree/main/Egil.Orleans.Testing/docs/recipes/) for scenario-driven guides covering:
 
-- [Assertion patterns](docs/recipes/assertion-patterns.md)
-- [Advanced assertions](docs/recipes/advanced-assertions.md)
-- [Timers and reminders](docs/recipes/timers-and-reminders.md)
-- [Streams](docs/recipes/streams.md)
+- [Assertion patterns](https://github.com/egil/framework/tree/main/Egil.Orleans.Testing/docs/recipes/assertion-patterns.md)
+- [Advanced assertions](https://github.com/egil/framework/tree/main/Egil.Orleans.Testing/docs/recipes/advanced-assertions.md)
+- [Timers and reminders](https://github.com/egil/framework/tree/main/Egil.Orleans.Testing/docs/recipes/timers-and-reminders.md)
+- [Streams](https://github.com/egil/framework/tree/main/Egil.Orleans.Testing/docs/recipes/streams.md)
 
 ## License
 
-[MIT](../LICENSE)
+[MIT](https://github.com/egil/framework/blob/main/LICENSE)

--- a/Egil.Orleans.Testing/docs/recipes/advanced-assertions.md
+++ b/Egil.Orleans.Testing/docs/recipes/advanced-assertions.md
@@ -12,7 +12,7 @@ Use the advanced methods when:
 
 ## Waiting for a specific storage operation
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 <!-- snippet: advanced_storage_assertion -->
 <a id='snippet-advanced_storage_assertion'></a>
@@ -56,7 +56,7 @@ The `StorageOperation` record exposes:
 
 ## Waiting for a specific grain call
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 <!-- snippet: advanced_grain_call_assertion -->
 <a id='snippet-advanced_grain_call_assertion'></a>

--- a/Egil.Orleans.Testing/docs/recipes/assertion-patterns.md
+++ b/Egil.Orleans.Testing/docs/recipes/assertion-patterns.md
@@ -1,6 +1,6 @@
 # Assertion Patterns
 
-These samples reuse the canonical [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture) from the README rather than repeating its full setup on every page.
+These samples reuse the canonical [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper) from the README rather than repeating its full setup on every page.
 
 ## Grain-scoped assertions
 
@@ -57,13 +57,13 @@ public sealed class CounterGrainTests(OrleansTestClusterFixture fixture) : IClas
 <sup><a href='/samples/Egil.Orleans.Testing.Samples/GrainScopedAssertionSample.cs#L32-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-grain_scoped_assertions_fixture' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ## Waiting for any grain activity
 
 The unscoped `WaitForAssertionAsync` overload retries the assertion each time any grain activity (call or storage operation) is observed. Use it when the observed outcome can be driven by more than one grain, or when you do not have a meaningful grain reference to scope the wait to.
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ```csharp
 await fixture.WaitForAssertionAsync(async () =>
@@ -76,7 +76,7 @@ await fixture.WaitForAssertionAsync(async () =>
 
 All `WaitForAssertionAsync` overloads have value-returning variants — use `Func<Task<TResult>>` or `Func<ValueTask<TResult>>`:
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ```csharp
 var count = await fixture.WaitForAssertionAsync(async () =>
@@ -92,7 +92,7 @@ var count = await fixture.WaitForAssertionAsync(async () =>
 
 The default timeout is **5 seconds** (or indefinite when a debugger is attached).
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 Override per-call:
 ```csharp

--- a/Egil.Orleans.Testing/docs/recipes/streams.md
+++ b/Egil.Orleans.Testing/docs/recipes/streams.md
@@ -4,7 +4,7 @@
 
 With explicit subscriptions, the subscriber grain calls `stream.SubscribeAsync(this)` to register for events. The test must subscribe the grain before publishing.
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ### Subscriber grain
 
@@ -97,7 +97,7 @@ public sealed class ExplicitStreamTests(OrleansTestClusterFixture fixture) : ICl
 
 With implicit subscriptions, Orleans automatically delivers stream events to grains decorated with `[ImplicitStreamSubscription(...)]`. The grain activates on first message delivery — no manual subscribe step is needed.
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ### Subscriber grain
 

--- a/Egil.Orleans.Testing/docs/recipes/timers-and-reminders.md
+++ b/Egil.Orleans.Testing/docs/recipes/timers-and-reminders.md
@@ -4,7 +4,7 @@
 
 Grain timers are supported. A timer callback is a grain-internal method call and also typically writes grain state, so it produces **both** grain call and storage activity signals that `WaitForAssertionAsync` can observe.
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 ### Timer grain example
 
@@ -137,7 +137,7 @@ public sealed class ReminderGrain(
 
 ### Reminder fixture setup
 
-Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleans-test-cluster-fixture)
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
 Create a derived fixture that owns a `ReminderTestClock` and attaches it to the cluster. Note that **no storage observer** is needed — `WaitForAssertionAsync` retries on grain call signals alone, which includes the `ReceiveReminder` callback:
 


### PR DESCRIPTION
## Summary
- remove the custom README anchor for the shared OrleansTestClusterFixture section
- retarget recipe references to the new heading anchor
- make NuGet-visible recipe and license links absolute GitHub URLs

## Verification
- dotnet pack Egil.Orleans.Testing/src/Egil.Orleans.Testing/Egil.Orleans.Testing.csproj -c Release
- inspected the generated .nupkg README to confirm the custom anchor is absent and links render as absolute URLs