### PR TITLE
feat(ot)!: replace WaitFor*/SubscribeTo* with IAsyncEnumerable Get*Async API

### DIFF
--- a/Egil.Orleans.Testing/AGENTS.md
+++ b/Egil.Orleans.Testing/AGENTS.md
@@ -26,7 +26,7 @@ Use the solution file from repository root:
 - Use `var` when the type is obvious; keep naming in PascalCase for types/methods.
 - Interfaces use `I*` naming.
 - All public types and methods must have full XML documentation comments (`<summary>`, `<param>`, `<returns>`, `<exception>` as applicable).
-- Advanced methods that expose implementation details (e.g., `WaitForStorageOperationAsync`, `WaitForGrainCallAsync`) must include a `<remarks>` section warning about tight coupling to production code internals.
+- Advanced methods that expose implementation details (e.g., `GetStorageOperationsAsync`, `GetGrainCallsAsync`) must include a `<remarks>` section warning about tight coupling to production code internals.
 
 ## Testing Guidelines
 - Test framework: `xunit.v3.mtp-v2` on Microsoft Testing Platform, with `Microsoft.Testing.Extensions.CodeCoverage` for coverage collection.

--- a/Egil.Orleans.Testing/PLAN.md
+++ b/Egil.Orleans.Testing/PLAN.md
@@ -96,29 +96,24 @@ public sealed class GrainActivityCollector
         where TGrain : IGrain;
 
     // ══════════════════════════════════════════════════════════════
-    // Advanced — wait for a specific storage operation
+    // IAsyncEnumerable feeds — collect events with LINQ composition
     // ══════════════════════════════════════════════════════════════
 
-    public Task WaitForStorageOperationAsync(
-        Func<StorageOperation, bool> predicate,
-        TimeSpan? timeout = null, CancellationToken ct = default);
+    public IAsyncEnumerable<GrainActivity> GetGrainActivityAsync(
+        bool includeExisting = false, CancellationToken cancellationToken = default);
 
-    public Task WaitForStorageOperationAsync<TGrain>(
-        TGrain grain, Func<StorageOperation, bool> predicate,
-        TimeSpan? timeout = null, CancellationToken ct = default)
+    public IAsyncEnumerable<StorageOperation> GetStorageOperationsAsync(
+        bool includeExisting = false, CancellationToken cancellationToken = default);
+
+    public IAsyncEnumerable<StorageOperation> GetStorageOperationsAsync<TGrain>(
+        TGrain grain, bool includeExisting = false, CancellationToken cancellationToken = default)
         where TGrain : IGrain;
 
-    // ══════════════════════════════════════════════════════════════
-    // Advanced — wait for a specific grain call
-    // ══════════════════════════════════════════════════════════════
+    public IAsyncEnumerable<IIncomingGrainCallContext> GetGrainCallsAsync(
+        bool includeExisting = false, CancellationToken cancellationToken = default);
 
-    public Task WaitForGrainCallAsync(
-        Func<IIncomingGrainCallContext, bool> predicate,
-        TimeSpan? timeout = null, CancellationToken ct = default);
-
-    public Task WaitForGrainCallAsync<TGrain>(
-        TGrain grain, Func<IIncomingGrainCallContext, bool> predicate,
-        TimeSpan? timeout = null, CancellationToken ct = default)
+    public IAsyncEnumerable<IIncomingGrainCallContext> GetGrainCallsAsync<TGrain>(
+        TGrain grain, bool includeExisting = false, CancellationToken cancellationToken = default)
         where TGrain : IGrain;
 }
 ```
@@ -136,7 +131,7 @@ public sealed class GrainActivityCollector
 | **Provider interface** | None — `GrainActivityCollector` is a concrete class, fixtures expose it directly |
 | **Visibility: GrainCallCollectionFilter** | **Internal** — exposed via builder registration only |
 | **Visibility: StorageObserver** | **Internal** — exposed via builder registration only |
-| **Visibility: StorageOperation** | **Public** — used in advanced `WaitForStorageOperationAsync` methods |
+| **Visibility: StorageOperation** | **Public** — used in `GetStorageOperationsAsync` feed methods |
 | **Visibility: GrainActivity / GrainActivityKind** | **Public** — lean event type for the standard wait methods |
 | **Visibility: channels** | **Internal** — users never subscribe manually |
 | **Id-type overloads** | Dropped — callers resolve grains themselves |
@@ -168,9 +163,9 @@ All public types and methods must have thorough XML doc comments:
 - Same as above, plus explain that only activity from the specified grain triggers retries.
 - For the `Func<TGrain, ...>` overloads, note that the grain reference is passed to the lambda for convenience.
 
-### Advanced methods (`WaitForStorageOperationAsync`, `WaitForGrainCallAsync`)
+### Feed methods (`GetStorageOperationsAsync`, `GetGrainCallsAsync`, `GetGrainActivityAsync`)
 
-- `<summary>` — explain that these wait for a specific event matching the predicate rather than retrying a general assertion.
+- `<summary>` — explain that these return IAsyncEnumerable feeds that can be composed with LINQ operators.
 - `<remarks>` — **must include a coupling warning**:
   > ⚠️ **Coupling risk:** This method inspects low-level implementation details of your grain
   > (storage operations / incoming call context). Tests using this method are tightly coupled
@@ -354,18 +349,19 @@ All public methods must have thorough XML doc comments — see **XML documentati
   - XML docs: `<summary>` explaining retry-on-activity, `<param>` for each param, `<exception>`, `<example>`
 - 4 grain-scoped `WaitForAssertionAsync` (2 without grain in lambda + 2 with grain in lambda)
   - XML docs: same as above, plus explain grain-scoping behavior
-- 2 advanced `WaitForStorageOperationAsync` (non-grain-scoped + grain-scoped)
-  - XML docs: `<summary>`, `<param>`, `<exception>`, plus `<remarks>` with **coupling warning** (see guidelines)
-- 2 advanced `WaitForGrainCallAsync` (non-grain-scoped + grain-scoped)
-  - XML docs: `<summary>`, `<param>`, `<exception>`, plus `<remarks>` with **coupling warning** (see guidelines)
+- 2 `GetStorageOperationsAsync` (global + grain-scoped) → `IAsyncEnumerable<StorageOperation>`
+  - XML docs: `<summary>`, `<param>`, plus `<remarks>` with **coupling warning** (see guidelines)
+- 2 `GetGrainCallsAsync` (global + grain-scoped) → `IAsyncEnumerable<IIncomingGrainCallContext>`
+  - XML docs: `<summary>`, `<param>`, plus `<remarks>` with **coupling warning** (see guidelines)
+- 1 `GetGrainActivityAsync` → `IAsyncEnumerable<GrainActivity>` (core stream)
 
 Each method follows the same pattern:
-1. Subscribe to the appropriate internal channel
-2. Pre-flight check (run assertion/predicate immediately)
+1. Subscribe to the unified internal channel
+2. Pre-flight check (run assertion/predicate immediately) for assertion methods
 3. On each channel event, retry assertion/predicate
 4. Wrap assertion in `RequestContextScope.ForAssertion()` (for assertion methods)
 5. On timeout → throw `WaitForAssertionTimeoutException` with last failure
-6. Unsubscribe on completion/timeout
+6. Unsubscribe on completion/timeout/cancellation
 
 ### implement-internal-sources — Implement internal event sources
 
@@ -426,8 +422,8 @@ public class GrainActivityCollectorBuilder
   - Standard `WaitForAssertionAsync` triggered by grain call
   - Standard `WaitForAssertionAsync` triggered by storage write
   - Grain-scoped `WaitForAssertionAsync` with grain passed to lambda
-  - Advanced `WaitForStorageOperationAsync` with predicate
-  - Advanced `WaitForGrainCallAsync` with predicate
+  - Advanced `GetStorageOperationsAsync` feed with LINQ composition
+  - Advanced `GetGrainCallsAsync` feed with LINQ composition
   - Timeout behavior (expect `WaitForAssertionTimeoutException`)
   - Value-returning assertions
   - Mixed signals (both call + storage active)

--- a/Egil.Orleans.Testing/README.md
+++ b/Egil.Orleans.Testing/README.md
@@ -349,7 +349,7 @@ In xUnit, see the official docs for fixture registration options:
 
 - **Grain-scoped assertions** — pass a grain reference to restrict retriggers to that grain only. This is the best default when one grain owns the state you are asserting.
 - **Standard assertions** — `WaitForAssertionAsync` without a grain scope retries on any detected grain activity (calls or storage operations). Useful when multiple grains contribute to the observed outcome.
-- **Advanced assertions** — `WaitForStorageOperationAsync` and `WaitForGrainCallAsync` wait for events matching a predicate. Use sparingly — these couple tests to implementation details.
+- **IAsyncEnumerable feeds** — `GetStorageOperationsAsync` and `GetGrainCallsAsync` return `IAsyncEnumerable<T>` feeds that can be composed with LINQ operators such as `Where`, `Take`, and `Select` for fine-grained event observation. Use `includeExisting: true` to replay recent history.
 - **Configurable timeout** — defaults to 5 seconds, overridable per call or via the `WAIT_FOR_ASSERTION_TIMEOUT_SECONDS` environment variable. Timeout is automatically bypassed when a debugger is attached.
 - **Test-framework-agnostic** — no runtime dependency on any test framework.
 

--- a/Egil.Orleans.Testing/docs/recipes/README.md
+++ b/Egil.Orleans.Testing/docs/recipes/README.md
@@ -13,8 +13,8 @@ All code samples are extracted from the [samples project](../../samples/Egil.Orl
 
 ## Advanced assertions
 
-- [Waiting for a specific storage operation](advanced-assertions.md#waiting-for-a-specific-storage-operation)
-- [Waiting for a specific grain call](advanced-assertions.md#waiting-for-a-specific-grain-call)
+- [Collecting storage operations](advanced-assertions.md#collecting-storage-operations)
+- [Collecting grain calls](advanced-assertions.md#collecting-grain-calls)
 - [When to prefer advanced over standard assertions](advanced-assertions.md#when-to-prefer-advanced-over-standard-assertions)
 
 ## Timers and reminders
@@ -31,5 +31,5 @@ All code samples are extracted from the [samples project](../../samples/Egil.Orl
 ## Operation feeds
 
 - [When to use operation feeds](operation-feeds.md#when-to-use-operation-feeds)
-- [Subscribing to storage operations](operation-feeds.md#subscribing-to-storage-operations)
-- [Subscribing to grain calls](operation-feeds.md#subscribing-to-grain-calls)
+- [Collecting storage operations](operation-feeds.md#collecting-storage-operations)
+- [Collecting grain calls](operation-feeds.md#collecting-grain-calls)

--- a/Egil.Orleans.Testing/docs/recipes/advanced-assertions.md
+++ b/Egil.Orleans.Testing/docs/recipes/advanced-assertions.md
@@ -2,15 +2,16 @@
 
 ## When to prefer advanced over standard assertions
 
-The standard `WaitForAssertionAsync` overloads assert against observable grain behavior — the *what*. The advanced methods (`WaitForStorageOperationAsync`, `WaitForGrainCallAsync`) inspect low-level storage operations and incoming call contexts — the *how*.
+The standard `WaitForAssertionAsync` overloads assert against observable grain behavior — the *what*. The advanced methods (`GetStorageOperationsAsync`, `GetGrainCallsAsync`) collect low-level storage operations and incoming call contexts as `IAsyncEnumerable<T>` feeds — the *how*.
 
 > ⚠️ **Coupling risk:** Tests using the advanced methods are tightly coupled to implementation details. If the grain's internal implementation changes (e.g., switching storage providers, renaming internal methods), these tests may break even if the grain's external contract is unchanged.
 
 Use the advanced methods when:
 - You need to assert that a specific write happened with specific data (e.g., ETag, state snapshot).
 - You need to assert that a specific grain-to-grain call occurred without being able to observe its side effects externally.
+- You need to collect and inspect a specific **number** of events (e.g., `.Take(N)`).
 
-## Waiting for a specific storage operation
+## Collecting storage operations
 
 Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
@@ -18,32 +19,39 @@ Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclus
 <a id='snippet-advanced_storage_assertion'></a>
 ```cs
 /// <summary>
-/// Demonstrates advanced wait methods that inspect storage operations directly.
+/// Demonstrates using <c>GetStorageOperationsAsync</c> to collect and inspect storage operations directly.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>WaitForStorageOperationAsync</c> couples your test to implementation details.
+/// ⚠️ <c>GetStorageOperationsAsync</c> couples your test to implementation details.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
 public sealed class WarehouseStorageOperationTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
 {
     [Fact]
-    public async Task WaitForStorageOperationAsync_waits_for_write_from_oneway_call()
+    public async Task GetStorageOperationsAsync_collects_write_from_oneway_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+
+        // Start collecting BEFORE triggering the action.
+        // Use Take(1) to automatically stop after the first matching write.
+        var collectTask = fixture.Collector
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("widget", 10);
 
-        // Assert after triggering the action. The collector remembers recent
-        // storage activity, so this also works when the write already happened.
-        await fixture.Collector.WaitForStorageOperationAsync(
-            op => op.Kind == StorageOperationKind.Write && op.GrainId == grain.GetGrainId(),
-            ct: TestContext.Current.CancellationToken);
+        var writes = await collectTask;
 
+        Assert.Single(writes);
+        Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
         Assert.Equal(10, await grain.GetReservedAsync("widget"));
     }
 }
 ```
-<sup><a href='/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs#L84-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-advanced_storage_assertion' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs#L84-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-advanced_storage_assertion' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `StorageOperation` record exposes:
@@ -54,7 +62,7 @@ The `StorageOperation` record exposes:
 - `ETag` — the ETag after the operation
 - `State` — the state value as `object?`
 
-## Waiting for a specific grain call
+## Collecting grain calls
 
 Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
@@ -62,31 +70,38 @@ Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclus
 <a id='snippet-advanced_grain_call_assertion'></a>
 ```cs
 /// <summary>
