### PR TITLE
fix(stjm): reject invalid target-owned migrator contracts

### DIFF
--- a/Egil.SystemTextJson.Migration/README.md
+++ b/Egil.SystemTextJson.Migration/README.md
@@ -39,9 +39,20 @@ public record UserV2(string FirstName, string LastName, int Age);
 <!-- endSnippet -->
 
 
+### Choosing a migration contract
+
+Use the contract that matches where the migration logic lives:
+
+| Scenario | Interface | Registration |
+|----------|-----------|--------------|
+| The current `[JsonMigratable]` target type owns the migration logic | `IMigrateFrom<TSource, TTarget>` | No `RegisterMigrator*` call. The target type's contracts are discovered automatically when its converter is created. |
+| A separate external class owns the migration logic | `IMigrate<TSource, TTarget>` | Register the migrator with `RegisterMigrator*` or `RegisterMigratorsFrom*`. |
+
+Do not implement `IMigrate<TSource, TTarget>` directly on a `[JsonMigratable]` type. That interface is reserved for separate external migrator classes.
+
 ### Static migration
 
-When the migration logic naturally belongs on the target type, implement `IMigrateFrom` directly:
+When the migration logic naturally belongs on the target type, implement `IMigrateFrom` directly. These target-owned migrations are discovered automatically; no `RegisterMigrator*` or `RegisterMigratorsFrom*` call is needed:
 
 <!-- snippet: static_migration_type -->
 <a id='snippet-static_migration_type'></a>
