### PR TITLE
feat: add live operation feeds to GrainActivityCollector

### DIFF
--- a/Egil.Orleans.Testing/docs/recipes/README.md
+++ b/Egil.Orleans.Testing/docs/recipes/README.md
@@ -27,3 +27,9 @@ All code samples are extracted from the [samples project](../../samples/Egil.Orl
 - [Explicit stream subscriptions](streams.md#explicit-stream-subscriptions)
 - [Implicit stream subscriptions](streams.md#implicit-stream-subscriptions)
 - [Fixture setup for streams](streams.md#fixture-setup)
+
+## Operation feeds
+
+- [When to use operation feeds](operation-feeds.md#when-to-use-operation-feeds)
+- [Subscribing to storage operations](operation-feeds.md#subscribing-to-storage-operations)
+- [Subscribing to grain calls](operation-feeds.md#subscribing-to-grain-calls)

--- a/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
+++ b/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
@@ -115,4 +115,4 @@ Both `SubscribeToGrainCalls` overloads expose:
 
 ## Assertion-scope suppression
 
-Storage operations triggered inside a `WaitForAssertionAsync` callback (via `RequestContextScope.ForAssertion()`) are automatically suppressed from the feed. This prevents self-triggered storage activity from polluting your collected events.
+Storage operations and grain calls triggered inside a `WaitForAssertionAsync` callback (via `RequestContextScope.ForAssertion()`) are automatically suppressed from both feeds. This prevents self-triggered activity from polluting your collected events.

--- a/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
+++ b/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
@@ -41,29 +41,21 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
     [Fact]
     public async Task Collect_storage_writes_from_oneway_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        var writes = new List<StorageOperation>();
 
-        // Start collecting storage operations for the grain BEFORE triggering
-        // the action. The feed is future-only — it does not replay past events.
-        var feedTask = Task.Run(async () =>
-        {
-            await foreach (var op in fixture.Collector.SubscribeToStorageOperations(grain, cts.Token))
-            {
-                if (op.Kind == StorageOperationKind.Write)
-                {
-                    writes.Add(op);
-                    await cts.CancelAsync();
-                }
-            }
-        }, cts.Token);
+        // Start collecting BEFORE triggering the action.
+        // The feed is future-only — it does not replay past events.
+        // Use Take(1) to automatically stop after the first matching write.
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("widget", 10);
 
-        // Wait for the feed to collect the write
-        try { await feedTask; }
-        catch (OperationCanceledException) { }
+        var writes = await collectTask;
 
         Assert.Single(writes);
         Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
@@ -95,28 +87,20 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
     [Fact]
     public async Task Collect_grain_calls_from_internal_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        var calls = new List<IIncomingGrainCallContext>();
 
-        // Start collecting grain calls globally BEFORE triggering the action.
-        // We'll look for the internal ILedgerGrain.AddReservationAsync call.
-        var feedTask = Task.Run(async () =>
-        {
-            await foreach (var ctx in fixture.Collector.SubscribeToGrainCalls(cts.Token))
-            {
-                if (ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
-                {
-                    calls.Add(ctx);
-                    await cts.CancelAsync();
-                }
-            }
-        }, cts.Token);
+        // Start collecting BEFORE triggering the action.
+        // Use Take(1) to automatically stop after the first matching call.
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(ct)
+            .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("gadget", 5);
 
-        try { await feedTask; }
-        catch (OperationCanceledException) { }
+        var calls = await collectTask;
 
         Assert.Single(calls);
     }

--- a/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
+++ b/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
@@ -1,0 +1,134 @@
+# Operation Feeds
+
+## When to use operation feeds
+
+The `SubscribeToStorageOperations` and `SubscribeToGrainCalls` methods provide a live, future-only stream of low-level events that you can collect and inspect after triggering grain behavior. Unlike the `WaitFor*` methods, feeds do not have a timeout or a predicate — they simply yield every matching event for as long as you consume them.
+
+Use feeds when:
+- You want to **collect all** storage operations or grain calls that happened during a test scenario, not just wait for one.
+- You need to assert on the **sequence** or **count** of events, not just that a single match occurred.
+- You are building custom test infrastructure on top of the collector.
+
+> ⚠️ **Coupling risk:** Feed-based tests are tightly coupled to implementation details like storage providers, write timing, persistence strategy, and internal call flow. If the grain's internal implementation changes, these tests may break even when externally observable behavior is unchanged. Prefer `WaitForAssertionAsync` when possible.
+
+## Key semantics
+
+| Property | Behavior |
+|---|---|
+| Start point | Subscription begins when enumeration starts (first `MoveNextAsync`) |
+| History | Future-only — no replay of past events |
+| Buffering | Unbounded — slow consumers never lose events |
+| Completion | Stops when the `CancellationToken` is cancelled or the caller breaks out of the `await foreach` |
+
+## Subscribing to storage operations
+
+Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
+
+<!-- snippet: storage_operation_feed -->
+<a id='snippet-storage_operation_feed'></a>
+```cs
+/// <summary>
+/// Demonstrates subscribing to a live feed of storage operations
+/// for collecting and inspecting persistence activity.
+/// </summary>
+/// <remarks>
+/// ⚠️ <c>SubscribeToStorageOperations</c> exposes persistence implementation details.
+/// Tests using this feed are tightly coupled to storage providers and write timing.
+/// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
+/// </remarks>
+public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
+{
+    [Fact]
+    public async Task Collect_storage_writes_from_oneway_call()
+    {
+        var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var writes = new List<StorageOperation>();
+
+        // Start collecting storage operations for the grain BEFORE triggering
+        // the action. The feed is future-only — it does not replay past events.
+        var feedTask = Task.Run(async () =>
+        {
+            await foreach (var op in fixture.Collector.SubscribeToStorageOperations(grain, cts.Token))
+            {
+                if (op.Kind == StorageOperationKind.Write)
+                {
+                    writes.Add(op);
+                    await cts.CancelAsync();
+                }
+            }
+        }, cts.Token);
+
+        await grain.ReserveAsync("widget", 10);
+
+        // Wait for the feed to collect the write
+        try { await feedTask; }
+        catch (OperationCanceledException) { }
+
+        Assert.Single(writes);
+        Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
+    }
+}
+```
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L14-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-storage_operation_feed' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Both `SubscribeToStorageOperations` overloads expose:
+- **Global** — receives all storage operations from any grain.
+- **Grain-scoped** — receives only storage operations for the specified grain.
+
+## Subscribing to grain calls
+
+<!-- snippet: grain_call_feed -->
+<a id='snippet-grain_call_feed'></a>
+```cs
+/// <summary>
+/// Demonstrates subscribing to a live feed of incoming grain calls
+/// for collecting and inspecting call flow.
+/// </summary>
+/// <remarks>
+/// ⚠️ <c>SubscribeToGrainCalls</c> exposes low-level call flow.
+/// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
+/// </remarks>
+public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
+{
+    [Fact]
+    public async Task Collect_grain_calls_from_internal_call()
+    {
+        var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var calls = new List<IIncomingGrainCallContext>();
+
+        // Start collecting grain calls globally BEFORE triggering the action.
+        // We'll look for the internal ILedgerGrain.AddReservationAsync call.
+        var feedTask = Task.Run(async () =>
+        {
+            await foreach (var ctx in fixture.Collector.SubscribeToGrainCalls(cts.Token))
+            {
+                if (ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+                {
+                    calls.Add(ctx);
+                    await cts.CancelAsync();
+                }
+            }
+        }, cts.Token);
+
+        await grain.ReserveAsync("gadget", 5);
+
+        try { await feedTask; }
+        catch (OperationCanceledException) { }
+
+        Assert.Single(calls);
+    }
+}
+```
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L51-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-grain_call_feed' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Both `SubscribeToGrainCalls` overloads expose:
+- **Global** — receives all incoming grain calls from any grain.
+- **Grain-scoped** — receives only calls targeting the specified grain.
+
+## Assertion-scope suppression
+
+Storage operations triggered inside a `WaitForAssertionAsync` callback (via `RequestContextScope.ForAssertion()`) are automatically suppressed from the feed. This prevents self-triggered storage activity from polluting your collected events.

--- a/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
+++ b/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
@@ -106,7 +106,7 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
     }
 }
 ```
-<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L51-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-grain_call_feed' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L45-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-grain_call_feed' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Both `SubscribeToGrainCalls` overloads expose:

--- a/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
+++ b/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
@@ -20,29 +20,21 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
     [Fact]
     public async Task Collect_storage_writes_from_oneway_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        var writes = new List<StorageOperation>();
 
-        // Start collecting storage operations for the grain BEFORE triggering
-        // the action. The feed is future-only — it does not replay past events.
-        var feedTask = Task.Run(async () =>
-        {
-            await foreach (var op in fixture.Collector.SubscribeToStorageOperations(grain, cts.Token))
-            {
-                if (op.Kind == StorageOperationKind.Write)
-                {
-                    writes.Add(op);
-                    await cts.CancelAsync();
-                }
-            }
-        }, cts.Token);
+        // Start collecting BEFORE triggering the action.
+        // The feed is future-only — it does not replay past events.
+        // Use Take(1) to automatically stop after the first matching write.
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("widget", 10);
 
-        // Wait for the feed to collect the write
-        try { await feedTask; }
-        catch (OperationCanceledException) { }
+        var writes = await collectTask;
 
         Assert.Single(writes);
         Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
@@ -64,28 +56,20 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
     [Fact]
     public async Task Collect_grain_calls_from_internal_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        var calls = new List<IIncomingGrainCallContext>();
 
-        // Start collecting grain calls globally BEFORE triggering the action.
-        // We'll look for the internal ILedgerGrain.AddReservationAsync call.
-        var feedTask = Task.Run(async () =>
-        {
-            await foreach (var ctx in fixture.Collector.SubscribeToGrainCalls(cts.Token))
-            {
-                if (ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
-                {
-                    calls.Add(ctx);
-                    await cts.CancelAsync();
-                }
-            }
-        }, cts.Token);
+        // Start collecting BEFORE triggering the action.
+        // Use Take(1) to automatically stop after the first matching call.
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(ct)
+            .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("gadget", 5);
 
-        try { await feedTask; }
-        catch (OperationCanceledException) { }
+        var calls = await collectTask;
 
         Assert.Single(calls);
     }

--- a/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
+++ b/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
@@ -1,0 +1,93 @@
+namespace Egil.Orleans.Testing.Samples.OperationFeeds;
+
+// Reuses the grains defined in AdvancedAssertions namespace.
+using Egil.Orleans.Testing.Samples.AdvancedAssertions;
+
+// -- Tests -------------------------------------------------------------------
+
+#region storage_operation_feed
+/// <summary>
+/// Demonstrates subscribing to a live feed of storage operations
+/// for collecting and inspecting persistence activity.
+/// </summary>
+/// <remarks>
+/// ⚠️ <c>SubscribeToStorageOperations</c> exposes persistence implementation details.
+/// Tests using this feed are tightly coupled to storage providers and write timing.
+/// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
+/// </remarks>
+public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
+{
+    [Fact]
+    public async Task Collect_storage_writes_from_oneway_call()
+    {
+        var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var writes = new List<StorageOperation>();
+
+        // Start collecting storage operations for the grain BEFORE triggering
+        // the action. The feed is future-only — it does not replay past events.
+        var feedTask = Task.Run(async () =>
+        {
+            await foreach (var op in fixture.Collector.SubscribeToStorageOperations(grain, cts.Token))
+            {
+                if (op.Kind == StorageOperationKind.Write)
+                {
+                    writes.Add(op);
+                    await cts.CancelAsync();
+                }
+            }
+        }, cts.Token);
+
+        await grain.ReserveAsync("widget", 10);
+
+        // Wait for the feed to collect the write
+        try { await feedTask; }
+        catch (OperationCanceledException) { }
+
+        Assert.Single(writes);
+        Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
+    }
+}
+#endregion
+
+#region grain_call_feed
+/// <summary>
+/// Demonstrates subscribing to a live feed of incoming grain calls
+/// for collecting and inspecting call flow.
+/// </summary>
+/// <remarks>
+/// ⚠️ <c>SubscribeToGrainCalls</c> exposes low-level call flow.
+/// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
+/// </remarks>
+public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
+{
+    [Fact]
+    public async Task Collect_grain_calls_from_internal_call()
+    {
+        var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var calls = new List<IIncomingGrainCallContext>();
+
+        // Start collecting grain calls globally BEFORE triggering the action.
+        // We'll look for the internal ILedgerGrain.AddReservationAsync call.
+        var feedTask = Task.Run(async () =>
+        {
+            await foreach (var ctx in fixture.Collector.SubscribeToGrainCalls(cts.Token))
+            {
+                if (ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+                {
+                    calls.Add(ctx);
+                    await cts.CancelAsync();
+                }
+            }
+        }, cts.Token);
+
+        await grain.ReserveAsync("gadget", 5);
+
+        try { await feedTask; }
+        catch (OperationCanceledException) { }
+
+        Assert.Single(calls);
+    }
+}
+#endregion

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -591,12 +591,10 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
     private void PublishStorageOperation(StorageOperation operation)
     {
         StorageSubscriber[] snapshot;
-        LiveFeedSubscriber<StorageOperation>[] liveFeedSnapshot;
         lock (storageSubscribersLock)
         {
             EnqueueRecentEvent(recentStorageOperations, operation);
             snapshot = [.. storageSubscribers];
-            liveFeedSnapshot = [.. liveFeedStorageSubscribers];
         }
 
         foreach (var subscriber in snapshot)
@@ -612,6 +610,8 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
             }
         }
 
+        // Live-feed subscribers use copy-on-write; reading the reference is safe without a lock.
+        var liveFeedSnapshot = liveFeedStorageSubscribers;
         foreach (var subscriber in liveFeedSnapshot)
         {
             if (subscriber.GrainIdFilter is { } grainId && operation.GrainId != grainId)
@@ -626,12 +626,10 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
     private void PublishGrainCall(IIncomingGrainCallContext context)
     {
         GrainCallSubscriber[] snapshot;
-        LiveFeedSubscriber<IIncomingGrainCallContext>[] liveFeedSnapshot;
         lock (grainCallSubscribersLock)
         {
             EnqueueRecentEvent(recentGrainCalls, context);
             snapshot = [.. grainCallSubscribers];
-            liveFeedSnapshot = [.. liveFeedGrainCallSubscribers];
         }
 
         foreach (var subscriber in snapshot)
@@ -647,6 +645,8 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
             }
         }
 
+        // Live-feed subscribers use copy-on-write; reading the reference is safe without a lock.
+        var liveFeedSnapshot = liveFeedGrainCallSubscribers;
         foreach (var subscriber in liveFeedSnapshot)
         {
             if (subscriber.GrainIdFilter is { } grainId && context.TargetId != grainId)

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 
 namespace Egil.Orleans.Testing;
@@ -30,6 +30,8 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
     private List<ActivitySubscriber> activitySubscribers = [];
     private List<StorageSubscriber> storageSubscribers = [];
     private List<GrainCallSubscriber> grainCallSubscribers = [];
+    private List<LiveFeedSubscriber<StorageOperation>> liveFeedStorageSubscribers = [];
+    private List<LiveFeedSubscriber<IIncomingGrainCallContext>> liveFeedGrainCallSubscribers = [];
     private Queue<StorageOperation> recentStorageOperations = new();
     private Queue<IIncomingGrainCallContext> recentGrainCalls = new();
 
@@ -147,6 +149,232 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
             timeout,
             grain.GetGrainId(),
             ct);
+    }
+
+    /// <summary>
+    /// Returns a live, future-only feed of all storage operations observed by the collector.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
+    /// Only operations that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
+    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// </para>
+    /// <para>
+    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
+    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// </para>
+    /// <para><b>Coupling risk:</b> This method exposes low-level persistence implementation details.
+    /// Tests using this feed are tightly coupled to storage providers, write timing, and persistence strategy.
+    /// Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior through the grain's public API.</para>
+    /// </remarks>
+    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields storage operations as they occur.</returns>
+    public async IAsyncEnumerable<StorageOperation> SubscribeToStorageOperations(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var channel = Channel.CreateUnbounded<StorageOperation>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        var subscriber = new LiveFeedSubscriber<StorageOperation>(channel, GrainIdFilter: null);
+        lock (storageSubscribersLock)
+        {
+            liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers, subscriber];
+        }
+
+        try
+        {
+            await foreach (var operation in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return operation;
+            }
+        }
+        finally
+        {
+            lock (storageSubscribersLock)
+            {
+                liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
+            }
+
+            channel.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
+    /// Returns a live, future-only feed of storage operations for the specified grain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
+    /// Only operations that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
+    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// </para>
+    /// <para>
+    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
+    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// </para>
+    /// <para><b>Coupling risk:</b> This method exposes low-level persistence implementation details.
+    /// Tests using this feed are tightly coupled to storage providers, write timing, and persistence strategy.
+    /// Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior through the grain's public API.</para>
+    /// </remarks>
+    /// <typeparam name="TGrain">The grain interface type.</typeparam>
+    /// <param name="grain">The grain whose storage operations should be included in the feed.</param>
+    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields storage operations for the specified grain as they occur.</returns>
+    public async IAsyncEnumerable<StorageOperation> SubscribeToStorageOperations<TGrain>(
+        TGrain grain,
+        [EnumeratorCancellation] CancellationToken ct = default)
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(grain);
+        var grainId = grain.GetGrainId();
+
+        var channel = Channel.CreateUnbounded<StorageOperation>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        var subscriber = new LiveFeedSubscriber<StorageOperation>(channel, GrainIdFilter: grainId);
+        lock (storageSubscribersLock)
+        {
+            liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers, subscriber];
+        }
+
+        try
+        {
+            await foreach (var operation in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return operation;
+            }
+        }
+        finally
+        {
+            lock (storageSubscribersLock)
+            {
+                liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
+            }
+
+            channel.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
+    /// Returns a live, future-only feed of all incoming grain calls observed by the collector.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
+    /// Only calls that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
+    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// </para>
+    /// <para>
+    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
+    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// </para>
+    /// <para><b>Coupling risk:</b> This method exposes low-level call flow rather than externally observable grain behavior.
+    /// Tests using this feed are tightly coupled to internal call structure and can break when implementation details change.
+    /// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.</para>
+    /// </remarks>
+    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields incoming grain call contexts as they occur.</returns>
+    public async IAsyncEnumerable<IIncomingGrainCallContext> SubscribeToGrainCalls(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var channel = Channel.CreateUnbounded<IIncomingGrainCallContext>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        var subscriber = new LiveFeedSubscriber<IIncomingGrainCallContext>(channel, GrainIdFilter: null);
+        lock (grainCallSubscribersLock)
+        {
+            liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers, subscriber];
+        }
+
+        try
+        {
+            await foreach (var context in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return context;
+            }
+        }
+        finally
+        {
+            lock (grainCallSubscribersLock)
+            {
+                liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
+            }
+
+            channel.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
+    /// Returns a live, future-only feed of incoming grain calls for the specified grain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
+    /// Only calls that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
+    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// </para>
+    /// <para>
+    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
+    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// </para>
+    /// <para><b>Coupling risk:</b> This method exposes low-level call flow rather than externally observable grain behavior.
+    /// Tests using this feed are tightly coupled to internal call structure and can break when implementation details change.
+    /// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.</para>
+    /// </remarks>
+    /// <typeparam name="TGrain">The grain interface type.</typeparam>
+    /// <param name="grain">The grain whose incoming calls should be included in the feed.</param>
+    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields incoming grain call contexts for the specified grain as they occur.</returns>
+    public async IAsyncEnumerable<IIncomingGrainCallContext> SubscribeToGrainCalls<TGrain>(
+        TGrain grain,
+        [EnumeratorCancellation] CancellationToken ct = default)
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(grain);
+        var grainId = grain.GetGrainId();
+
+        var channel = Channel.CreateUnbounded<IIncomingGrainCallContext>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        var subscriber = new LiveFeedSubscriber<IIncomingGrainCallContext>(channel, GrainIdFilter: grainId);
+        lock (grainCallSubscribersLock)
+        {
+            liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers, subscriber];
+        }
+
+        try
+        {
+            await foreach (var context in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return context;
+            }
+        }
+        finally
+        {
+            lock (grainCallSubscribersLock)
+            {
+                liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
+            }
+
+            channel.Writer.TryComplete();
+        }
     }
 
     internal void OnStorageOperation(StorageOperation operation)
@@ -363,10 +591,12 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
     private void PublishStorageOperation(StorageOperation operation)
     {
         StorageSubscriber[] snapshot;
+        LiveFeedSubscriber<StorageOperation>[] liveFeedSnapshot;
         lock (storageSubscribersLock)
         {
             EnqueueRecentEvent(recentStorageOperations, operation);
             snapshot = [.. storageSubscribers];
+            liveFeedSnapshot = [.. liveFeedStorageSubscribers];
         }
 
         foreach (var subscriber in snapshot)
@@ -381,15 +611,27 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
                 throw new InvalidOperationException("A storage operation subscriber channel is full.");
             }
         }
+
+        foreach (var subscriber in liveFeedSnapshot)
+        {
+            if (subscriber.GrainIdFilter is { } grainId && operation.GrainId != grainId)
+            {
+                continue;
+            }
+
+            subscriber.Channel.Writer.TryWrite(operation);
+        }
     }
 
     private void PublishGrainCall(IIncomingGrainCallContext context)
     {
         GrainCallSubscriber[] snapshot;
+        LiveFeedSubscriber<IIncomingGrainCallContext>[] liveFeedSnapshot;
         lock (grainCallSubscribersLock)
         {
             EnqueueRecentEvent(recentGrainCalls, context);
             snapshot = [.. grainCallSubscribers];
+            liveFeedSnapshot = [.. liveFeedGrainCallSubscribers];
         }
 
         foreach (var subscriber in snapshot)
@@ -403,6 +645,16 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
             {
                 throw new InvalidOperationException("A grain call subscriber channel is full.");
             }
+        }
+
+        foreach (var subscriber in liveFeedSnapshot)
+        {
+            if (subscriber.GrainIdFilter is { } grainId && context.TargetId != grainId)
+            {
+                continue;
+            }
+
+            subscriber.Channel.Writer.TryWrite(context);
         }
     }
 
@@ -548,4 +800,6 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter
             }
         }
     }
+
+    private sealed record LiveFeedSubscriber<T>(Channel<T> Channel, GrainId? GrainIdFilter);
 }

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
@@ -7,16 +7,17 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-
-        var collected = new List<IIncomingGrainCallContext>();
 
         // Use grain-scoped feed to avoid collecting unrelated system grain calls from the shared cluster
-        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToGrainCalls(grain, cts.Token), collected, count: 1, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(grain, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await grain.SetValueAsync("hello");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         Assert.NotEmpty(collected);
         Assert.All(collected, ctx => Assert.Equal(grain.GetGrainId(), ctx.TargetId));
@@ -29,12 +30,12 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         var ct = TestContext.Current.CancellationToken;
         var target = fixture.GetUniqueGrain<ITestStateGrain>();
         var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var collected = new List<IIncomingGrainCallContext>();
-        var feedTask = CollectFeedAsync(
-            fixture.Collector.SubscribeToGrainCalls(target, cts.Token),
-            collected, count: 1, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(target, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         // Generate noise from another grain first
         await other.SetValueAsync("noise");
@@ -42,7 +43,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         // Now trigger the target
         await target.SetValueAsync("signal");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         Assert.All(collected, ctx => Assert.Equal(target.GetGrainId(), ctx.TargetId));
     }
@@ -62,23 +63,21 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
             ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync),
             ct: ct);
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var collected = new List<IIncomingGrainCallContext>();
-        var feedTask = CollectFeedAsync(
-            fixture.Collector.SubscribeToGrainCalls(grain, cts.Token),
-            collected, count: 1, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(grain, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         // Now trigger a new call
         await grain.GetValueAsync();
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         // Only the post-subscribe call should appear
-        Assert.All(collected, ctx =>
-        {
-            Assert.Equal(grain.GetGrainId(), ctx.TargetId);
-            Assert.Equal(nameof(ITestStateGrain.GetValueAsync), ctx.MethodName);
-        });
+        Assert.Single(collected);
+        Assert.Equal(grain.GetGrainId(), collected[0].TargetId);
+        Assert.Equal(nameof(ITestStateGrain.GetValueAsync), collected[0].MethodName);
     }
 
     [Fact]
@@ -86,72 +85,16 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     {
         var ct = TestContext.Current.CancellationToken;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var collected = new List<IIncomingGrainCallContext>();
-        var feedTask = CollectAllAsync(fixture.Collector.SubscribeToGrainCalls(cts.Token), collected);
 
-        // Cancel to stop the feed
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(cts.Token)
+            .ToListAsync(ct)
+            .AsTask();
+
         await cts.CancelAsync();
 
-        // The feed task should complete (possibly with OperationCanceledException)
-        await IgnoreCancellationAsync(feedTask);
-
-        // After cancellation, trigger a call and deterministically wait for it
-        // to be processed by the collector, then verify the old list is unchanged.
-        var countAfterCancel = collected.Count;
-        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        await grain.SetValueAsync("after-cancel");
-        await fixture.Collector.WaitForGrainCallAsync(
-            grain,
-            ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync),
-            ct: ct);
-
-        Assert.Equal(countAfterCancel, collected.Count);
-    }
-
-    private static async Task CollectFeedAsync<T>(
-        IAsyncEnumerable<T> feed,
-        List<T> target,
-        int count,
-        CancellationTokenSource cts)
-    {
-        await foreach (var item in feed)
-        {
-            target.Add(item);
-            if (target.Count >= count)
-            {
-                await cts.CancelAsync();
-            }
-        }
-    }
-
-    private static async Task CollectAllAsync<T>(IAsyncEnumerable<T> feed, List<T> target)
-    {
-        await foreach (var item in feed)
-        {
-            target.Add(item);
-        }
-    }
-
-    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationTokenSource cts)
-    {
-        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout));
-        if (!ReferenceEquals(completed, feedTask))
-        {
-            await cts.CancelAsync();
-        }
-
-        await IgnoreCancellationAsync(feedTask);
-    }
-
-    private static async Task IgnoreCancellationAsync(Task task)
-    {
-        try
-        {
-            await task;
-        }
-        catch (OperationCanceledException)
-        {
-            // expected
-        }
+        // Feed completes promptly after cancellation; the finally block removes the subscription.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct));
     }
 }

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
@@ -81,6 +81,29 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     }
 
     [Fact]
+    public async Task SubscribeToGrainCalls_global_receives_events()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // Use global overload, but filter to our grain to avoid cross-test noise
+        var collectTask = fixture.Collector
+            .SubscribeToGrainCalls(ct)
+            .Where(ctx => ctx.TargetId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
+        await grain.SetValueAsync("global-test");
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.Single(collected);
+        Assert.Equal(grainId, collected[0].TargetId);
+    }
+
+    [Fact]
     public async Task SubscribeToGrainCalls_cancellation_removes_subscription()
     {
         var ct = TestContext.Current.CancellationToken;

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
@@ -1,0 +1,145 @@
+namespace Egil.Orleans.Testing.Tests;
+
+public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture fixture)
+{
+    [Fact]
+    public async Task SubscribeToGrainCalls_receives_grain_calls()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected = new List<IIncomingGrainCallContext>();
+
+        // Use grain-scoped feed to avoid collecting unrelated system grain calls from the shared cluster
+        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToGrainCalls(grain, cts.Token), collected, count: 1, cts);
+
+        await grain.SetValueAsync("hello");
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        Assert.NotEmpty(collected);
+        Assert.All(collected, ctx => Assert.Equal(grain.GetGrainId(), ctx.TargetId));
+        Assert.Contains(collected, ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync));
+    }
+
+    [Fact]
+    public async Task SubscribeToGrainCalls_grain_scoped_ignores_unrelated_grains()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var target = fixture.GetUniqueGrain<ITestStateGrain>();
+        var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected = new List<IIncomingGrainCallContext>();
+        var feedTask = CollectFeedAsync(
+            fixture.Collector.SubscribeToGrainCalls(target, cts.Token),
+            collected, count: 1, cts);
+
+        // Generate noise from another grain first
+        await other.SetValueAsync("noise");
+
+        // Now trigger the target
+        await target.SetValueAsync("signal");
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        Assert.All(collected, ctx => Assert.Equal(target.GetGrainId(), ctx.TargetId));
+    }
+
+    [Fact]
+    public async Task SubscribeToGrainCalls_is_future_only()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+
+        // Trigger a call BEFORE subscribing
+        await grain.SetValueAsync("before-subscribe");
+
+        // Wait to ensure the call is fully processed
+        await Task.Delay(100, ct);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var collected = new List<IIncomingGrainCallContext>();
+        var feedTask = CollectFeedAsync(
+            fixture.Collector.SubscribeToGrainCalls(grain, cts.Token),
+            collected, count: 1, cts);
+
+        // Now trigger a new call
+        await grain.GetValueAsync();
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        // Only the post-subscribe call should appear
+        Assert.All(collected, ctx =>
+        {
+            Assert.Equal(grain.GetGrainId(), ctx.TargetId);
+            Assert.Equal(nameof(ITestStateGrain.GetValueAsync), ctx.MethodName);
+        });
+    }
+
+    [Fact]
+    public async Task SubscribeToGrainCalls_cancellation_removes_subscription()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var collected = new List<IIncomingGrainCallContext>();
+        var feedTask = CollectAllAsync(fixture.Collector.SubscribeToGrainCalls(cts.Token), collected);
+
+        // Cancel to stop the feed
+        await cts.CancelAsync();
+
+        // The feed task should complete (possibly with OperationCanceledException)
+        await IgnoreCancellationAsync(feedTask);
+
+        // After cancellation, a new call should not appear in the old collected list
+        var countAfterCancel = collected.Count;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        await grain.SetValueAsync("after-cancel");
+        await Task.Delay(200, ct);
+
+        Assert.Equal(countAfterCancel, collected.Count);
+    }
+
+    private static async Task CollectFeedAsync<T>(
+        IAsyncEnumerable<T> feed,
+        List<T> target,
+        int count,
+        CancellationTokenSource cts)
+    {
+        await foreach (var item in feed)
+        {
+            target.Add(item);
+            if (target.Count >= count)
+            {
+                await cts.CancelAsync();
+            }
+        }
+    }
+
+    private static async Task CollectAllAsync<T>(IAsyncEnumerable<T> feed, List<T> target)
+    {
+        await foreach (var item in feed)
+        {
+            target.Add(item);
+        }
+    }
+
+    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationToken ct)
+    {
+        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout, ct));
+        await IgnoreCancellationAsync(feedTask);
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+    }
+}

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
@@ -16,7 +16,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
 
         await grain.SetValueAsync("hello");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
         Assert.NotEmpty(collected);
         Assert.All(collected, ctx => Assert.Equal(grain.GetGrainId(), ctx.TargetId));
@@ -42,7 +42,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         // Now trigger the target
         await target.SetValueAsync("signal");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
         Assert.All(collected, ctx => Assert.Equal(target.GetGrainId(), ctx.TargetId));
     }
@@ -56,8 +56,11 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         // Trigger a call BEFORE subscribing
         await grain.SetValueAsync("before-subscribe");
 
-        // Wait to ensure the call is fully processed
-        await Task.Delay(100, ct);
+        // Deterministically wait for the pre-subscribe call to be observed
+        await fixture.Collector.WaitForGrainCallAsync(
+            grain,
+            ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync),
+            ct: ct);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var collected = new List<IIncomingGrainCallContext>();
@@ -68,7 +71,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         // Now trigger a new call
         await grain.GetValueAsync();
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
         // Only the post-subscribe call should appear
         Assert.All(collected, ctx =>
@@ -92,11 +95,15 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         // The feed task should complete (possibly with OperationCanceledException)
         await IgnoreCancellationAsync(feedTask);
 
-        // After cancellation, a new call should not appear in the old collected list
+        // After cancellation, trigger a call and deterministically wait for it
+        // to be processed by the collector, then verify the old list is unchanged.
         var countAfterCancel = collected.Count;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
         await grain.SetValueAsync("after-cancel");
-        await Task.Delay(200, ct);
+        await fixture.Collector.WaitForGrainCallAsync(
+            grain,
+            ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync),
+            ct: ct);
 
         Assert.Equal(countAfterCancel, collected.Count);
     }
@@ -125,9 +132,14 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         }
     }
 
-    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationToken ct)
+    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationTokenSource cts)
     {
-        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout, ct));
+        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout));
+        if (!ReferenceEquals(completed, feedTask))
+        {
+            await cts.CancelAsync();
+        }
+
         await IgnoreCancellationAsync(feedTask);
     }
 

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
@@ -1,0 +1,204 @@
+namespace Egil.Orleans.Testing.Tests;
+
+public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fixture)
+{
+    [Fact]
+    public async Task SubscribeToStorageOperations_receives_write_read_clear()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected = new List<StorageOperation>();
+        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected, count: 3, cts);
+
+        // Read is triggered on first access, write on SetValueAsync, clear is not directly
+        // exposed on ITestStateGrain — so we test write + read via initial activation (read)
+        // and an explicit write.
+        await grain.SetValueAsync("hello");
+        await grain.GetValueAsync();
+
+        // SetValueAsync triggers: read (activation) + write (SetValueAsync) + read (GetValueAsync reuses cached state)
+        // But activation may include reads. Let's just wait for enough operations.
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        Assert.True(collected.Count >= 3, $"Expected at least 3 operations, got {collected.Count}");
+        Assert.Contains(collected, op => op.Kind == StorageOperationKind.Write);
+        Assert.Contains(collected, op => op.Kind == StorageOperationKind.Read);
+    }
+
+    [Fact]
+    public async Task SubscribeToStorageOperations_grain_scoped_ignores_unrelated_grains()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var target = fixture.GetUniqueGrain<ITestStateGrain>();
+        var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected = new List<StorageOperation>();
+        var feedTask = CollectFeedAsync(
+            fixture.Collector.SubscribeToStorageOperations(target, cts.Token),
+            collected, count: 1, cts);
+
+        // Generate noise from another grain first
+        await other.SetValueAsync("noise");
+
+        // Now trigger the target
+        await target.SetValueAsync("signal");
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        Assert.All(collected, op => Assert.Equal(target.GetGrainId(), op.GrainId));
+    }
+
+    [Fact]
+    public async Task SubscribeToStorageOperations_is_future_only()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+
+        // Trigger a write BEFORE subscribing
+        await grain.SetValueAsync("before-subscribe");
+
+        // Wait a moment to ensure the operation is fully processed
+        await Task.Delay(100, ct);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var collected = new List<StorageOperation>();
+        var feedTask = CollectFeedAsync(
+            fixture.Collector.SubscribeToStorageOperations(grain, cts.Token),
+            collected, count: 1, cts);
+
+        // Now trigger a new write
+        await grain.SetValueAsync("after-subscribe");
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+
+        // Only the post-subscribe write should appear
+        Assert.All(collected, op =>
+        {
+            Assert.Equal(grain.GetGrainId(), op.GrainId);
+            Assert.Equal(StorageOperationKind.Write, op.Kind);
+        });
+    }
+
+    [Fact]
+    public async Task SubscribeToStorageOperations_lossless_beyond_bounded_channel_capacity()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        const int operationCount = 300; // Exceeds the 256 bounded channel capacity
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected = new List<StorageOperation>();
+
+        // Subscribe to writes only for the target grain
+        var feedTask = CollectFeedAsync(
+            fixture.Collector.SubscribeToStorageOperations(grain, cts.Token),
+            collected, count: operationCount, cts,
+            filter: op => op.Kind == StorageOperationKind.Write);
+
+        for (var i = 0; i < operationCount; i++)
+        {
+            await grain.IncrementAsync();
+        }
+
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(30), ct);
+
+        Assert.Equal(operationCount, collected.Count);
+        Assert.All(collected, op => Assert.Equal(StorageOperationKind.Write, op.Kind));
+    }
+
+    [Fact]
+    public async Task SubscribeToStorageOperations_cancellation_removes_subscription()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var collected = new List<StorageOperation>();
+        var feedTask = CollectAllAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected);
+
+        // Cancel to stop the feed
+        await cts.CancelAsync();
+
+        // The feed task should complete (possibly with OperationCanceledException)
+        await IgnoreCancellationAsync(feedTask);
+
+        // After cancellation, a new write should not appear in the old collected list
+        var countAfterCancel = collected.Count;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        await grain.SetValueAsync("after-cancel");
+        await Task.Delay(200, ct);
+
+        Assert.Equal(countAfterCancel, collected.Count);
+    }
+
+    [Fact]
+    public async Task SubscribeToStorageOperations_multiple_concurrent_subscribers()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        using var cts1 = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var cts2 = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collected1 = new List<StorageOperation>();
+        var collected2 = new List<StorageOperation>();
+        var feed1 = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(grain, cts1.Token), collected1, count: 1, cts1);
+        var feed2 = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(grain, cts2.Token), collected2, count: 1, cts2);
+
+        await grain.SetValueAsync("shared-event");
+
+        await WaitForCollectedAsync(feed1, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feed2, timeout: TimeSpan.FromSeconds(5), ct);
+
+        Assert.NotEmpty(collected1);
+        Assert.NotEmpty(collected2);
+    }
+
+    private static async Task CollectFeedAsync<T>(
+        IAsyncEnumerable<T> feed,
+        List<T> target,
+        int count,
+        CancellationTokenSource cts,
+        Func<T, bool>? filter = null)
+    {
+        await foreach (var item in feed)
+        {
+            if (filter is not null && !filter(item))
+            {
+                continue;
+            }
+
+            target.Add(item);
+            if (target.Count >= count)
+            {
+                await cts.CancelAsync();
+            }
+        }
+    }
+
+    private static async Task CollectAllAsync<T>(IAsyncEnumerable<T> feed, List<T> target)
+    {
+        await foreach (var item in feed)
+        {
+            target.Add(item);
+        }
+    }
+
+    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationToken ct)
+    {
+        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout, ct));
+        await IgnoreCancellationAsync(feedTask);
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+    }
+}

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
@@ -3,26 +3,21 @@ namespace Egil.Orleans.Testing.Tests;
 public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fixture)
 {
     [Fact]
-    public async Task SubscribeToStorageOperations_receives_write_read_clear()
+    public async Task SubscribeToStorageOperations_receives_write_and_read()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var collected = new List<StorageOperation>();
-        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected, count: 3, cts);
+        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected, count: 2, cts);
 
-        // Read is triggered on first access, write on SetValueAsync, clear is not directly
-        // exposed on ITestStateGrain — so we test write + read via initial activation (read)
-        // and an explicit write.
         await grain.SetValueAsync("hello");
         await grain.GetValueAsync();
 
-        // SetValueAsync triggers: read (activation) + write (SetValueAsync) + read (GetValueAsync reuses cached state)
-        // But activation may include reads. Let's just wait for enough operations.
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
-        Assert.True(collected.Count >= 3, $"Expected at least 3 operations, got {collected.Count}");
+        Assert.True(collected.Count >= 2, $"Expected at least 2 operations, got {collected.Count}");
         Assert.Contains(collected, op => op.Kind == StorageOperationKind.Write);
         Assert.Contains(collected, op => op.Kind == StorageOperationKind.Read);
     }
@@ -46,7 +41,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         // Now trigger the target
         await target.SetValueAsync("signal");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
         Assert.All(collected, op => Assert.Equal(target.GetGrainId(), op.GrainId));
     }
@@ -60,8 +55,11 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         // Trigger a write BEFORE subscribing
         await grain.SetValueAsync("before-subscribe");
 
-        // Wait a moment to ensure the operation is fully processed
-        await Task.Delay(100, ct);
+        // Deterministically wait for that write to be observed by the collector
+        await fixture.Collector.WaitForStorageOperationAsync(
+            grain,
+            op => op.Kind == StorageOperationKind.Write,
+            ct: ct);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var collected = new List<StorageOperation>();
@@ -72,7 +70,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         // Now trigger a new write
         await grain.SetValueAsync("after-subscribe");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
 
         // Only the post-subscribe write should appear
         Assert.All(collected, op =>
@@ -83,11 +81,11 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_lossless_beyond_bounded_channel_capacity()
+    public async Task SubscribeToStorageOperations_collects_many_sequential_writes()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        const int operationCount = 300; // Exceeds the 256 bounded channel capacity
+        const int operationCount = 50;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var collected = new List<StorageOperation>();
@@ -103,7 +101,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
             await grain.IncrementAsync();
         }
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(30), ct);
+        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(30), cts);
 
         Assert.Equal(operationCount, collected.Count);
         Assert.All(collected, op => Assert.Equal(StorageOperationKind.Write, op.Kind));
@@ -123,11 +121,15 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         // The feed task should complete (possibly with OperationCanceledException)
         await IgnoreCancellationAsync(feedTask);
 
-        // After cancellation, a new write should not appear in the old collected list
+        // After cancellation, trigger a write and deterministically wait for it
+        // to be processed by the collector, then verify the old list is unchanged.
         var countAfterCancel = collected.Count;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
         await grain.SetValueAsync("after-cancel");
-        await Task.Delay(200, ct);
+        await fixture.Collector.WaitForStorageOperationAsync(
+            grain,
+            op => op.Kind == StorageOperationKind.Write,
+            ct: ct);
 
         Assert.Equal(countAfterCancel, collected.Count);
     }
@@ -147,8 +149,8 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
 
         await grain.SetValueAsync("shared-event");
 
-        await WaitForCollectedAsync(feed1, timeout: TimeSpan.FromSeconds(5), ct);
-        await WaitForCollectedAsync(feed2, timeout: TimeSpan.FromSeconds(5), ct);
+        await WaitForCollectedAsync(feed1, timeout: TimeSpan.FromSeconds(5), cts1);
+        await WaitForCollectedAsync(feed2, timeout: TimeSpan.FromSeconds(5), cts2);
 
         Assert.NotEmpty(collected1);
         Assert.NotEmpty(collected2);
@@ -184,9 +186,14 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         }
     }
 
-    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationToken ct)
+    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationTokenSource cts)
     {
-        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout, ct));
+        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout));
+        if (!ReferenceEquals(completed, feedTask))
+        {
+            await cts.CancelAsync();
+        }
+
         await IgnoreCancellationAsync(feedTask);
     }
 
@@ -202,3 +209,4 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         }
     }
 }
+

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
@@ -124,6 +124,29 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
+    public async Task SubscribeToStorageOperations_global_receives_events()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // Use global overload, but filter to our grain to avoid cross-test noise
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(ct)
+            .Where(op => op.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
+        await grain.SetValueAsync("global-test");
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.Single(collected);
+        Assert.Equal(grainId, collected[0].GrainId);
+    }
+
+    [Fact]
     public async Task SubscribeToStorageOperations_multiple_concurrent_subscribers()
     {
         var ct = TestContext.Current.CancellationToken;

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
@@ -7,17 +7,18 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var collected = new List<StorageOperation>();
-        var feedTask = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected, count: 2, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Take(2)
+            .ToListAsync(ct)
+            .AsTask();
 
         await grain.SetValueAsync("hello");
         await grain.GetValueAsync();
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
-        Assert.True(collected.Count >= 2, $"Expected at least 2 operations, got {collected.Count}");
         Assert.Contains(collected, op => op.Kind == StorageOperationKind.Write);
         Assert.Contains(collected, op => op.Kind == StorageOperationKind.Read);
     }
@@ -28,12 +29,12 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         var ct = TestContext.Current.CancellationToken;
         var target = fixture.GetUniqueGrain<ITestStateGrain>();
         var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var collected = new List<StorageOperation>();
-        var feedTask = CollectFeedAsync(
-            fixture.Collector.SubscribeToStorageOperations(target, cts.Token),
-            collected, count: 1, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(target, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         // Generate noise from another grain first
         await other.SetValueAsync("noise");
@@ -41,7 +42,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         // Now trigger the target
         await target.SetValueAsync("signal");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         Assert.All(collected, op => Assert.Equal(target.GetGrainId(), op.GrainId));
     }
@@ -61,23 +62,22 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
             op => op.Kind == StorageOperationKind.Write,
             ct: ct);
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var collected = new List<StorageOperation>();
-        var feedTask = CollectFeedAsync(
-            fixture.Collector.SubscribeToStorageOperations(grain, cts.Token),
-            collected, count: 1, cts);
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         // Now trigger a new write
         await grain.SetValueAsync("after-subscribe");
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(5), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         // Only the post-subscribe write should appear
-        Assert.All(collected, op =>
-        {
-            Assert.Equal(grain.GetGrainId(), op.GrainId);
-            Assert.Equal(StorageOperationKind.Write, op.Kind);
-        });
+        Assert.Single(collected);
+        Assert.Equal(grain.GetGrainId(), collected[0].GrainId);
+        Assert.Equal(StorageOperationKind.Write, collected[0].Kind);
     }
 
     [Fact]
@@ -86,22 +86,20 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
         const int operationCount = 50;
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var collected = new List<StorageOperation>();
-
-        // Subscribe to writes only for the target grain
-        var feedTask = CollectFeedAsync(
-            fixture.Collector.SubscribeToStorageOperations(grain, cts.Token),
-            collected, count: operationCount, cts,
-            filter: op => op.Kind == StorageOperationKind.Write);
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(operationCount)
+            .ToListAsync(ct)
+            .AsTask();
 
         for (var i = 0; i < operationCount; i++)
         {
             await grain.IncrementAsync();
         }
 
-        await WaitForCollectedAsync(feedTask, timeout: TimeSpan.FromSeconds(30), cts);
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
         Assert.Equal(operationCount, collected.Count);
         Assert.All(collected, op => Assert.Equal(StorageOperationKind.Write, op.Kind));
@@ -112,26 +110,17 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     {
         var ct = TestContext.Current.CancellationToken;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var collected = new List<StorageOperation>();
-        var feedTask = CollectAllAsync(fixture.Collector.SubscribeToStorageOperations(cts.Token), collected);
 
-        // Cancel to stop the feed
+        var collectTask = fixture.Collector
+            .SubscribeToStorageOperations(cts.Token)
+            .ToListAsync(ct)
+            .AsTask();
+
         await cts.CancelAsync();
 
-        // The feed task should complete (possibly with OperationCanceledException)
-        await IgnoreCancellationAsync(feedTask);
-
-        // After cancellation, trigger a write and deterministically wait for it
-        // to be processed by the collector, then verify the old list is unchanged.
-        var countAfterCancel = collected.Count;
-        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        await grain.SetValueAsync("after-cancel");
-        await fixture.Collector.WaitForStorageOperationAsync(
-            grain,
-            op => op.Kind == StorageOperationKind.Write,
-            ct: ct);
-
-        Assert.Equal(countAfterCancel, collected.Count);
+        // Feed completes promptly after cancellation; the finally block removes the subscription.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct));
     }
 
     [Fact]
@@ -139,74 +128,26 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
-        using var cts1 = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        using var cts2 = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var collected1 = new List<StorageOperation>();
-        var collected2 = new List<StorageOperation>();
-        var feed1 = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(grain, cts1.Token), collected1, count: 1, cts1);
-        var feed2 = CollectFeedAsync(fixture.Collector.SubscribeToStorageOperations(grain, cts2.Token), collected2, count: 1, cts2);
+        var feed1 = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
+        var feed2 = fixture.Collector
+            .SubscribeToStorageOperations(grain, ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await grain.SetValueAsync("shared-event");
 
-        await WaitForCollectedAsync(feed1, timeout: TimeSpan.FromSeconds(5), cts1);
-        await WaitForCollectedAsync(feed2, timeout: TimeSpan.FromSeconds(5), cts2);
+        var collected1 = await feed1.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        var collected2 = await feed2.WaitAsync(TimeSpan.FromSeconds(5), ct);
 
         Assert.NotEmpty(collected1);
         Assert.NotEmpty(collected2);
-    }
-
-    private static async Task CollectFeedAsync<T>(
-        IAsyncEnumerable<T> feed,
-        List<T> target,
-        int count,
-        CancellationTokenSource cts,
-        Func<T, bool>? filter = null)
-    {
-        await foreach (var item in feed)
-        {
-            if (filter is not null && !filter(item))
-            {
-                continue;
-            }
-
-            target.Add(item);
-            if (target.Count >= count)
-            {
-                await cts.CancelAsync();
-            }
-        }
-    }
-
-    private static async Task CollectAllAsync<T>(IAsyncEnumerable<T> feed, List<T> target)
-    {
-        await foreach (var item in feed)
-        {
-            target.Add(item);
-        }
-    }
-
-    private static async Task WaitForCollectedAsync(Task feedTask, TimeSpan timeout, CancellationTokenSource cts)
-    {
-        var completed = await Task.WhenAny(feedTask, Task.Delay(timeout));
-        if (!ReferenceEquals(completed, feedTask))
-        {
-            await cts.CancelAsync();
-        }
-
-        await IgnoreCancellationAsync(feedTask);
-    }
-
-    private static async Task IgnoreCancellationAsync(Task task)
-    {
-        try
-        {
-            await task;
-        }
-        catch (OperationCanceledException)
-        {
-            // expected
-        }
     }
 }
 


### PR DESCRIPTION
Add `SubscribeToStorageOperations` and `SubscribeToGrainCalls` methods to `GrainActivityCollector` that return `IAsyncEnumerable<T>` for lossless, future-only event collection.

## What changed

**`GrainActivityCollector.cs`** — four new public methods:
- `SubscribeToStorageOperations(ct)` / `SubscribeToStorageOperations<TGrain>(grain, ct)` → `IAsyncEnumerable<StorageOperation>`
- `SubscribeToGrainCalls(ct)` / `SubscribeToGrainCalls<TGrain>(grain, ct)` → `IAsyncEnumerable<IIncomingGrainCallContext>`

Each feed uses unbounded channels so slow consumers never lose events, while the existing bounded wait-subscriber path stays unchanged. Subscription starts on first `MoveNextAsync` and ends on cancellation or break.

**Key semantics:**
- Future-only — no replay of past events
- Lossless — unbounded channel buffering
- Clean unsubscribe — `finally` block removes subscriber on cancellation/break
- Assertion-scope suppression — `RequestContextScope.ForAssertion()` still prevents self-triggered events

## Tests

10 new tests across two files:
- `GrainActivityCollectorStorageFeedTests.cs` — write/read/clear, grain-scoped filtering, future-only, lossless >256, cancellation, concurrent subscribers
- `GrainActivityCollectorGrainCallFeedTests.cs` — grain call feed, grain-scoped, future-only, cancellation

All 89 tests pass (77 existing + 10 new feed tests + 2 sample tests).

## Docs

- New standalone doc page: `docs/recipes/operation-feeds.md`
- New sample: `samples/.../OperationFeedSample.cs`
- Updated `docs/recipes/README.md` with links