-/// Demonstrates advanced wait methods that inspect incoming grain calls directly.
+/// Demonstrates using <c>GetGrainCallsAsync</c> to collect and inspect incoming grain calls directly.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>WaitForGrainCallAsync</c> couples your test to implementation details.
+/// ⚠️ <c>GetGrainCallsAsync</c> couples your test to implementation details.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
 public sealed class WarehouseGrainCallTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
 {
     [Fact]
-    public async Task WaitForGrainCallAsync_waits_for_internal_grain_to_grain_call()
+    public async Task GetGrainCallsAsync_collects_internal_grain_to_grain_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-
-        await grain.ReserveAsync("gadget", 5);
 
         // The warehouse grain internally calls ILedgerGrain.AddReservationAsync,
         // which is a grain-to-grain call invisible to the original test caller.
-        // The collector keeps recent calls, so you can wait after triggering the action too.
-        await fixture.Collector.WaitForGrainCallAsync(
-            ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync),
-            ct: TestContext.Current.CancellationToken);
+        // Use Take(1) to automatically stop after the first matching call.
+        var collectTask = fixture.Collector
+            .GetGrainCallsAsync(cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+            .Take(1)
+            .ToListAsync(ct);
+
+        await grain.ReserveAsync("gadget", 5);
+
+        var calls = await collectTask;
+
+        Assert.Single(calls);
     }
 }
 ```
-<sup><a href='/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs#L112-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-advanced_grain_call_assertion' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs#L120-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-advanced_grain_call_assertion' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `IIncomingGrainCallContext` exposes:

--- a/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
+++ b/Egil.Orleans.Testing/docs/recipes/operation-feeds.md
@@ -2,7 +2,7 @@
 
 ## When to use operation feeds
 
-The `SubscribeToStorageOperations` and `SubscribeToGrainCalls` methods provide a live, future-only stream of low-level events that you can collect and inspect after triggering grain behavior. Unlike the `WaitFor*` methods, feeds do not have a timeout or a predicate — they simply yield every matching event for as long as you consume them.
+The `GetStorageOperationsAsync` and `GetGrainCallsAsync` methods return live `IAsyncEnumerable<T>` feeds of low-level events that you can collect and inspect after triggering grain behavior. Compose them with standard LINQ operators such as `Where`, `Take`, and `Select` to wait for a specific number of occurrences or filter to a specific grain.
 
 Use feeds when:
 - You want to **collect all** storage operations or grain calls that happened during a test scenario, not just wait for one.
@@ -16,11 +16,11 @@ Use feeds when:
 | Property | Behavior |
 |---|---|
 | Start point | Subscription begins when enumeration starts (first `MoveNextAsync`) |
-| History | Future-only — no replay of past events |
+| History | Future-only by default. Pass `includeExisting: true` to replay recent events (up to 256) before live events. |
 | Buffering | Unbounded — slow consumers never lose events |
 | Completion | Stops when the `CancellationToken` is cancelled or the caller breaks out of the `await foreach` |
 
-## Subscribing to storage operations
+## Collecting storage operations
 
 Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclusterfixture-reusable-helper)
 
@@ -28,11 +28,11 @@ Fixture reference: [`OrleansTestClusterFixture`](../../README.md#orleanstestclus
 <a id='snippet-storage_operation_feed'></a>
 ```cs
 /// <summary>
-/// Demonstrates subscribing to a live feed of storage operations
-/// for collecting and inspecting persistence activity.
+/// Demonstrates using <c>GetStorageOperationsAsync</c> to collect and inspect
+/// persistence activity via a live <see cref="IAsyncEnumerable{T}"/> feed.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>SubscribeToStorageOperations</c> exposes persistence implementation details.
+/// ⚠️ <c>GetStorageOperationsAsync</c> exposes persistence implementation details.
 /// Tests using this feed are tightly coupled to storage providers and write timing.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
@@ -45,10 +45,10 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
 
         // Start collecting BEFORE triggering the action.
-        // The feed is future-only — it does not replay past events.
+        // The feed is future-only by default — it does not replay past events.
         // Use Take(1) to automatically stop after the first matching write.
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Where(op => op.Kind == StorageOperationKind.Write)
             .Take(1)
             .ToListAsync(ct);
@@ -62,24 +62,24 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
     }
 }
 ```
-<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L14-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-storage_operation_feed' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L8-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-storage_operation_feed' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Both `SubscribeToStorageOperations` overloads expose:
+Both `GetStorageOperationsAsync` overloads expose:
 - **Global** — receives all storage operations from any grain.
 - **Grain-scoped** — receives only storage operations for the specified grain.
 
-## Subscribing to grain calls
+## Collecting grain calls
 
 <!-- snippet: grain_call_feed -->
 <a id='snippet-grain_call_feed'></a>
 ```cs
 /// <summary>
-/// Demonstrates subscribing to a live feed of incoming grain calls
-/// for collecting and inspecting call flow.
+/// Demonstrates using <c>GetGrainCallsAsync</c> to collect and inspect
+/// incoming grain calls via a live <see cref="IAsyncEnumerable{T}"/> feed.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>SubscribeToGrainCalls</c> exposes low-level call flow.
+/// ⚠️ <c>GetGrainCallsAsync</c> exposes low-level call flow.
 /// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
 /// </remarks>
 public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
@@ -93,7 +93,7 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
         // Start collecting BEFORE triggering the action.
         // Use Take(1) to automatically stop after the first matching call.
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(ct)
+            .GetGrainCallsAsync(cancellationToken: ct)
             .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
             .Take(1)
             .ToListAsync(ct);
@@ -109,7 +109,7 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
 <sup><a href='/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs#L45-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-grain_call_feed' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Both `SubscribeToGrainCalls` overloads expose:
+Both `GetGrainCallsAsync` overloads expose:
 - **Global** — receives all incoming grain calls from any grain.
 - **Grain-scoped** — receives only calls targeting the specified grain.
 

--- a/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs
+++ b/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/AdvancedAssertionsSample.cs
@@ -8,8 +8,8 @@ namespace Egil.Orleans.Testing.Samples.AdvancedAssertions;
 /// A warehouse grain that accepts incoming reservation requests.
 /// <c>ReserveAsync</c> is <see cref="OneWayAttribute"/>, so the caller returns
 /// immediately while the grain processes the reservation asynchronously.
-/// This makes the advanced wait methods the only reliable way to know
-/// when the storage write or internal grain call completes.
+/// This makes the <c>Get*Async</c> feeds and <c>WaitForAssertionAsync</c> the only
+/// reliable way to know when the storage write or internal grain call completes.
 /// </summary>
 public interface IWarehouseGrain : IGrainWithStringKey
 {
@@ -56,7 +56,7 @@ public sealed class WarehouseGrain(
         await state.WriteStateAsync();
 
         // Delegate to an internal ledger grain — a grain-to-grain call that
-        // is invisible to the original caller but observable via WaitForGrainCallAsync.
+        // is invisible to the original caller but observable via GetGrainCallsAsync.
         var ledger = grainFactory.GetGrain<ILedgerGrain>(sku);
         await ledger.AddReservationAsync(quantity);
     }
@@ -83,27 +83,34 @@ public sealed class LedgerGrain(
 
 #region advanced_storage_assertion
 /// <summary>
-/// Demonstrates advanced wait methods that inspect storage operations directly.
+/// Demonstrates using <c>GetStorageOperationsAsync</c> to collect and inspect storage operations directly.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>WaitForStorageOperationAsync</c> couples your test to implementation details.
+/// ⚠️ <c>GetStorageOperationsAsync</c> couples your test to implementation details.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
 public sealed class WarehouseStorageOperationTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
 {
     [Fact]
-    public async Task WaitForStorageOperationAsync_waits_for_write_from_oneway_call()
+    public async Task GetStorageOperationsAsync_collects_write_from_oneway_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
+
+        // Start collecting BEFORE triggering the action.
+        // Use Take(1) to automatically stop after the first matching write.
+        var collectTask = fixture.Collector
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct);
 
         await grain.ReserveAsync("widget", 10);
 
-        // Assert after triggering the action. The collector remembers recent
-        // storage activity, so this also works when the write already happened.
-        await fixture.Collector.WaitForStorageOperationAsync(
-            op => op.Kind == StorageOperationKind.Write && op.GrainId == grain.GetGrainId(),
-            ct: TestContext.Current.CancellationToken);
+        var writes = await collectTask;
 
+        Assert.Single(writes);
+        Assert.Equal(grain.GetGrainId(), writes[0].GrainId);
         Assert.Equal(10, await grain.GetReservedAsync("widget"));
     }
 }
@@ -111,27 +118,34 @@ public sealed class WarehouseStorageOperationTests(OrleansTestClusterFixture fix
 
 #region advanced_grain_call_assertion
 /// <summary>
-/// Demonstrates advanced wait methods that inspect incoming grain calls directly.
+/// Demonstrates using <c>GetGrainCallsAsync</c> to collect and inspect incoming grain calls directly.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>WaitForGrainCallAsync</c> couples your test to implementation details.
+/// ⚠️ <c>GetGrainCallsAsync</c> couples your test to implementation details.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
 public sealed class WarehouseGrainCallTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
 {
     [Fact]
-    public async Task WaitForGrainCallAsync_waits_for_internal_grain_to_grain_call()
+    public async Task GetGrainCallsAsync_collects_internal_grain_to_grain_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
-
-        await grain.ReserveAsync("gadget", 5);
 
         // The warehouse grain internally calls ILedgerGrain.AddReservationAsync,
         // which is a grain-to-grain call invisible to the original test caller.
-        // The collector keeps recent calls, so you can wait after triggering the action too.
-        await fixture.Collector.WaitForGrainCallAsync(
-            ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync),
-            ct: TestContext.Current.CancellationToken);
+        // Use Take(1) to automatically stop after the first matching call.
+        var collectTask = fixture.Collector
+            .GetGrainCallsAsync(cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
+            .Take(1)
+            .ToListAsync(ct);
+
+        await grain.ReserveAsync("gadget", 5);
+
+        var calls = await collectTask;
+
+        Assert.Single(calls);
     }
 }
 #endregion

--- a/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
+++ b/Egil.Orleans.Testing/samples/Egil.Orleans.Testing.Samples/OperationFeedSample.cs
@@ -7,11 +7,11 @@ using Egil.Orleans.Testing.Samples.AdvancedAssertions;
 
 #region storage_operation_feed
 /// <summary>
-/// Demonstrates subscribing to a live feed of storage operations
-/// for collecting and inspecting persistence activity.
+/// Demonstrates using <c>GetStorageOperationsAsync</c> to collect and inspect
+/// persistence activity via a live <see cref="IAsyncEnumerable{T}"/> feed.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>SubscribeToStorageOperations</c> exposes persistence implementation details.
+/// ⚠️ <c>GetStorageOperationsAsync</c> exposes persistence implementation details.
 /// Tests using this feed are tightly coupled to storage providers and write timing.
 /// Prefer <c>WaitForAssertionAsync</c> when you can assert the externally observable result.
 /// </remarks>
@@ -24,10 +24,10 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
         var grain = fixture.GetUniqueGrain<IWarehouseGrain>();
 
         // Start collecting BEFORE triggering the action.
-        // The feed is future-only — it does not replay past events.
+        // The feed is future-only by default — it does not replay past events.
         // Use Take(1) to automatically stop after the first matching write.
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Where(op => op.Kind == StorageOperationKind.Write)
             .Take(1)
             .ToListAsync(ct);
@@ -44,11 +44,11 @@ public sealed class StorageOperationFeedTests(OrleansTestClusterFixture fixture)
 
 #region grain_call_feed
 /// <summary>
-/// Demonstrates subscribing to a live feed of incoming grain calls
-/// for collecting and inspecting call flow.
+/// Demonstrates using <c>GetGrainCallsAsync</c> to collect and inspect
+/// incoming grain calls via a live <see cref="IAsyncEnumerable{T}"/> feed.
 /// </summary>
 /// <remarks>
-/// ⚠️ <c>SubscribeToGrainCalls</c> exposes low-level call flow.
+/// ⚠️ <c>GetGrainCallsAsync</c> exposes low-level call flow.
 /// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
 /// </remarks>
 public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : IClassFixture<OrleansTestClusterFixture>
@@ -62,7 +62,7 @@ public sealed class GrainCallFeedTests(OrleansTestClusterFixture fixture) : ICla
         // Start collecting BEFORE triggering the action.
         // Use Take(1) to automatically stop after the first matching call.
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(ct)
+            .GetGrainCallsAsync(cancellationToken: ct)
             .Where(ctx => ctx.MethodName == nameof(ILedgerGrain.AddReservationAsync))
             .Take(1)
             .ToListAsync(ct);

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivity.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivity.cs
@@ -1,7 +1,7 @@
 namespace Egil.Orleans.Testing;
 
 /// <summary>