@@ -119,7 +130,7 @@ CustomerNameV1 customer = JsonSerializer.Deserialize<CustomerNameV1>(json, optio
 
 ### External migration
 
-When migration logic should live in its own class — for separation of concerns, testability, or because you don't control the target type — implement `IMigrate` and register it:
+When migration logic should live in its own separate class — for separation of concerns, testability, dependency injection, or because you don't control the target type — implement `IMigrate` and register it:
 
 <!-- snippet: external_migrator -->
 <a id='snippet-external_migrator'></a>
@@ -254,7 +265,7 @@ If no service provider is configured, the library falls back to creating the mig
 
 ### Assembly scanning
 
-Register all `IMigrate<,>` implementations in one or more assemblies instead of listing each one:
+Register external `IMigrate<,>` migrator classes in one or more assemblies instead of listing each one. Assembly scanning is not required for target-owned `IMigrateFrom<,>` migrations:
 
 <!-- snippet: assembly_scanning -->
 <a id='snippet-assembly_scanning'></a>

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/JsonMigrationInvalidTargetMigratorException.cs
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/JsonMigrationInvalidTargetMigratorException.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+
+namespace Egil.SystemTextJson.Migration;
+
+/// <summary>
+/// Thrown when a JSON migratable type implements the external migrator contract directly.
+/// </summary>
+public sealed class JsonMigrationInvalidTargetMigratorException : JsonException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMigrationInvalidTargetMigratorException"/> class.
+    /// </summary>
+    public JsonMigrationInvalidTargetMigratorException(Type targetType, Type migratorContractType)
+        : base(CreateMessage(targetType, migratorContractType))
+    {
+        TargetType = targetType;
+        MigratorContractType = migratorContractType;
+    }
+
+    /// <summary>
+    /// Gets the JSON migratable type with the invalid migrator contract.
+    /// </summary>
+    public Type TargetType { get; }
+
+    /// <summary>
+    /// Gets the invalid <see cref="IMigrate{TSource,TTarget}"/> contract implemented by <see cref="TargetType"/>.
+    /// </summary>
+    public Type MigratorContractType { get; }
+
+    private static string CreateMessage(Type targetType, Type migratorContractType)
+    {
+        ArgumentNullException.ThrowIfNull(targetType);
+        ArgumentNullException.ThrowIfNull(migratorContractType);
+
+        return
+            $"JSON migratable type '{targetType.FullName}' implements external migrator contract '{migratorContractType.FullName}', which is not supported. " +
+            $"Types marked with '{nameof(JsonMigratableAttribute)}' must use 'IMigrateFrom<TSource,TTarget>' for target-owned migrations; those contracts are discovered automatically when migration support creates the converter. " +
+            "Use 'IMigrate<TSource,TTarget>' only on separate external migrator classes, and register those classes with RegisterMigrator*, RegisterMigrator<TMigrator>(), RegisterMigratorsFromAssembly, or RegisterMigratorsFromAssemblies. " +
+            "See the 'Choosing a migration contract' section in the Egil.SystemTextJson.Migration README: https://github.com/egil/framework/tree/main/Egil.SystemTextJson.Migration#choosing-a-migration-contract";
+    }
+}

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverterFactory.cs
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/Migrations/JsonMigratableConverterFactory.cs
@@ -32,6 +32,8 @@ internal sealed class JsonMigratableConverterFactory(JsonMigrationRegistry regis
 
     private JsonConverter CreateConverterCore(Type typeToConvert, JsonSerializerOptions options)
     {
+        ValidateTargetMigratorContracts(typeToConvert);
+
         TypeMetadata targetMetadata = registry.GetTypeMetadata(typeToConvert);
 
         // Clone options and replace this factory with a type-excluding instance so metadata lookup can still
@@ -122,6 +124,21 @@ internal sealed class JsonMigratableConverterFactory(JsonMigrationRegistry regis
         }
 
         return [.. migrators.Values.Select(static candidate => candidate.Migrator)];
+    }
+
+    private static void ValidateTargetMigratorContracts(Type targetType)
+    {
+        foreach (Type @interface in targetType.GetInterfaces())
+        {
+            if (!@interface.IsGenericType
+                || @interface.ContainsGenericParameters
+                || @interface.GetGenericTypeDefinition() != typeof(IMigrate<,>))
+            {
+                continue;
+            }
+
+            throw new JsonMigrationInvalidTargetMigratorException(targetType, @interface);
+        }
     }
 
     private static MigratorReference? ResolveUndiscriminatedSourceMigrator(

--- a/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/RegistrationAndTrackingTests.cs
+++ b/Egil.SystemTextJson.Migration/test/Egil.SystemTextJson.Migration.Tests/RegistrationAndTrackingTests.cs
@@ -55,6 +55,59 @@ public class RegistrationAndTrackingTests
     }
 
     [Fact]
+    public void Target_owned_static_migrator_is_discovered_without_registration()
+    {
+        var options = CreateOptions();
+
+        var json = JsonSerializer.Serialize(new PrecedenceV1("Egil Hansen", 42), options);
+        var migrated = JsonSerializer.Deserialize<PrecedenceV2>(json, options);
+
+        Assert.NotNull(migrated);
+        Assert.Equal("static", migrated.MigrationPath);
+    }
+
+    [Fact]
+    public void Json_migratable_type_implementing_external_migrator_contract_for_itself_throws_detailed_error()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        var exception = Assert.Throws<JsonMigrationInvalidTargetMigratorException>(
+            () => JsonSerializer.Deserialize<InvalidSelfMigratorTarget>("{}", options));
+
+        Assert.Equal(typeof(InvalidSelfMigratorTarget), exception.TargetType);
+        Assert.Equal(
+            typeof(IMigrate<InvalidSelfMigratorSource, InvalidSelfMigratorTarget>),
+            exception.MigratorContractType);
+        Assert.Contains(nameof(InvalidSelfMigratorTarget), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("IMigrate<", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("IMigrateFrom<", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("RegisterMigrator", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Choosing a migration contract", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("README", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Json_migratable_type_implementing_external_migrator_contract_for_other_target_throws_detailed_error()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.AddJsonMigrationSupport();
+
+        var exception = Assert.Throws<JsonMigrationInvalidTargetMigratorException>(
+            () => JsonSerializer.Deserialize<InvalidOtherMigratorHost>("{}", options));
+
+        Assert.Equal(typeof(InvalidOtherMigratorHost), exception.TargetType);
+        Assert.Equal(
+            typeof(IMigrate<InvalidOtherMigratorSource, InvalidOtherMigratorTarget>),
+            exception.MigratorContractType);
+        Assert.Contains(nameof(InvalidOtherMigratorHost), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(InvalidOtherMigratorTarget), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("IMigrateFrom<", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("RegisterMigratorsFrom", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Choosing a migration contract", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Scoped_assembly_scan_registers_external_migrator()
     {
         var options = CreateOptions(builder => builder.RegisterMigratorsFromAssembly(typeof(TrackingExternalMigrator).Assembly));
@@ -411,6 +464,37 @@ public class PrecedenceExternalMigrator : IMigrate<PrecedenceV1, PrecedenceV2>
             names.Length > 1 ? names[1] : string.Empty,
             source.Age,
             "external");
+        return true;
+    }
+}
+
+[JsonMigratable]
+public record class InvalidSelfMigratorSource(string Name);
+
+[JsonMigratable]
+public record class InvalidSelfMigratorTarget(string Name) :
+    IMigrate<InvalidSelfMigratorSource, InvalidSelfMigratorTarget>
+{
+    public bool TryMigrateFrom(InvalidSelfMigratorSource source, out InvalidSelfMigratorTarget result)
+    {
+        result = new InvalidSelfMigratorTarget(source.Name);
+        return true;
+    }
+}
+
+[JsonMigratable]
+public record class InvalidOtherMigratorSource(string Name);
+
+[JsonMigratable]
+public record class InvalidOtherMigratorTarget(string Name);
+
+[JsonMigratable]
+public record class InvalidOtherMigratorHost(string Name) :
+    IMigrate<InvalidOtherMigratorSource, InvalidOtherMigratorTarget>
+{
+    public bool TryMigrateFrom(InvalidOtherMigratorSource source, out InvalidOtherMigratorTarget result)
+    {
+        result = new InvalidOtherMigratorTarget(source.Name);
         return true;
     }
 }


### PR DESCRIPTION
## Why

Target-owned migrations are already discovered through `IMigrateFrom<TSource,TTarget>`, but it is easy to misremember the contract split and implement `IMigrate<TSource,TTarget>` directly on a `[JsonMigratable]` type. That mistake previously looked like missing discovery behavior instead of an invalid contract choice.

## What changed

- Adds public `JsonMigrationInvalidTargetMigratorException` with the invalid target type, offending migrator contract, and actionable guidance.
- Fails fast during migratable converter creation when a `[JsonMigratable]` type implements any closed `IMigrate<,>` contract.
- Keeps `IMigrate<,>` as the external-migrator-only contract and leaves target-owned `IMigrateFrom<,>` discovery unchanged.
- Updates README guidance with a stable "Choosing a migration contract" section and clarifies when registration APIs are required.
- Adds tests for automatic target-owned discovery and the new detailed diagnostic.

## Validation

- `dotnet test --project .\test\Egil.SystemTextJson.Migration.Tests\Egil.SystemTextJson.Migration.Tests.csproj -c Release -v minimal -- --filter-class Egil.SystemTextJson.Migration.Tests.RegistrationAndTrackingTests`
- `dotnet test --solution .\Egil.SystemTextJson.Migration.slnx -c Release -v minimal`
- `dotnet build .\Egil.SystemTextJson.Migration.slnx -c Release -v minimal`