-/// Represents a lightweight grain activity signal used to retry assertions.
+/// Represents a grain activity signal observed by the testing collector.
 /// </summary>
 /// <param name="grainId">The grain instance that produced the activity.</param>
 /// <param name="kind">The kind of activity that occurred.</param>
@@ -22,4 +22,28 @@ public readonly record struct GrainActivity(GrainId grainId, GrainActivityKind k
     /// Gets the time when the activity was observed.
     /// </summary>
     public DateTimeOffset Timestamp { get; } = timestamp;
+
+    /// <summary>
+    /// Gets the detailed storage operation when <see cref="Kind"/> is a storage activity.
+    /// </summary>
+    public StorageOperation? StorageOperation { get; init; }
+
+    /// <summary>
+    /// Gets the incoming grain call context when <see cref="Kind"/> is <see cref="GrainActivityKind.GrainCall"/>.
+    /// </summary>
+    public IIncomingGrainCallContext? GrainCallContext { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this activity represents a storage operation.
+    /// When <see langword="true"/>, <see cref="StorageOperation"/> is guaranteed to have a value.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(StorageOperation))]
+    public bool IsStorageActivity => StorageOperation.HasValue;
+
+    /// <summary>
+    /// Gets a value indicating whether this activity represents an incoming grain call.
+    /// When <see langword="true"/>, <see cref="GrainCallContext"/> is guaranteed to be non-null.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(GrainCallContext))]
+    public bool IsGrainCall => GrainCallContext is not null;
 }

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -34,11 +35,14 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
 {
     private const int RecentEventHistoryCapacity = 256;
 
-    private readonly Lock subscribersLock = new();
-    private bool disposed;
-
-    private List<Subscriber> subscribers = [];
-    private Queue<GrainActivity> recentActivity = new();
+    // All activity is written to the ring buffer (recentActivity) and fanned out
+    // to subscriber channels under activityLock. This ensures that subscribe+snapshot
+    // (for includeExisting) and publish are mutually exclusive, eliminating
+    // duplicate or missed events.
+    private readonly Lock activityLock = new();
+    private readonly ConcurrentDictionary<Channel<GrainActivity>, object?> subscribers = [];
+    private readonly Queue<GrainActivity> recentActivity = new();
+    private volatile bool disposed;
 
     /// <inheritdoc cref="IGrainActivityWaiter.WaitForAssertionAsync{TResult}"/>
     [StackTraceHidden]
@@ -77,16 +81,22 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         var channel = CreateChannel();
         GrainActivity[]? history = null;
 
-        var subscriber = new Subscriber(channel);
-        lock (subscribersLock)
+        if (includeExisting)
         {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            if (includeExisting)
+            // Subscribe and snapshot under the same lock so that Publish cannot
+            // interleave — events before the lock are in the snapshot only, events
+            // after the lock go to the channel only. No duplicates, no gaps.
+            lock (activityLock)
             {
+                ObjectDisposedException.ThrowIf(disposed, this);
+                subscribers[channel] = null;
                 history = [.. recentActivity];
             }
-
-            subscribers = [.. subscribers, subscriber];
+        }
+        else
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            subscribers[channel] = null;
         }
 
         try
@@ -106,11 +116,7 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         }
         finally
         {
-            lock (subscribersLock)
-            {
-                subscribers = [.. subscribers.Where(s => !ReferenceEquals(s, subscriber))];
-            }
-
+            subscribers.TryRemove(channel, out _);
             channel.Writer.TryComplete();
         }
     }
@@ -229,6 +235,30 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
             .Where(ctx => ctx.TargetId == grainId);
     }
 
+    /// <summary>
+    /// Completes all active subscriber channels, removes every subscription, and clears
+    /// the recent-event history. After disposal, <c>WaitFor*</c> and <c>Get*Async</c>
+    /// methods throw <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        lock (activityLock)
+        {
+            disposed = true;
+            recentActivity.Clear();
+        }
+
+        foreach (var subscriber in subscribers)
+        {
+            subscriber.Key.Writer.TryComplete();
+        }
+    }
+
     internal void OnStorageOperation(StorageOperation operation)
     {
         Publish(new GrainActivity(
@@ -253,6 +283,29 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         {
             GrainCallContext = context,
         });
+    }
+
+    private void Publish(GrainActivity activity)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        lock (activityLock)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            EnqueueRecentEvent(activity);
+
+            foreach (var subscriber in subscribers)
+            {
+                subscriber.Key.Writer.TryWrite(activity);
+            }
+        }
     }
 
     [StackTraceHidden]
@@ -305,12 +358,8 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         // no activity events are lost between the initial assertion attempt and the
         // start of the retry loop.
         var channel = CreateChannel();
-        var subscriber = new Subscriber(channel);
-        lock (subscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            subscribers = [.. subscribers, subscriber];
-        }
+        ObjectDisposedException.ThrowIf(disposed, this);
+        subscribers[channel] = null;
 
         try
         {
@@ -364,60 +413,8 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         }
         finally
         {
-            lock (subscribersLock)
-            {
-                subscribers = [.. subscribers.Where(s => !ReferenceEquals(s, subscriber))];
-            }
-
+            subscribers.TryRemove(channel, out _);
             channel.Writer.TryComplete();
-        }
-    }
-
-    private void Publish(GrainActivity activity)
-    {
-        if (Volatile.Read(ref disposed))
-        {
-            return;
-        }
-
-        List<Subscriber> snapshot;
-        lock (subscribersLock)
-        {
-            EnqueueRecentEvent(recentActivity, activity);
-            snapshot = subscribers;
-        }
-
-        foreach (var subscriber in snapshot)
-        {
-            subscriber.Channel.Writer.TryWrite(activity);
-        }
-    }
-
-    /// <summary>
-    /// Completes all active subscriber channels, removes every subscription, and clears
-    /// the recent-event history. After disposal, <c>WaitFor*</c> and <c>Get*Async</c>
-    /// methods throw <see cref="ObjectDisposedException"/>.
-    /// </summary>
-    public void Dispose()
-    {
-        if (disposed)
-        {
-            return;
-        }
-
-        disposed = true;
-
-        List<Subscriber> snapshot;
-        lock (subscribersLock)
-        {
-            snapshot = subscribers;
-            subscribers = [];
-            recentActivity.Clear();
-        }
-
-        foreach (var subscriber in snapshot)
-        {
-            subscriber.Channel.Writer.TryComplete();
         }
     }
 
@@ -457,14 +454,12 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
             AllowSynchronousContinuations = false,
         });
 
-    private static void EnqueueRecentEvent(Queue<GrainActivity> history, GrainActivity item)
+    private void EnqueueRecentEvent(GrainActivity item)
     {
-        history.Enqueue(item);
-        while (history.Count > RecentEventHistoryCapacity)
+        recentActivity.Enqueue(item);
+        while (recentActivity.Count > RecentEventHistoryCapacity)
         {
-            history.Dequeue();
+            recentActivity.Dequeue();
         }
     }
-
-    private sealed record Subscriber(Channel<GrainActivity> Channel);
 }

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -100,8 +100,11 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
             }
             else
             {
-                ObjectDisposedException.ThrowIf(disposed, this);
-                subscribers[channel] = null;
+                lock (activityLock)
+                {
+                    ObjectDisposedException.ThrowIf(disposed, this);
+                    subscribers[channel] = null;
+                }
             }
 
             await foreach (var activity in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
@@ -353,8 +356,11 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         // no activity events are lost between the initial assertion attempt and the
         // start of the retry loop.
         var channel = CreateChannel();
-        ObjectDisposedException.ThrowIf(disposed, this);
-        subscribers[channel] = null;
+        lock (activityLock)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            subscribers[channel] = null;
+        }
 
         try
         {

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -12,16 +12,21 @@ namespace Egil.Orleans.Testing;
 /// Register an instance with the <c>AddGrainActivityCollector</c> extension method from
 /// <see cref="global::Orleans.Hosting.GrainActivityCollectorSiloBuilderExtensions"/>
 /// and optionally enable storage collection through <see cref="GrainActivityCollectorBuilder"/>.
-/// The standard <c>WaitForAssertionAsync</c> overloads retry assertions based on observed grain activity,
-/// while the advanced wait methods can observe low-level storage operations and incoming grain calls directly.
+/// <para>
+/// The standard <c>WaitForAssertionAsync</c> overloads retry assertions based on observed grain activity.
+/// The <c>Get*Async</c> methods return <see cref="IAsyncEnumerable{T}"/> feeds that can be composed with
+/// LINQ operators such as <c>Where</c>, <c>Take</c>, and <c>Select</c> for fine-grained event observation.
+/// </para>
+/// <para>
 /// <see cref="GrainActivityCollector"/> also implements <see cref="IGrainActivityWaiter"/>, so fixtures can
 /// forward a single low-level wait primitive and expose the same wait surface through
 /// <see cref="GrainActivityWaiterExtensions"/> without forcing callers through a <c>fixture.Collector</c> hop.
+/// </para>
 /// <para>
 /// The collector implements <see cref="IDisposable"/>. Calling <see cref="Dispose"/> completes all
 /// active subscriber channels (causing any pending <c>ReadAllAsync</c> loops to terminate), removes
 /// every subscription, and clears the recent-event history. After disposal, <c>WaitFor*</c> and
-/// <c>SubscribeTo*</c> methods throw <see cref="ObjectDisposedException"/>, while internal publish
+/// <c>Get*Async</c> methods throw <see cref="ObjectDisposedException"/>, while internal publish
 /// methods become silent no-ops to avoid cascading failures during shutdown.
 /// </para>
 /// </remarks>
@@ -29,18 +34,11 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
 {
     private const int RecentEventHistoryCapacity = 256;
 
-    private readonly Lock activitySubscribersLock = new();
-    private readonly Lock storageSubscribersLock = new();
-    private readonly Lock grainCallSubscribersLock = new();
+    private readonly Lock subscribersLock = new();
     private bool disposed;
 
-    private List<ActivitySubscriber> activitySubscribers = [];
-    private List<StorageSubscriber> storageSubscribers = [];
-    private List<GrainCallSubscriber> grainCallSubscribers = [];
-    private List<LiveFeedSubscriber<StorageOperation>> liveFeedStorageSubscribers = [];
-    private List<LiveFeedSubscriber<IIncomingGrainCallContext>> liveFeedGrainCallSubscribers = [];
-    private Queue<StorageOperation> recentStorageOperations = new();
-    private Queue<IIncomingGrainCallContext> recentGrainCalls = new();
+    private List<Subscriber> subscribers = [];
+    private Queue<GrainActivity> recentActivity = new();
 
     /// <inheritdoc cref="IGrainActivityWaiter.WaitForAssertionAsync{TResult}"/>
     [StackTraceHidden]
@@ -52,161 +50,65 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         => WaitForAssertionAsyncCore(assertion, filter, timeout, grainId: null, cancellationToken);
 
     /// <summary>
-    /// Waits for a storage operation matching the supplied predicate.
-    /// </summary>
-    /// <param name="predicate">Returns <see langword="true"/> when the expected operation has been observed.</param>
-    /// <param name="timeout">The maximum time to wait. When <see langword="null"/>, <see cref="IGrainActivityWaiter.DefaultWaitTimeout"/> is used.</param>
-    /// <param name="ct">A token that cancels the wait.</param>
-    /// <returns>A task that completes when a matching storage operation is observed.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    /// <exception cref="WaitForAssertionTimeoutException">Thrown when a matching operation is not observed before the timeout expires.</exception>
-    /// <remarks>
-    /// <para><b>Coupling risk:</b> This method inspects low-level persistence behavior rather than externally observable grain behavior.</para>
-    /// <para>
-    /// Tests that wait on storage operations are tightly coupled to implementation details like storage providers,
-    /// write timing, and persistence strategy. Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior
-    /// through the grain's public API instead.
-    /// </para>
-    /// </remarks>
-    public Task WaitForStorageOperationAsync(
-        Func<StorageOperation, bool> predicate,
-        TimeSpan? timeout = null,
-        CancellationToken ct = default)
-        => WaitForPredicateAsyncCore(
-            predicate,
-            (out ChannelReader<StorageOperation> reader, out StorageOperation[] history) => SubscribeStorageOperations(out reader, out history),
-            timeout,
-            grainId: null,
-            ct);
-
-    /// <summary>
-    /// Waits for a storage operation matching the supplied predicate on the specified grain.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>Coupling risk:</b> This method inspects low-level persistence behavior rather than externally observable grain behavior.</para>
-    /// <para>
-    /// Tests that wait on storage operations are tightly coupled to implementation details like storage providers,
-    /// write timing, and persistence strategy. Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior
-    /// through the grain's public API instead.
-    /// </para>
-    /// </remarks>
-    public Task WaitForStorageOperationAsync<TGrain>(
-        TGrain grain,
-        Func<StorageOperation, bool> predicate,
-        TimeSpan? timeout = null,
-        CancellationToken ct = default)
-        where TGrain : IGrain
-    {
-        ArgumentNullException.ThrowIfNull(grain);
-        return WaitForPredicateAsyncCore(
-            predicate,
-            (out ChannelReader<StorageOperation> reader, out StorageOperation[] history) => SubscribeStorageOperations(out reader, out history, operation => operation.GrainId == grain.GetGrainId()),
-            timeout,
-            grain.GetGrainId(),
-            ct);
-    }
-
-    /// <summary>
-    /// Waits for an incoming grain call matching the supplied predicate.
-    /// </summary>
-    /// <param name="predicate">Returns <see langword="true"/> when the expected incoming call has been observed.</param>
-    /// <param name="timeout">The maximum time to wait. When <see langword="null"/>, <see cref="IGrainActivityWaiter.DefaultWaitTimeout"/> is used.</param>
-    /// <param name="ct">A token that cancels the wait.</param>
-    /// <returns>A task that completes when a matching grain call is observed.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-    /// <exception cref="WaitForAssertionTimeoutException">Thrown when a matching call is not observed before the timeout expires.</exception>
-    /// <remarks>
-    /// <para><b>Coupling risk:</b> This method inspects low-level call flow rather than externally observable grain behavior.</para>
-    /// <para>
-    /// Tests that wait on incoming grain calls are tightly coupled to internal call structure and can break when implementation
-    /// details change even if externally visible behavior is unchanged. Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
-    /// </para>
-    /// </remarks>
-    public Task WaitForGrainCallAsync(
-        Func<IIncomingGrainCallContext, bool> predicate,
-        TimeSpan? timeout = null,
-        CancellationToken ct = default)
-        => WaitForPredicateAsyncCore(
-            predicate,
-            (out ChannelReader<IIncomingGrainCallContext> reader, out IIncomingGrainCallContext[] history) => SubscribeGrainCalls(out reader, out history),
-            timeout,
-            grainId: null,
-            ct);
-
-    /// <summary>
-    /// Waits for an incoming grain call matching the supplied predicate on the specified grain.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>Coupling risk:</b> This method inspects low-level call flow rather than externally observable grain behavior.</para>
-    /// <para>
-    /// Tests that wait on incoming grain calls are tightly coupled to internal call structure and can break when implementation
-    /// details change even if externally visible behavior is unchanged. Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.
-    /// </para>
-    /// </remarks>
-    public Task WaitForGrainCallAsync<TGrain>(
-        TGrain grain,
-        Func<IIncomingGrainCallContext, bool> predicate,
-        TimeSpan? timeout = null,
-        CancellationToken ct = default)
-        where TGrain : IGrain
-    {
-        ArgumentNullException.ThrowIfNull(grain);
-        return WaitForPredicateAsyncCore(
-            predicate,
-            (out ChannelReader<IIncomingGrainCallContext> reader, out IIncomingGrainCallContext[] history) => SubscribeGrainCalls(out reader, out history, context => context.TargetId == grain.GetGrainId()),
-            timeout,
-            grain.GetGrainId(),
-            ct);
-    }
-
-    /// <summary>
-    /// Returns a live, future-only feed of all storage operations observed by the collector.
+    /// Returns a live feed of all grain activity observed by the collector.
     /// </summary>
     /// <remarks>
     /// <para>
     /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
-    /// Only operations that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
-    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// When <paramref name="includeExisting"/> is <see langword="false"/> (the default), only activity that
+    /// occurs <b>after</b> enumeration begins is delivered. When <see langword="true"/>, the most recent
+    /// activity history (up to 256 events) is replayed before live events.
     /// </para>
     /// <para>
     /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
-    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// when <paramref name="cancellationToken"/> is cancelled or the caller stops enumerating.
     /// </para>
-    /// <para><b>Coupling risk:</b> This method exposes low-level persistence implementation details.
-    /// Tests using this feed are tightly coupled to storage providers, write timing, and persistence strategy.
-    /// Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior through the grain's public API.</para>
     /// </remarks>
-    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
-    /// <returns>An async enumerable that yields storage operations as they occur.</returns>
-    public async IAsyncEnumerable<StorageOperation> SubscribeToStorageOperations(
-        [EnumeratorCancellation] CancellationToken ct = default)
+    /// <param name="includeExisting">
+    /// When <see langword="true"/>, replays the recent activity history before live events.
+    /// Defaults to <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields grain activity as it occurs.</returns>
+    public async IAsyncEnumerable<GrainActivity> GetGrainActivityAsync(
+        bool includeExisting = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var channel = Channel.CreateUnbounded<StorageOperation>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            AllowSynchronousContinuations = false,
-        });
+        var channel = CreateChannel();
+        GrainActivity[]? history = null;
 
-        var subscriber = new LiveFeedSubscriber<StorageOperation>(channel, GrainIdFilter: null);
-        lock (storageSubscribersLock)
+        var subscriber = new Subscriber(channel);
+        lock (subscribersLock)
         {
             ObjectDisposedException.ThrowIf(disposed, this);
-            liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers, subscriber];
+            if (includeExisting)
+            {
+                history = [.. recentActivity];
+            }
+
+            subscribers = [.. subscribers, subscriber];
         }
 
         try
         {
-            await foreach (var operation in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            if (history is not null)
             {
-                yield return operation;
+                foreach (var activity in history)
+                {
+                    yield return activity;
+                }
+            }
+
+            await foreach (var activity in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return activity;
             }
         }
         finally
         {
-            lock (storageSubscribersLock)
+            lock (subscribersLock)
             {
-                liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
+                subscribers = [.. subscribers.Where(s => !ReferenceEquals(s, subscriber))];
             }
 
             channel.Writer.TryComplete();
@@ -214,17 +116,37 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
     }
 
     /// <summary>
-    /// Returns a live, future-only feed of storage operations for the specified grain.
+    /// Returns a live feed of all storage operations observed by the collector.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
-    /// Only operations that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
-    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
+    /// Internally delegates to <see cref="GetGrainActivityAsync"/> and filters to storage activity.
+    /// Use LINQ operators such as <c>Where</c>, <c>Take</c>, and <c>Select</c> for further composition.
     /// </para>
+    /// <para><b>Coupling risk:</b> This method exposes low-level persistence implementation details.
+    /// Tests using this feed are tightly coupled to storage providers, write timing, and persistence strategy.
+    /// Prefer <c>WaitForAssertionAsync</c> when you can express the expected behavior through the grain's public API.</para>
+    /// </remarks>
+    /// <param name="includeExisting">
+    /// When <see langword="true"/>, replays the recent activity history before live events.
+    /// Defaults to <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token that stops the feed and removes the subscription.</param>
+    /// <returns>An async enumerable that yields storage operations as they occur.</returns>
+    public IAsyncEnumerable<StorageOperation> GetStorageOperationsAsync(
+        bool includeExisting = false,
+        CancellationToken cancellationToken = default)
+        => GetGrainActivityAsync(includeExisting, cancellationToken)
+            .Where(a => a.IsStorageActivity)
+            .Select(a => a.StorageOperation!.Value);
+
+    /// <summary>
+    /// Returns a live feed of storage operations for the specified grain.
+    /// </summary>
+    /// <remarks>
     /// <para>
-    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
-    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// Delegates to the global <see cref="GetStorageOperationsAsync(bool, CancellationToken)"/> overload
+    /// and filters by grain identity.
     /// </para>
     /// <para><b>Coupling risk:</b> This method exposes low-level persistence implementation details.
     /// Tests using this feed are tightly coupled to storage providers, write timing, and persistence strategy.
@@ -232,114 +154,56 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
     /// </remarks>
     /// <typeparam name="TGrain">The grain interface type.</typeparam>
     /// <param name="grain">The grain whose storage operations should be included in the feed.</param>
-    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <param name="includeExisting">
+    /// When <see langword="true"/>, replays the recent activity history before live events.
+    /// Defaults to <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token that stops the feed and removes the subscription.</param>
     /// <returns>An async enumerable that yields storage operations for the specified grain as they occur.</returns>
-    public async IAsyncEnumerable<StorageOperation> SubscribeToStorageOperations<TGrain>(
+    public IAsyncEnumerable<StorageOperation> GetStorageOperationsAsync<TGrain>(
         TGrain grain,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        bool includeExisting = false,
+        CancellationToken cancellationToken = default)
         where TGrain : IGrain
     {
         ArgumentNullException.ThrowIfNull(grain);
         var grainId = grain.GetGrainId();
-
-        var channel = Channel.CreateUnbounded<StorageOperation>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            AllowSynchronousContinuations = false,
-        });
-
-        var subscriber = new LiveFeedSubscriber<StorageOperation>(channel, GrainIdFilter: grainId);
-        lock (storageSubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers, subscriber];
-        }
-
-        try
-        {
-            await foreach (var operation in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-            {
-                yield return operation;
-            }
-        }
-        finally
-        {
-            lock (storageSubscribersLock)
-            {
-                liveFeedStorageSubscribers = [.. liveFeedStorageSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
-            }
-
-            channel.Writer.TryComplete();
-        }
+        return GetStorageOperationsAsync(includeExisting, cancellationToken)
+            .Where(op => op.GrainId == grainId);
     }
 
     /// <summary>
-    /// Returns a live, future-only feed of all incoming grain calls observed by the collector.
+    /// Returns a live feed of all incoming grain calls observed by the collector.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
-    /// Only calls that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
-    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
-    /// </para>
-    /// <para>
-    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
-    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// Internally delegates to <see cref="GetGrainActivityAsync"/> and filters to grain call activity.
+    /// Use LINQ operators such as <c>Where</c>, <c>Take</c>, and <c>Select</c> for further composition.
     /// </para>
     /// <para><b>Coupling risk:</b> This method exposes low-level call flow rather than externally observable grain behavior.
     /// Tests using this feed are tightly coupled to internal call structure and can break when implementation details change.
     /// Prefer <c>WaitForAssertionAsync</c> for behavior-first assertions.</para>
     /// </remarks>
-    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <param name="includeExisting">
+    /// When <see langword="true"/>, replays the recent activity history before live events.
+    /// Defaults to <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token that stops the feed and removes the subscription.</param>
     /// <returns>An async enumerable that yields incoming grain call contexts as they occur.</returns>
-    public async IAsyncEnumerable<IIncomingGrainCallContext> SubscribeToGrainCalls(
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        var channel = Channel.CreateUnbounded<IIncomingGrainCallContext>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            AllowSynchronousContinuations = false,
-        });
-
-        var subscriber = new LiveFeedSubscriber<IIncomingGrainCallContext>(channel, GrainIdFilter: null);
-        lock (grainCallSubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers, subscriber];
-        }
-
-        try
-        {
-            await foreach (var context in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-            {
-                yield return context;
-            }
-        }
-        finally
-        {
-            lock (grainCallSubscribersLock)
-            {
-                liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
-            }
-
-            channel.Writer.TryComplete();
-        }
-    }
+    public IAsyncEnumerable<IIncomingGrainCallContext> GetGrainCallsAsync(
+        bool includeExisting = false,
+        CancellationToken cancellationToken = default)
+        => GetGrainActivityAsync(includeExisting, cancellationToken)
+            .Where(a => a.IsGrainCall)
+            .Select(a => a.GrainCallContext!);
 
     /// <summary>
-    /// Returns a live, future-only feed of incoming grain calls for the specified grain.
+    /// Returns a live feed of incoming grain calls for the specified grain.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The subscription begins when enumeration starts (i.e. when the first <c>MoveNextAsync</c> call is made).
-    /// Only calls that occur <b>after</b> enumeration begins are delivered — no historical replay is performed.
-    /// Start consuming the feed <b>before</b> triggering the behavior you want to observe.
-    /// </para>
-    /// <para>
-    /// The feed uses an unbounded buffer so slow consumers never lose events. The feed completes
-    /// when <paramref name="ct"/> is cancelled or the caller stops enumerating.
+    /// Delegates to the global <see cref="GetGrainCallsAsync(bool, CancellationToken)"/> overload
+    /// and filters by grain identity.
     /// </para>
     /// <para><b>Coupling risk:</b> This method exposes low-level call flow rather than externally observable grain behavior.
     /// Tests using this feed are tightly coupled to internal call structure and can break when implementation details change.
@@ -347,52 +211,27 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
     /// </remarks>
     /// <typeparam name="TGrain">The grain interface type.</typeparam>
     /// <param name="grain">The grain whose incoming calls should be included in the feed.</param>
-    /// <param name="ct">A token that stops the feed and removes the subscription.</param>
+    /// <param name="includeExisting">
+    /// When <see langword="true"/>, replays the recent activity history before live events.
+    /// Defaults to <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token that stops the feed and removes the subscription.</param>
     /// <returns>An async enumerable that yields incoming grain call contexts for the specified grain as they occur.</returns>
-    public async IAsyncEnumerable<IIncomingGrainCallContext> SubscribeToGrainCalls<TGrain>(
+    public IAsyncEnumerable<IIncomingGrainCallContext> GetGrainCallsAsync<TGrain>(
         TGrain grain,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        bool includeExisting = false,
+        CancellationToken cancellationToken = default)
         where TGrain : IGrain
     {
         ArgumentNullException.ThrowIfNull(grain);
         var grainId = grain.GetGrainId();
-
-        var channel = Channel.CreateUnbounded<IIncomingGrainCallContext>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            AllowSynchronousContinuations = false,
-        });
-
-        var subscriber = new LiveFeedSubscriber<IIncomingGrainCallContext>(channel, GrainIdFilter: grainId);
-        lock (grainCallSubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers, subscriber];
-        }
-
-        try
-        {
-            await foreach (var context in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-            {
-                yield return context;
-            }
-        }
-        finally
-        {
-            lock (grainCallSubscribersLock)
-            {
-                liveFeedGrainCallSubscribers = [.. liveFeedGrainCallSubscribers.Where(s => !ReferenceEquals(s, subscriber))];
-            }
-
-            channel.Writer.TryComplete();
-        }
+        return GetGrainCallsAsync(includeExisting, cancellationToken)
+            .Where(ctx => ctx.TargetId == grainId);
     }
 
     internal void OnStorageOperation(StorageOperation operation)
     {
-        PublishStorageOperation(operation);
-        PublishActivity(new GrainActivity(
+        Publish(new GrainActivity(
             operation.GrainId,
             operation.Kind switch
             {
@@ -401,15 +240,19 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
                 StorageOperationKind.Write => GrainActivityKind.StorageWrite,
                 _ => throw new UnreachableException(),
             },
-            DateTimeOffset.UtcNow));
+            DateTimeOffset.UtcNow)
+        {
+            StorageOperation = operation,
+        });
     }
 
     internal void OnGrainCall(IIncomingGrainCallContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-
-        PublishGrainCall(context);
-        PublishActivity(new GrainActivity(context.TargetId, GrainActivityKind.GrainCall, DateTimeOffset.UtcNow));
+        Publish(new GrainActivity(context.TargetId, GrainActivityKind.GrainCall, DateTimeOffset.UtcNow)
+        {
+            GrainCallContext = context,
+        });
     }
 
     [StackTraceHidden]
@@ -456,266 +299,103 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         StrongBox<TimeSpan?> timeoutElapsed,
         CancellationToken ct)
     {
-        using var subscription = SubscribeActivities(out var reader, filter);
         var stopwatch = Stopwatch.StartNew();
 
-        using (RequestContextScope.ForAssertion())
+        // Register the subscription eagerly — before the first assertion — so that
+        // no activity events are lost between the initial assertion attempt and the
+        // start of the retry loop.
+        var channel = CreateChannel();
+        var subscriber = new Subscriber(channel);
+        lock (subscribersLock)
         {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            subscribers = [.. subscribers, subscriber];
+        }
+
+        try
+        {
+            using (RequestContextScope.ForAssertion())
+            {
+                try
+                {
+                    return await assertion().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    lastFailure.Value = ex;
+                }
+            }
+
+            using var timeoutCts = CreateTimeoutCancellationTokenSource(timeout, ct);
+            var effectiveToken = timeoutCts?.Token ?? ct;
+
+            IAsyncEnumerable<GrainActivity> stream = channel.Reader.ReadAllAsync(effectiveToken);
+            if (filter is not null)
+            {
+                stream = stream.Where(a => filter(a));
+            }
+
             try
             {
-                return await assertion().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                lastFailure.Value = ex;
-            }
-        }
-
-        using var timeoutCts = CreateTimeoutCancellationTokenSource(timeout, ct);
-        var effectiveToken = timeoutCts?.Token ?? ct;
-
-        try
-        {
-            await foreach (var _ in reader.ReadAllAsync(effectiveToken).ConfigureAwait(false))
-            {
-                using (RequestContextScope.ForAssertion())
+                await foreach (var _ in stream.ConfigureAwait(false))
                 {
-                    try
+                    using (RequestContextScope.ForAssertion())
                     {
-                        return await assertion().ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        lastFailure.Value = ex;
+                        try
+                        {
+                            return await assertion().ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            lastFailure.Value = ex;
+                        }
                     }
                 }
             }
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            timeoutElapsed.Value = stopwatch.Elapsed;
-            throw;
-        }
-
-        ct.ThrowIfCancellationRequested();
-        ObjectDisposedException.ThrowIf(disposed, this);
-        throw new InvalidOperationException("The activity stream completed unexpectedly.");
-    }
-
-    private async Task WaitForPredicateAsyncCore<T>(
-        Func<T, bool> predicate,
-        SubscribeDelegate<T> subscribe,
-        TimeSpan? timeout,
-        GrainId? grainId,
-        CancellationToken ct)
-    {
-        ObjectDisposedException.ThrowIf(disposed, this);
-        ArgumentNullException.ThrowIfNull(predicate);
-        ArgumentNullException.ThrowIfNull(subscribe);
-
-        using var subscription = subscribe(out var reader, out var recentItems);
-        using var timeoutCts = CreateTimeoutCancellationTokenSource(timeout, ct);
-        var effectiveToken = timeoutCts?.Token ?? ct;
-        var stopwatch = Stopwatch.StartNew();
-
-        foreach (var item in recentItems)
-        {
-            if (predicate(item))
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                return;
+                timeoutElapsed.Value = stopwatch.Elapsed;
+                throw;
             }
-        }
 
-        try
+            ct.ThrowIfCancellationRequested();
+            ObjectDisposedException.ThrowIf(disposed, this);
+            throw new InvalidOperationException("The activity stream completed unexpectedly.");
+        }
+        finally
         {
-            await foreach (var item in reader.ReadAllAsync(effectiveToken).ConfigureAwait(false))
+            lock (subscribersLock)
             {
-                if (predicate(item))
-                {
-                    return;
-                }
+                subscribers = [.. subscribers.Where(s => !ReferenceEquals(s, subscriber))];
             }
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            throw CreateTimeoutException(innerException: null, grainId, stopwatch.Elapsed);
-        }
 
-        ct.ThrowIfCancellationRequested();
-        ObjectDisposedException.ThrowIf(disposed, this);
-        throw new InvalidOperationException("The event stream completed unexpectedly.");
+            channel.Writer.TryComplete();
+        }
     }
 
-    private IDisposable SubscribeActivities(out ChannelReader<GrainActivity> reader, Predicate<GrainActivity>? filter = null)
+    private void Publish(GrainActivity activity)
     {
-        var channel = CreateChannel<GrainActivity>();
-        var subscriber = new ActivitySubscriber(channel, filter);
-        lock (activitySubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            activitySubscribers = [.. activitySubscribers, subscriber];
-        }
-
-        reader = channel.Reader;
-        return new ActivitySubscription(this, subscriber);
-    }
-
-    private IDisposable SubscribeStorageOperations(out ChannelReader<StorageOperation> reader, out StorageOperation[] history, Predicate<StorageOperation>? filter = null)
-    {
-        var channel = CreateChannel<StorageOperation>();
-        var subscriber = new StorageSubscriber(channel, filter);
-        lock (storageSubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            history = GetHistorySnapshot(recentStorageOperations, filter);
-            storageSubscribers = [.. storageSubscribers, subscriber];
-        }
-
-        reader = channel.Reader;
-        return new StorageSubscription(this, subscriber);
-    }
-
-    private IDisposable SubscribeGrainCalls(out ChannelReader<IIncomingGrainCallContext> reader, out IIncomingGrainCallContext[] history, Predicate<IIncomingGrainCallContext>? filter = null)
-    {
-        var channel = CreateChannel<IIncomingGrainCallContext>();
-        var subscriber = new GrainCallSubscriber(channel, filter);
-        lock (grainCallSubscribersLock)
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            history = GetHistorySnapshot(recentGrainCalls, filter);
-            grainCallSubscribers = [.. grainCallSubscribers, subscriber];
-        }
-
-        reader = channel.Reader;
-        return new GrainCallSubscription(this, subscriber);
-    }
-
-    private void PublishActivity(GrainActivity activity)
-    {
-        if (disposed)
+        if (Volatile.Read(ref disposed))
         {
             return;
         }
 
-        var snapshot = activitySubscribers;
+        List<Subscriber> snapshot;
+        lock (subscribersLock)
+        {
+            EnqueueRecentEvent(recentActivity, activity);
+            snapshot = subscribers;
+        }
+
         foreach (var subscriber in snapshot)
         {
-            if (subscriber.Filter is not null && !subscriber.Filter(activity))
-            {
-                continue;
-            }
-
             subscriber.Channel.Writer.TryWrite(activity);
         }
     }
 
-    private void PublishStorageOperation(StorageOperation operation)
-    {
-        if (disposed)
-        {
-            return;
-        }
-
-        StorageSubscriber[] snapshot;
-        lock (storageSubscribersLock)
-        {
-            EnqueueRecentEvent(recentStorageOperations, operation);
-            snapshot = [.. storageSubscribers];
-        }
-
-        foreach (var subscriber in snapshot)
-        {
-            if (subscriber.Filter is not null && !subscriber.Filter(operation))
-            {
-                continue;
-            }
-
-            subscriber.Channel.Writer.TryWrite(operation);
-        }
-
-        // Live-feed subscribers use copy-on-write; reading the reference is safe without a lock.
-        var liveFeedSnapshot = liveFeedStorageSubscribers;
-        foreach (var subscriber in liveFeedSnapshot)
-        {
-            if (subscriber.GrainIdFilter is { } grainId && operation.GrainId != grainId)
-            {
-                continue;
-            }
-
-            subscriber.Channel.Writer.TryWrite(operation);
-        }
-    }
-
-    private void PublishGrainCall(IIncomingGrainCallContext context)
-    {
-        if (disposed)
-        {
-            return;
-        }
-
-        GrainCallSubscriber[] snapshot;
-        lock (grainCallSubscribersLock)
-        {
-            EnqueueRecentEvent(recentGrainCalls, context);
-            snapshot = [.. grainCallSubscribers];
-        }
-
-        foreach (var subscriber in snapshot)
-        {
-            if (subscriber.Filter is not null && !subscriber.Filter(context))
-            {
-                continue;
-            }
-
-            subscriber.Channel.Writer.TryWrite(context);
-        }
-
-        // Live-feed subscribers use copy-on-write; reading the reference is safe without a lock.
-        var liveFeedSnapshot = liveFeedGrainCallSubscribers;
-        foreach (var subscriber in liveFeedSnapshot)
-        {
-            if (subscriber.GrainIdFilter is { } grainId && context.TargetId != grainId)
-            {
-                continue;
-            }
-
-            subscriber.Channel.Writer.TryWrite(context);
-        }
-    }
-
-    private void Unsubscribe(ActivitySubscriber subscriber)
-    {
-        lock (activitySubscribersLock)
-        {
-            activitySubscribers = [.. activitySubscribers.Where(current => !ReferenceEquals(current, subscriber))];
-        }
-
-        subscriber.Channel.Writer.TryComplete();
-    }
-
-    private void Unsubscribe(StorageSubscriber subscriber)
-    {
-        lock (storageSubscribersLock)
-        {
-            storageSubscribers = [.. storageSubscribers.Where(current => !ReferenceEquals(current, subscriber))];
-        }
-
-        subscriber.Channel.Writer.TryComplete();
-    }
-
-    private void Unsubscribe(GrainCallSubscriber subscriber)
-    {
-        lock (grainCallSubscribersLock)
-        {
-            grainCallSubscribers = [.. grainCallSubscribers.Where(current => !ReferenceEquals(current, subscriber))];
-        }
-
-        subscriber.Channel.Writer.TryComplete();
-    }
-
     /// <summary>
     /// Completes all active subscriber channels, removes every subscription, and clears
-    /// the recent-event history. After disposal, <c>WaitFor*</c> and <c>SubscribeTo*</c>
+    /// the recent-event history. After disposal, <c>WaitFor*</c> and <c>Get*Async</c>
     /// methods throw <see cref="ObjectDisposedException"/>.
     /// </summary>
     public void Dispose()
@@ -727,56 +407,15 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
 
         disposed = true;
 
-        List<ActivitySubscriber> activitySnapshot;
-        lock (activitySubscribersLock)
+        List<Subscriber> snapshot;
+        lock (subscribersLock)
         {
-            activitySnapshot = activitySubscribers;
-            activitySubscribers = [];
+            snapshot = subscribers;
+            subscribers = [];
+            recentActivity.Clear();
         }
 
-        foreach (var subscriber in activitySnapshot)
-        {
-            subscriber.Channel.Writer.TryComplete();
-        }
-
-        List<StorageSubscriber> storageSnapshot;
-        List<LiveFeedSubscriber<StorageOperation>> liveFeedStorageSnapshot;
-        lock (storageSubscribersLock)
-        {
-            storageSnapshot = storageSubscribers;
-            liveFeedStorageSnapshot = liveFeedStorageSubscribers;
-            storageSubscribers = [];
-            liveFeedStorageSubscribers = [];
-            recentStorageOperations.Clear();
-        }
-
-        foreach (var subscriber in storageSnapshot)
-        {
-            subscriber.Channel.Writer.TryComplete();
-        }
-
-        foreach (var subscriber in liveFeedStorageSnapshot)
-        {
-            subscriber.Channel.Writer.TryComplete();
-        }
-
-        List<GrainCallSubscriber> grainCallSnapshot;
-        List<LiveFeedSubscriber<IIncomingGrainCallContext>> liveFeedGrainCallSnapshot;
-        lock (grainCallSubscribersLock)
-        {
-            grainCallSnapshot = grainCallSubscribers;
-            liveFeedGrainCallSnapshot = liveFeedGrainCallSubscribers;
-            grainCallSubscribers = [];
-            liveFeedGrainCallSubscribers = [];
-            recentGrainCalls.Clear();
-        }
-
-        foreach (var subscriber in grainCallSnapshot)
-        {
-            subscriber.Channel.Writer.TryComplete();
-        }
-
-        foreach (var subscriber in liveFeedGrainCallSnapshot)
+        foreach (var subscriber in snapshot)
         {
             subscriber.Channel.Writer.TryComplete();
         }
@@ -810,20 +449,15 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         return exception;
     }
 
-    private static Channel<T> CreateChannel<T>() =>
-        Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+    private static Channel<GrainActivity> CreateChannel() =>
+        Channel.CreateUnbounded<GrainActivity>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = false,
             AllowSynchronousContinuations = false,
         });
 
-    private static T[] GetHistorySnapshot<T>(Queue<T> history, Predicate<T>? filter)
-        => filter is null
-            ? [.. history]
-            : [.. history.Where(item => filter(item))];
-
-    private static void EnqueueRecentEvent<T>(Queue<T> history, T item)
+    private static void EnqueueRecentEvent(Queue<GrainActivity> history, GrainActivity item)
     {
         history.Enqueue(item);
         while (history.Count > RecentEventHistoryCapacity)
@@ -832,67 +466,5 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         }
     }
 
-    private delegate IDisposable SubscribeDelegate<T>(out ChannelReader<T> reader, out T[] history);
-
-    private sealed class ActivitySubscriber(Channel<GrainActivity> channel, Predicate<GrainActivity>? filter)
-    {
-        public Channel<GrainActivity> Channel { get; } = channel;
-
-        public Predicate<GrainActivity>? Filter { get; } = filter;
-    }
-
-    private sealed class StorageSubscriber(Channel<StorageOperation> channel, Predicate<StorageOperation>? filter)
-    {
-        public Channel<StorageOperation> Channel { get; } = channel;
-
-        public Predicate<StorageOperation>? Filter { get; } = filter;
-    }
-
-    private sealed class GrainCallSubscriber(Channel<IIncomingGrainCallContext> channel, Predicate<IIncomingGrainCallContext>? filter)
-    {
-        public Channel<IIncomingGrainCallContext> Channel { get; } = channel;
-
-        public Predicate<IIncomingGrainCallContext>? Filter { get; } = filter;
-    }
-
-    private sealed class ActivitySubscription(GrainActivityCollector owner, ActivitySubscriber subscriber) : IDisposable
-    {
-        private int disposed;
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref disposed, 1) == 0)
-            {
-                owner.Unsubscribe(subscriber);
-            }
-        }
-    }
-
-    private sealed class StorageSubscription(GrainActivityCollector owner, StorageSubscriber subscriber) : IDisposable
-    {
-        private int disposed;
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref disposed, 1) == 0)
-            {
-                owner.Unsubscribe(subscriber);
-            }
-        }
-    }
-
-    private sealed class GrainCallSubscription(GrainActivityCollector owner, GrainCallSubscriber subscriber) : IDisposable
-    {
-        private int disposed;
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref disposed, 1) == 0)
-            {
-                owner.Unsubscribe(subscriber);
-            }
-        }
-    }
-
-    private sealed record LiveFeedSubscriber<T>(Channel<T> Channel, GrainId? GrainIdFilter);
+    private sealed record Subscriber(Channel<GrainActivity> Channel);
 }

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -80,30 +80,30 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
     {
         var channel = CreateChannel();
 
-        if (includeExisting)
+        try
         {
-            // Subscribe and prefill the channel with history under the same lock
-            // so that Publish cannot interleave — events before the lock are
-            // written to the channel as history, events after the lock are
-            // written by Publish. No duplicates, no gaps, no array copy.
-            lock (activityLock)
+            if (includeExisting)
+            {
+                // Subscribe and prefill the channel with history under the same lock
+                // so that Publish cannot interleave — events before the lock are
+                // written to the channel as history, events after the lock are
+                // written by Publish. No duplicates, no gaps, no array copy.
+                lock (activityLock)
+                {
+                    ObjectDisposedException.ThrowIf(disposed, this);
+                    subscribers[channel] = null;
+                    foreach (var item in recentActivity)
+                    {
+                        channel.Writer.TryWrite(item);
+                    }
+                }
+            }
+            else
             {
                 ObjectDisposedException.ThrowIf(disposed, this);
                 subscribers[channel] = null;
-                foreach (var item in recentActivity)
-                {
-                    channel.Writer.TryWrite(item);
-                }
             }
-        }
-        else
-        {
-            ObjectDisposedException.ThrowIf(disposed, this);
-            subscribers[channel] = null;
-        }
 
-        try
-        {
             await foreach (var activity in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 yield return activity;

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollector.cs
@@ -79,18 +79,21 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var channel = CreateChannel();
-        GrainActivity[]? history = null;
 
         if (includeExisting)
         {
-            // Subscribe and snapshot under the same lock so that Publish cannot
-            // interleave — events before the lock are in the snapshot only, events
-            // after the lock go to the channel only. No duplicates, no gaps.
+            // Subscribe and prefill the channel with history under the same lock
+            // so that Publish cannot interleave — events before the lock are
+            // written to the channel as history, events after the lock are
+            // written by Publish. No duplicates, no gaps, no array copy.
             lock (activityLock)
             {
                 ObjectDisposedException.ThrowIf(disposed, this);
                 subscribers[channel] = null;
-                history = [.. recentActivity];
+                foreach (var item in recentActivity)
+                {
+                    channel.Writer.TryWrite(item);
+                }
             }
         }
         else
@@ -101,14 +104,6 @@ public sealed class GrainActivityCollector : IGrainActivityWaiter, IDisposable
 
         try
         {
-            if (history is not null)
-            {
-                foreach (var activity in history)
-                {
-                    yield return activity;
-                }
-            }
-
             await foreach (var activity in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 yield return activity;

--- a/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollectorBuilder.cs
+++ b/Egil.Orleans.Testing/src/Egil.Orleans.Testing/GrainActivityCollectorBuilder.cs
@@ -40,6 +40,38 @@ public sealed class GrainActivityCollectorBuilder
         return this;
     }
 
+    /// <summary>
+    /// Enables storage activity collection for <b>all</b> keyed <see cref="IGrainStorage"/> providers
+    /// currently registered in the service collection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method must be called <b>after</b> all storage providers have been registered with the silo builder,
+    /// because it iterates the current service collection to discover providers. Providers registered after this
+    /// call will not be included.
+    /// </para>
+    /// </remarks>
+    /// <returns>The current builder instance.</returns>
+    public GrainActivityCollectorBuilder CollectStorageActivity()
+    {
+        var providerNames = services
+            .Where(descriptor =>
+                descriptor.ServiceType == typeof(IGrainStorage)
+                && descriptor.IsKeyedService
+                && descriptor.ServiceKey is string key
+                && !key.StartsWith("Egil.Orleans.Testing.Inner::", StringComparison.Ordinal))
+            .Select(descriptor => (string)descriptor.ServiceKey!)
+            .Distinct()
+            .ToList();
+
+        foreach (var providerName in providerNames)
+        {
+            DecorateGrainStorage(providerName);
+        }
+
+        return this;
+    }
+
     private void DecorateGrainStorage(string providerName)
     {
         var descriptor = services.LastOrDefault(candidate =>

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorActivityFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorActivityFeedTests.cs
@@ -1,0 +1,140 @@
+namespace Egil.Orleans.Testing.Tests;
+
+public class GrainActivityCollectorActivityFeedTests(OrleansTestClusterFixture fixture)
+{
+    [Fact]
+    public async Task GetGrainActivityAsync_receives_grain_call_and_storage_activity()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // Subscribe to the unified feed filtered to our grain.
+        // A single SetValueAsync produces: StorageRead (activation) + StorageWrite + GrainCall.
+        var collectTask = fixture.Collector
+            .GetGrainActivityAsync(cancellationToken: ct)
+            .Where(a => a.GrainId == grainId)
+            .Take(3)
+            .ToListAsync(ct)
+            .AsTask();
+
+        await grain.SetValueAsync("mixed-test");
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.Equal(3, collected.Count);
+        Assert.Contains(collected, a => a.IsGrainCall);
+        Assert.Contains(collected, a => a.IsStorageActivity);
+    }
+
+    [Fact]
+    public async Task GetGrainActivityAsync_includeExisting_replays_history()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // Generate activity BEFORE subscribing
+        await grain.SetValueAsync("history-test");
+
+        // Wait for the activity to land in the collector's history
+        await fixture.Collector
+            .GetGrainActivityAsync(includeExisting: true, cancellationToken: ct)
+            .Where(a => a.GrainId == grainId && a.IsStorageActivity)
+            .Take(1)
+            .FirstAsync(ct);
+
+        // Now subscribe with includeExisting — should replay the history
+        var collected = await fixture.Collector
+            .GetGrainActivityAsync(includeExisting: true, cancellationToken: ct)
+            .Where(a => a.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.NotEmpty(collected);
+        Assert.Equal(grainId, collected[0].GrainId);
+    }
+
+    [Fact]
+    public async Task GetGrainActivityAsync_populates_StorageOperation_and_GrainCallContext()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // StorageRead (activation) + StorageWrite + GrainCall = 3 events
+        var collectTask = fixture.Collector
+            .GetGrainActivityAsync(cancellationToken: ct)
+            .Where(a => a.GrainId == grainId)
+            .Take(3)
+            .ToListAsync(ct)
+            .AsTask();
+
+        await grain.SetValueAsync("props-test");
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        var grainCall = collected.First(a => a.IsGrainCall);
+        Assert.NotNull(grainCall.GrainCallContext);
+        Assert.Null(grainCall.StorageOperation);
+        Assert.Equal(GrainActivityKind.GrainCall, grainCall.Kind);
+
+        var storageWrite = collected.First(a => a.IsStorageActivity && a.Kind == GrainActivityKind.StorageWrite);
+        Assert.NotNull(storageWrite.StorageOperation);
+        Assert.Null(storageWrite.GrainCallContext);
+        Assert.Equal(StorageOperationKind.Write, storageWrite.StorageOperation!.Value.Kind);
+    }
+
+    [Fact]
+    public async Task GetGrainActivityAsync_future_only_does_not_replay_history()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var grain = fixture.GetUniqueGrain<ITestStateGrain>();
+        var grainId = grain.GetGrainId();
+
+        // Generate activity BEFORE subscribing
+        await grain.SetValueAsync("pre-subscribe");
+
+        // Wait for it to be observed
+        await fixture.Collector
+            .GetGrainActivityAsync(includeExisting: true, cancellationToken: ct)
+            .Where(a => a.GrainId == grainId && a.IsStorageActivity)
+            .Take(1)
+            .FirstAsync(ct);
+
+        // Subscribe future-only
+        var collectTask = fixture.Collector
+            .GetGrainActivityAsync(cancellationToken: ct)
+            .Where(a => a.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
+        // Trigger new activity
+        await grain.SetValueAsync("post-subscribe");
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        Assert.Single(collected);
+        Assert.Equal(grainId, collected[0].GrainId);
+    }
+
+    [Fact]
+    public async Task GetGrainActivityAsync_cancellation_removes_subscription()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collectTask = fixture.Collector
+            .GetGrainActivityAsync(cancellationToken: cts.Token)
+            .ToListAsync(ct)
+            .AsTask();
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct));
+    }
+}

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorAdvancedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorAdvancedTests.cs
@@ -3,68 +3,85 @@ namespace Egil.Orleans.Testing.Tests;
 public class GrainActivityCollectorAdvancedTests(OrleansTestClusterFixture fixture)
 {
     [Fact]
-    public async Task WaitForStorageOperationAsync_matches_storage_write()
+    public async Task GetStorageOperationsAsync_matches_storage_write()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
 
         await grain.SetValueAsync("written");
 
-        await fixture.Collector.WaitForStorageOperationAsync(
-            operation => operation.Kind == StorageOperationKind.Write && operation.StateName == "state",
-            timeout: TimeSpan.FromSeconds(2),
-            ct: TestContext.Current.CancellationToken);
+        var operation = await fixture.Collector
+            .GetStorageOperationsAsync(includeExisting: true, cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write && op.StateName == "state")
+            .Take(1)
+            .FirstAsync(ct);
+
+        Assert.Equal(StorageOperationKind.Write, operation.Kind);
     }
 
     [Fact]
-    public async Task WaitForStorageOperationAsync_grain_scope_ignores_unrelated_grains_when_called_after_unrelated_action()
+    public async Task GetStorageOperationsAsync_grain_scope_ignores_unrelated_grains()
     {
+        var ct = TestContext.Current.CancellationToken;
         var targetGrain = fixture.GetUniqueGrain<ITestStateGrain>();
         var otherGrain = fixture.GetUniqueGrain<ITestStateGrain>("other");
 
+        var collectTask = fixture.Collector
+            .GetStorageOperationsAsync(targetGrain, cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
         await otherGrain.SetValueAsync("noise");
 
-        var waitTask = fixture.Collector.WaitForStorageOperationAsync(
-            targetGrain,
-            operation => operation.Kind == StorageOperationKind.Write,
-            timeout: TimeSpan.FromSeconds(2),
-            ct: TestContext.Current.CancellationToken);
-
-        Assert.False(waitTask.IsCompleted);
+        Assert.False(collectTask.IsCompleted);
 
         await targetGrain.SetValueAsync("hit");
-        await waitTask;
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        Assert.Single(collected);
+        Assert.Equal(targetGrain.GetGrainId(), collected[0].GrainId);
     }
 
     [Fact]
-    public async Task WaitForGrainCallAsync_matches_grain_call()
+    public async Task GetGrainCallsAsync_matches_grain_call()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
 
         await grain.SetValueAsync("called");
 
-        await fixture.Collector.WaitForGrainCallAsync(
-            context => context.MethodName == nameof(ITestStateGrain.SetValueAsync),
-            timeout: TimeSpan.FromSeconds(2),
-            ct: TestContext.Current.CancellationToken);
+        var call = await fixture.Collector
+            .GetGrainCallsAsync(grain, includeExisting: true, cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync))
+            .Take(1)
+            .FirstAsync(ct);
+
+        Assert.Equal(nameof(ITestStateGrain.SetValueAsync), call.MethodName);
     }
 
     [Fact]
-    public async Task WaitForGrainCallAsync_grain_scope_ignores_unrelated_grains_when_called_after_unrelated_action()
+    public async Task GetGrainCallsAsync_grain_scope_ignores_unrelated_grains()
     {
+        var ct = TestContext.Current.CancellationToken;
         var targetGrain = fixture.GetUniqueGrain<ITestStateGrain>();
         var otherGrain = fixture.GetUniqueGrain<ITestStateGrain>("other");
 
+        var collectTask = fixture.Collector
+            .GetGrainCallsAsync(targetGrain, cancellationToken: ct)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
+
         await otherGrain.SetValueAsync("noise");
 
-        var waitTask = fixture.Collector.WaitForGrainCallAsync(
-            targetGrain,
-            context => context.MethodName == nameof(ITestStateGrain.SetValueAsync),
-            timeout: TimeSpan.FromSeconds(2),
-            ct: TestContext.Current.CancellationToken);
-
-        Assert.False(waitTask.IsCompleted);
+        Assert.False(collectTask.IsCompleted);
 
         await targetGrain.SetValueAsync("hit");
-        await waitTask;
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        Assert.Single(collected);
+        Assert.Equal(targetGrain.GetGrainId(), collected[0].TargetId);
     }
 }

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorBuilderTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorBuilderTests.cs
@@ -92,17 +92,22 @@ public class GrainActivityCollectorBuilderTests
         var decoratedStorage = provider.GetRequiredKeyedService<IGrainStorage>("Default");
         var grainId = GrainId.Create("test-grain", "builder");
         var state = new TestGrainState<string> { ETag = "etag-1", State = "value" };
-        var waitTask = collector.WaitForStorageOperationAsync(
-            operation => operation.StorageName == "Default" && operation.GrainId == grainId,
-            timeout: TimeSpan.FromMilliseconds(250),
-            ct: TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        var collectTask = collector
+            .GetStorageOperationsAsync(cancellationToken: ct)
+            .Where(op => op.StorageName == "Default" && op.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         Assert.Same(collector, provider.GetRequiredService<GrainActivityCollector>());
         Assert.NotSame(storage, decoratedStorage);
 
         await decoratedStorage.WriteStateAsync("state", grainId, state);
-        await waitTask;
+        var collected = await collectTask.WaitAsync(TimeSpan.FromMilliseconds(250), ct);
 
+        Assert.Single(collected);
         Assert.Equal(1, storage.WriteCount);
         Assert.Single(builder.Services, descriptor => descriptor.ServiceType == typeof(object) && descriptor.IsKeyedService && Equals(descriptor.ServiceKey, "Default"));
     }
@@ -159,13 +164,19 @@ public class GrainActivityCollectorBuilderTests
         var decoratedStorage = provider.GetRequiredKeyedService<IGrainStorage>("FactoryBased");
         var grainId = GrainId.Create("test-grain", "factory-based");
         var state = new TestGrainState<string> { ETag = "etag-1", State = "value" };
-        var waitTask = collector.WaitForStorageOperationAsync(
-            operation => operation.StorageName == "FactoryBased" && operation.GrainId == grainId,
-            timeout: TimeSpan.FromMilliseconds(250),
-            ct: TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        var collectTask = collector
+            .GetStorageOperationsAsync(cancellationToken: ct)
+            .Where(op => op.StorageName == "FactoryBased" && op.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await decoratedStorage.WriteStateAsync("state", grainId, state);
-        await waitTask;
+        var collected = await collectTask.WaitAsync(TimeSpan.FromMilliseconds(250), ct);
+
+        Assert.Single(collected);
 
         Assert.NotSame(storage, decoratedStorage);
         Assert.Equal(1, factoryCallCount);

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorBuilderTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorBuilderTests.cs
@@ -184,6 +184,81 @@ public class GrainActivityCollectorBuilderTests
         Assert.Equal(1, storage.WriteCount);
     }
 
+    [Fact]
+    public void CollectStorageActivity_discovers_all_keyed_providers()
+    {
+        var builder = new TestSiloBuilder();
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Default", new FakeGrainStorage()));
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Archive", new FakeGrainStorage()));
+
+        builder.AddGrainActivityCollector(new GrainActivityCollector())
+            .CollectStorageActivity();
+
+        Assert.Single(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::Default"));
+        Assert.Single(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::Archive"));
+        Assert.NotNull(GetSingleDescriptor(builder.Services, "Default").KeyedImplementationFactory);
+        Assert.NotNull(GetSingleDescriptor(builder.Services, "Archive").KeyedImplementationFactory);
+    }
+
+    [Fact]
+    public void CollectStorageActivity_skips_inner_registrations()
+    {
+        var builder = new TestSiloBuilder();
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Default", new FakeGrainStorage()));
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Egil.Orleans.Testing.Inner::Default", new FakeGrainStorage()));
+
+        builder.AddGrainActivityCollector(new GrainActivityCollector())
+            .CollectStorageActivity();
+
+        // The manually added inner registration should not be decorated again
+        Assert.Single(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::Default"));
+    }
+
+    [Fact]
+    public void CollectStorageActivity_is_idempotent()
+    {
+        var builder = new TestSiloBuilder();
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Default", new FakeGrainStorage()));
+
+        var collectorBuilder = builder.AddGrainActivityCollector(new GrainActivityCollector());
+        collectorBuilder.CollectStorageActivity();
+        collectorBuilder.CollectStorageActivity();
+
+        Assert.Single(GetDescriptors(builder.Services, "Default"));
+        Assert.Single(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::Default"));
+    }
+
+    [Fact]
+    public void CollectStorageActivity_ignores_non_keyed_registrations()
+    {
+        var builder = new TestSiloBuilder();
+        // Non-keyed registration — should not be discovered
+        builder.Services.AddSingleton<IGrainStorage>(new FakeGrainStorage());
+        builder.Services.Add(ServiceDescriptor.KeyedSingleton(typeof(IGrainStorage), "Named", new FakeGrainStorage()));
+
+        builder.AddGrainActivityCollector(new GrainActivityCollector())
+            .CollectStorageActivity();
+
+        // Only the keyed "Named" provider should be decorated
+        Assert.Single(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::Named"));
+        Assert.Empty(GetDescriptors(builder.Services, "Egil.Orleans.Testing.Inner::"));
+    }
+
+    [Fact]
+    public void CollectStorageActivity_with_no_providers_is_noop()
+    {
+        var builder = new TestSiloBuilder();
+
+        var collectorBuilder = builder.AddGrainActivityCollector(new GrainActivityCollector());
+
+        // Should not throw
+        collectorBuilder.CollectStorageActivity();
+
+        Assert.DoesNotContain(builder.Services, d =>
+            d.ServiceType == typeof(IGrainStorage) && d.IsKeyedService &&
+            d.ServiceKey is string key && key.StartsWith("Egil.Orleans.Testing.Inner::", StringComparison.Ordinal));
+    }
+
     private static ServiceDescriptor GetSingleDescriptor(IServiceCollection services, object key)
         => Assert.Single(GetDescriptors(services, key));
 

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorCoreTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorCoreTests.cs
@@ -27,48 +27,20 @@ public class GrainActivityCollectorCoreTests
     }
 
     [Fact]
-    public async Task WaitForStorageOperationAsync_with_grain_scope_throws_for_null_grain()
+    public void GetStorageOperationsAsync_grain_scope_throws_for_null_grain()
     {
         var collector = new GrainActivityCollector();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            collector.WaitForStorageOperationAsync<ITestStateGrain>(
-                null!,
-                static _ => true,
-                ct: TestContext.Current.CancellationToken));
+        Assert.Throws<ArgumentNullException>(() =>
+            collector.GetStorageOperationsAsync<ITestStateGrain>(null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
-    public async Task WaitForGrainCallAsync_with_grain_scope_throws_for_null_grain()
+    public void GetGrainCallsAsync_grain_scope_throws_for_null_grain()
     {
         var collector = new GrainActivityCollector();
 
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            collector.WaitForGrainCallAsync<ITestStateGrain>(
-                null!,
-                static _ => true,
-                ct: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task WaitForStorageOperationAsync_throws_for_null_predicate()
-    {
-        var collector = new GrainActivityCollector();
-
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            collector.WaitForStorageOperationAsync(
-                (Func<StorageOperation, bool>)null!,
-                ct: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task WaitForGrainCallAsync_throws_for_null_predicate()
-    {
-        var collector = new GrainActivityCollector();
-
-        await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            collector.WaitForGrainCallAsync(
-                (Func<IIncomingGrainCallContext, bool>)null!,
-                ct: TestContext.Current.CancellationToken));
+        Assert.Throws<ArgumentNullException>(() =>
+            collector.GetGrainCallsAsync<ITestStateGrain>(null!, cancellationToken: TestContext.Current.CancellationToken));
     }
 }

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorDisposeTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorDisposeTests.cs
@@ -23,36 +23,12 @@ public class GrainActivityCollectorDisposeTests
     }
 
     [Fact]
-    public async Task WaitForStorageOperationAsync_throws_ObjectDisposedException_after_dispose()
+    public async Task GetStorageOperationsAsync_throws_ObjectDisposedException_after_dispose()
     {
         var collector = new GrainActivityCollector();
         collector.Dispose();
 
-        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            collector.WaitForStorageOperationAsync(
-                static _ => true,
-                ct: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task WaitForGrainCallAsync_throws_ObjectDisposedException_after_dispose()
-    {
-        var collector = new GrainActivityCollector();
-        collector.Dispose();
-
-        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            collector.WaitForGrainCallAsync(
-                static _ => true,
-                ct: TestContext.Current.CancellationToken));
-    }
-
-    [Fact]
-    public async Task SubscribeToStorageOperations_throws_ObjectDisposedException_after_dispose()
-    {
-        var collector = new GrainActivityCollector();
-        collector.Dispose();
-
-        var enumerable = collector.SubscribeToStorageOperations(TestContext.Current.CancellationToken);
+        var enumerable = collector.GetStorageOperationsAsync(cancellationToken: TestContext.Current.CancellationToken);
         await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
         {
             await foreach (var _ in enumerable)
@@ -62,12 +38,27 @@ public class GrainActivityCollectorDisposeTests
     }
 
     [Fact]
-    public async Task SubscribeToGrainCalls_throws_ObjectDisposedException_after_dispose()
+    public async Task GetGrainCallsAsync_throws_ObjectDisposedException_after_dispose()
     {
         var collector = new GrainActivityCollector();
         collector.Dispose();
 
-        var enumerable = collector.SubscribeToGrainCalls(TestContext.Current.CancellationToken);
+        var enumerable = collector.GetGrainCallsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+        {
+            await foreach (var _ in enumerable)
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task GetGrainActivityAsync_throws_ObjectDisposedException_after_dispose()
+    {
+        var collector = new GrainActivityCollector();
+        collector.Dispose();
+
+        var enumerable = collector.GetGrainActivityAsync(cancellationToken: TestContext.Current.CancellationToken);
         await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
         {
             await foreach (var _ in enumerable)
@@ -91,38 +82,6 @@ public class GrainActivityCollectorDisposeTests
             ct: TestContext.Current.CancellationToken);
 
         await waitStarted.Task;
-        collector.Dispose();
-
-        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
-    }
-
-    [Fact]
-    public async Task WaitForStorageOperationAsync_throws_ObjectDisposedException_when_disposed_during_wait()
-    {
-        var collector = new GrainActivityCollector();
-
-        var waitTask = collector.WaitForStorageOperationAsync(
-            _ => false,
-            ct: TestContext.Current.CancellationToken);
-
-        // Give the wait time to subscribe and block on ReadAllAsync.
-        await Task.Yield();
-        collector.Dispose();
-
-        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
-    }
-
-    [Fact]
-    public async Task WaitForGrainCallAsync_throws_ObjectDisposedException_when_disposed_during_wait()
-    {
-        var collector = new GrainActivityCollector();
-
-        var waitTask = collector.WaitForGrainCallAsync(
-            _ => false,
-            ct: TestContext.Current.CancellationToken);
-
-        // Give the wait time to subscribe and block on ReadAllAsync.
-        await Task.Yield();
         collector.Dispose();
 
         await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorGrainCallFeedTests.cs
@@ -3,14 +3,14 @@ namespace Egil.Orleans.Testing.Tests;
 public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture fixture)
 {
     [Fact]
-    public async Task SubscribeToGrainCalls_receives_grain_calls()
+    public async Task GetGrainCallsAsync_receives_grain_calls()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
 
         // Use grain-scoped feed to avoid collecting unrelated system grain calls from the shared cluster
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(grain, ct)
+            .GetGrainCallsAsync(grain, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
@@ -25,14 +25,14 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     }
 
     [Fact]
-    public async Task SubscribeToGrainCalls_grain_scoped_ignores_unrelated_grains()
+    public async Task GetGrainCallsAsync_grain_scoped_ignores_unrelated_grains()
     {
         var ct = TestContext.Current.CancellationToken;
         var target = fixture.GetUniqueGrain<ITestStateGrain>();
         var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
 
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(target, ct)
+            .GetGrainCallsAsync(target, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
@@ -49,7 +49,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     }
 
     [Fact]
-    public async Task SubscribeToGrainCalls_is_future_only()
+    public async Task GetGrainCallsAsync_is_future_only_by_default()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
@@ -58,13 +58,14 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
         await grain.SetValueAsync("before-subscribe");
 
         // Deterministically wait for the pre-subscribe call to be observed
-        await fixture.Collector.WaitForGrainCallAsync(
-            grain,
-            ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync),
-            ct: ct);
+        await fixture.Collector
+            .GetGrainCallsAsync(grain, includeExisting: true, cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(ITestStateGrain.SetValueAsync))
+            .Take(1)
+            .FirstAsync(ct);
 
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(grain, ct)
+            .GetGrainCallsAsync(grain, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
@@ -81,7 +82,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     }
 
     [Fact]
-    public async Task SubscribeToGrainCalls_global_receives_events()
+    public async Task GetGrainCallsAsync_global_receives_events()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
@@ -89,7 +90,7 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
 
         // Use global overload, but filter to our grain to avoid cross-test noise
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(ct)
+            .GetGrainCallsAsync(cancellationToken: ct)
             .Where(ctx => ctx.TargetId == grainId)
             .Take(1)
             .ToListAsync(ct)
@@ -104,13 +105,13 @@ public class GrainActivityCollectorGrainCallFeedTests(OrleansTestClusterFixture 
     }
 
     [Fact]
-    public async Task SubscribeToGrainCalls_cancellation_removes_subscription()
+    public async Task GetGrainCallsAsync_cancellation_removes_subscription()
     {
         var ct = TestContext.Current.CancellationToken;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var collectTask = fixture.Collector
-            .SubscribeToGrainCalls(cts.Token)
+            .GetGrainCallsAsync(cancellationToken: cts.Token)
             .ToListAsync(ct)
             .AsTask();
 

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorOneWayTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorOneWayTests.cs
@@ -3,17 +3,22 @@ namespace Egil.Orleans.Testing.Tests;
 public class GrainActivityCollectorOneWayTests(OrleansTestClusterFixture fixture)
 {
     [Fact]
-    public async Task WaitForGrainCallAsync_matches_oneway_method()
+    public async Task GetGrainCallsAsync_matches_oneway_method()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IOneWayActivityGrain>();
-        var waitTask = fixture.Collector.WaitForGrainCallAsync(
-            grain,
-            context => context.MethodName == nameof(IOneWayActivityGrain.NotifyAsync),
-            timeout: TimeSpan.FromSeconds(2),
-            ct: TestContext.Current.CancellationToken);
+
+        var collectTask = fixture.Collector
+            .GetGrainCallsAsync(grain, cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(IOneWayActivityGrain.NotifyAsync))
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await grain.NotifyAsync("ready");
-        await waitTask;
+
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        Assert.Single(collected);
     }
 
     [Fact]

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorReminderTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorReminderTests.cs
@@ -20,20 +20,24 @@ public class GrainActivityCollectorReminderTests(OrleansReminderTestClusterFixtu
     }
 
     [Fact]
-    public async Task WaitForGrainCallAsync_observes_reminder_callbacks()
+    public async Task GetGrainCallsAsync_observes_reminder_callbacks()
     {
+        var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<IReminderActivityGrain>();
 
-        var waitTask = fixture.Collector.WaitForGrainCallAsync(
-            grain,
-            context => context.MethodName == nameof(IRemindable.ReceiveReminder),
-            ct: TestContext.Current.CancellationToken);
+        var collectTask = fixture.Collector
+            .GetGrainCallsAsync(grain, cancellationToken: ct)
+            .Where(ctx => ctx.MethodName == nameof(IRemindable.ReceiveReminder))
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await grain.StartReminderAsync("ready");
 
         // Advance the deterministic clock past the reminder due time.
-        await fixture.ReminderClock.AdvanceAsync(TimeSpan.FromMinutes(2), TestContext.Current.CancellationToken);
+        await fixture.ReminderClock.AdvanceAsync(TimeSpan.FromMinutes(2), ct);
 
-        await waitTask;
+        var collected = await collectTask.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        Assert.Single(collected);
     }
 }

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/GrainActivityCollectorStorageFeedTests.cs
@@ -3,13 +3,13 @@ namespace Egil.Orleans.Testing.Tests;
 public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fixture)
 {
     [Fact]
-    public async Task SubscribeToStorageOperations_receives_write_and_read()
+    public async Task GetStorageOperationsAsync_receives_write_and_read()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
 
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Take(2)
             .ToListAsync(ct)
             .AsTask();
@@ -24,14 +24,14 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_grain_scoped_ignores_unrelated_grains()
+    public async Task GetStorageOperationsAsync_grain_scoped_ignores_unrelated_grains()
     {
         var ct = TestContext.Current.CancellationToken;
         var target = fixture.GetUniqueGrain<ITestStateGrain>();
         var other = fixture.GetUniqueGrain<ITestStateGrain>("other");
 
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(target, ct)
+            .GetStorageOperationsAsync(target, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
@@ -48,7 +48,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_is_future_only()
+    public async Task GetStorageOperationsAsync_is_future_only_by_default()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
@@ -57,13 +57,14 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         await grain.SetValueAsync("before-subscribe");
 
         // Deterministically wait for that write to be observed by the collector
-        await fixture.Collector.WaitForStorageOperationAsync(
-            grain,
-            op => op.Kind == StorageOperationKind.Write,
-            ct: ct);
+        await fixture.Collector
+            .GetStorageOperationsAsync(grain, includeExisting: true, cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write)
+            .Take(1)
+            .FirstAsync(ct);
 
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Where(op => op.Kind == StorageOperationKind.Write)
             .Take(1)
             .ToListAsync(ct)
@@ -81,14 +82,14 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_collects_many_sequential_writes()
+    public async Task GetStorageOperationsAsync_collects_many_sequential_writes()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
         const int operationCount = 50;
 
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Where(op => op.Kind == StorageOperationKind.Write)
             .Take(operationCount)
             .ToListAsync(ct)
@@ -106,13 +107,13 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_cancellation_removes_subscription()
+    public async Task GetStorageOperationsAsync_cancellation_removes_subscription()
     {
         var ct = TestContext.Current.CancellationToken;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(cts.Token)
+            .GetStorageOperationsAsync(cancellationToken: cts.Token)
             .ToListAsync(ct)
             .AsTask();
 
@@ -124,7 +125,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_global_receives_events()
+    public async Task GetStorageOperationsAsync_global_receives_events()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
@@ -132,7 +133,7 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
 
         // Use global overload, but filter to our grain to avoid cross-test noise
         var collectTask = fixture.Collector
-            .SubscribeToStorageOperations(ct)
+            .GetStorageOperationsAsync(cancellationToken: ct)
             .Where(op => op.GrainId == grainId)
             .Take(1)
             .ToListAsync(ct)
@@ -147,19 +148,19 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
     }
 
     [Fact]
-    public async Task SubscribeToStorageOperations_multiple_concurrent_subscribers()
+    public async Task GetStorageOperationsAsync_multiple_concurrent_subscribers()
     {
         var ct = TestContext.Current.CancellationToken;
         var grain = fixture.GetUniqueGrain<ITestStateGrain>();
 
         var feed1 = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
 
         var feed2 = fixture.Collector
-            .SubscribeToStorageOperations(grain, ct)
+            .GetStorageOperationsAsync(grain, cancellationToken: ct)
             .Take(1)
             .ToListAsync(ct)
             .AsTask();
@@ -173,4 +174,3 @@ public class GrainActivityCollectorStorageFeedTests(OrleansTestClusterFixture fi
         Assert.NotEmpty(collected2);
     }
 }
-

--- a/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/StorageObserverTests.cs
+++ b/Egil.Orleans.Testing/test/Egil.Orleans.Testing.Tests/StorageObserverTests.cs
@@ -12,19 +12,24 @@ public class StorageObserverTests
         using var harness = CreateHarness(new FakeGrainStorage());
         var grainId = GrainId.Create("test-grain", "write");
         var state = new TestGrainState<string> { ETag = "etag-1", State = "value" };
-        var waitTask = harness.Collector.WaitForStorageOperationAsync(
-            operation => operation.Kind == StorageOperationKind.Write
-                && operation.GrainId == grainId
-                && operation.StorageName == "Default"
-                && operation.StateName == "state"
-                && Equals(operation.State, "value")
-                && operation.Etag == "etag-1",
-            timeout: TimeSpan.FromMilliseconds(250),
-            ct: TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        var collectTask = harness.Collector
+            .GetStorageOperationsAsync(cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Write
+                && op.GrainId == grainId
+                && op.StorageName == "Default"
+                && op.StateName == "state"
+                && Equals(op.State, "value")
+                && op.Etag == "etag-1")
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await harness.Storage.WriteStateAsync("state", grainId, state);
-        await waitTask;
+        var collected = await collectTask.WaitAsync(TimeSpan.FromMilliseconds(250), ct);
 
+        Assert.Single(collected);
         Assert.Equal(1, harness.Inner.WriteCount);
     }
 
@@ -34,14 +39,19 @@ public class StorageObserverTests
         using var harness = CreateHarness(new FakeGrainStorage());
         var grainId = GrainId.Create("test-grain", "read");
         var state = new TestGrainState<string> { ETag = "etag-2", State = "value" };
-        var waitTask = harness.Collector.WaitForStorageOperationAsync(
-            operation => operation.Kind == StorageOperationKind.Read && operation.GrainId == grainId,
-            timeout: TimeSpan.FromMilliseconds(250),
-            ct: TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        var collectTask = harness.Collector
+            .GetStorageOperationsAsync(cancellationToken: ct)
+            .Where(op => op.Kind == StorageOperationKind.Read && op.GrainId == grainId)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         await harness.Storage.ReadStateAsync("state", grainId, state);
-        await waitTask;
+        var collected = await collectTask.WaitAsync(TimeSpan.FromMilliseconds(250), ct);
 
+        Assert.Single(collected);
         Assert.Equal(1, harness.Inner.ReadCount);
     }
 
@@ -51,10 +61,15 @@ public class StorageObserverTests
         using var harness = CreateHarness(new FakeGrainStorage());
         var grainId = GrainId.Create("test-grain", "clear");
         var state = new TestGrainState<string> { ETag = "etag-3", State = "value" };
-        var waitTask = harness.Collector.WaitForStorageOperationAsync(
-            _ => true,
-            timeout: TimeSpan.FromMilliseconds(100),
-            ct: TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var collectTask = harness.Collector
+            .GetStorageOperationsAsync(cancellationToken: cts.Token)
+            .Take(1)
+            .ToListAsync(ct)
+            .AsTask();
 
         using (RequestContextScope.ForAssertion())
         {
@@ -62,7 +77,11 @@ public class StorageObserverTests
         }
 
         Assert.Equal(1, harness.Inner.ClearCount);
-        await Assert.ThrowsAsync<WaitForAssertionTimeoutException>(() => waitTask);
+
+        // Cancel after a short delay to verify no event was published
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collectTask.WaitAsync(TimeSpan.FromMilliseconds(250), ct));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Replace `WaitForStorageOperationAsync`, `WaitForGrainCallAsync`, and `SubscribeTo*` methods with a unified `IAsyncEnumerable<T>`-based API. The new methods return live feeds composable with LINQ operators like `Where`, `Take`, and `Select`, making it straightforward to wait for a specific number of events.

## Breaking Changes

**Removed methods:**
- `WaitForStorageOperationAsync` (2 overloads)
- `WaitForGrainCallAsync` (2 overloads)
- `SubscribeToStorageOperations` (2 overloads)
- `SubscribeToGrainCalls` (2 overloads)

**New methods:**
- `GetGrainActivityAsync(bool includeExisting, CancellationToken)` — core `IAsyncEnumerable<GrainActivity>` stream
- `GetStorageOperationsAsync` — global + grain-scoped overloads returning `IAsyncEnumerable<StorageOperation>`
- `GetGrainCallsAsync` — global + grain-scoped overloads returning `IAsyncEnumerable<IIncomingGrainCallContext>`
- `CollectStorageActivity()` — auto-discovers and decorates all keyed `IGrainStorage` registrations

## Migration

```csharp
// Before:
await collector.WaitForStorageOperationAsync(
    op => op.Kind == StorageOperationKind.Write && op.GrainId == grain.GetGrainId(),
    ct: ct);

// After:
var write = await collector
    .GetStorageOperationsAsync(grain, cancellationToken: ct)
    .Where(op => op.Kind == StorageOperationKind.Write)
    .Take(1)
    .FirstAsync(ct);
```

## Internal simplification

- 5 subscriber lists → 1
- 3 locks → 1  
- 2 history queues → 1
- `GrainActivity` extended with optional `StorageOperation?` and `IIncomingGrainCallContext?` properties

## Tests

96 tests passing (84 unit/integration + 12 sample tests).