### PR TITLE
docs(stjm): document [JsonPolymorphic] incompatibility

### DIFF
--- a/Egil.SystemTextJson.Migration/docs/recipes/README.md
+++ b/Egil.SystemTextJson.Migration/docs/recipes/README.md
@@ -69,6 +69,10 @@ All code samples are extracted from the [samples project](../../samples/Egil.Sys
 - [Using `IJsonOnSerializing` to prepare data before serialization](stj-features.md#using-ijsononserializing-to-prepare-data-before-serialization)
 - [Combining `IJsonOnDeserialized` with `IJsonMigrationTracked`](stj-features.md#combining-ijsonondeserialized-with-ijsonmigrationtracked)
 
+## Polymorphism
+
+- [`[JsonPolymorphic]` compatibility](polymorphism.md) — current limitation and recommended workarounds
+
 ## Real-world integration patterns
 
 - [Database / cache migration on read](integration-patterns.md#database--cache-migration-on-read)

--- a/Egil.SystemTextJson.Migration/docs/recipes/polymorphism.md
+++ b/Egil.SystemTextJson.Migration/docs/recipes/polymorphism.md
@@ -1,0 +1,76 @@
+# Polymorphism (`[JsonPolymorphic]`) Compatibility
+
+This page documents a current limitation: **`[JsonMigratable]` cannot be combined with `[JsonPolymorphic]` / `[JsonDerivedType]` on the same type hierarchy**. It explains why, what happens if you try, and the recommended workarounds.
+
+## Summary
+
+| Scenario | Supported? |
+|----------|------------|
+| `[JsonPolymorphic]` on a base type with `[JsonDerivedType]` entries (no `[JsonMigratable]` anywhere in the hierarchy) | ✅ Works — uses System.Text.Json's built-in polymorphism |
+| `[JsonMigratable]` on a non-polymorphic type | ✅ Works — this is the library's primary scenario |
+| `[JsonMigratable]` on a `[JsonPolymorphic]` base type | ❌ Throws `NotSupportedException` at type-info configuration time |
+| `[JsonPolymorphic]` on a base, `[JsonMigratable]` on a derived `[JsonDerivedType]` entry | ❌ Throws `NotSupportedException` at deserialization time |
+
+## Why it doesn't work
+
+System.Text.Json's polymorphic infrastructure requires every converter in a polymorphic hierarchy to support the internal **metadata protocol** — the read-ahead state machine that handles the `$type` discriminator property.
+
+The gating check is the `JsonConverter.CanHaveMetadata` property:
+
+```csharp
+// In System.Text.Json (internal):
+internal virtual bool CanHaveMetadata => false;
+```
+
+This property is `internal virtual`. It defaults to `false` for all custom `JsonConverter<T>` implementations and is overridden to `true` only by built-in converters such as `ObjectDefaultConverter<T>`. There is no public extensibility point for it (see [dotnet/runtime#118900](https://github.com/dotnet/runtime/issues/118900) for the open API proposal to expose it).
+
+When STJ configures a polymorphic type, it calls into `PolymorphicTypeResolver`, which inspects `Converter.CanHaveMetadata`:
+
+```csharp
+// In PolymorphicTypeResolver constructor:
+if (UsesTypeDiscriminators && !converterCanHaveMetadata)
+{
+    ThrowHelper.ThrowNotSupportedException_BaseConverterDoesNotSupportMetadata(BaseType);
+}
+```
+
+Because `JsonMigratableConverter<T>` is a custom `JsonConverter<T>`, it inherits `CanHaveMetadata == false`. That trips the check above the moment the polymorphic type info is built.
+
+## What you'll see
+
+Either of these exceptions:
+
+```
+System.NotSupportedException: The converter for derived type 'YourType'
+does not support metadata writes or reads.
+```
+
+The first form fires at type-info configuration time when `[JsonMigratable]` is on the polymorphic base. The second fires at serialization/deserialization time when `[JsonMigratable]` is on a derived `[JsonDerivedType]` entry.
+
+## Recommended workarounds
+
+### Option 1 — Use `[JsonMigratable]` discriminator-based dispatch instead of `[JsonPolymorphic]`
+
+`[JsonMigratable]` already provides discriminator-based dispatch — it just calls the property `$type` (or whatever you configure via `TypeDiscriminatorPropertyName`) and the value `TypeDiscriminator`. If your only reason to use `[JsonPolymorphic]` was to dispatch to subtypes by a discriminator, model each subtype as a `[JsonMigratable]` type and migrate between them as needed:
+
+```csharp
+[JsonMigratable(TypeDiscriminator = "dog")]
+public class Dog { /* ... */ }
+
+[JsonMigratable(TypeDiscriminator = "cat")]
+public class Cat { /* ... */ }
+```
+
+Deserialize as the concrete type, or as a base interface, depending on your call site needs. See [type-discriminators.md](type-discriminators.md) for customization options.
+
+### Option 2 — Keep `[JsonPolymorphic]` and migrate at the leaf types only
+
+If you need full STJ polymorphism (for example, you rely on `JsonUnknownDerivedTypeHandling`, source-generator emission, or interop with another tool), keep `[JsonPolymorphic]` on the base type and **do not** put `[JsonMigratable]` anywhere in the hierarchy. Handle version migration outside the polymorphic layer — for example, deserialize the polymorphic payload, then transform old derived types to current ones in your application code.
+
+### Option 3 — Wrap migratable types behind a non-polymorphic boundary
+
+If a class needs to participate in a polymorphic hierarchy and also evolve over time, expose a stable wrapper type to the polymorphic layer and put `[JsonMigratable]` on the wrapper's payload property type instead of the wrapper itself. The polymorphic layer sees only the stable wrapper; the migration layer handles the inner payload.
+
+## Future support
+
+The .NET 11 timeframe is introducing `JsonTypeClassifier` ([dotnet/runtime#125449](https://github.com/dotnet/runtime/issues/125449), [#127299](https://github.com/dotnet/runtime/issues/127299)) — a new abstraction that lets custom code drive polymorphic type dispatch. If that ships and `CanHaveMetadata` becomes overridable ([dotnet/runtime#118900](https://github.com/dotnet/runtime/issues/118900)), it should become possible to combine `[JsonMigratable]` with STJ-level polymorphism. This is being tracked; until then, use one of the workarounds above.

--- a/Egil.SystemTextJson.Migration/docs/recipes/stj-features.md
+++ b/Egil.SystemTextJson.Migration/docs/recipes/stj-features.md
@@ -2,6 +2,8 @@
 
 These are built-in `System.Text.Json` interfaces that complement the migration library. They are not part of this library, but they are commonly needed in migration scenarios.
 
+> **Note on `[JsonPolymorphic]` / `[JsonDerivedType]`:** These STJ attributes **cannot** be combined with `[JsonMigratable]` on the same type hierarchy. See [polymorphism.md](polymorphism.md) for the reason and recommended workarounds.
+
 ## Using `IJsonOnDeserialized` for post-migration validation
 
 Implement `IJsonOnDeserialized` on the target type to validate or normalize data after deserialization. This runs for current-format payloads deserialized by STJ:

--- a/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/JsonMigratableAttribute.cs
+++ b/Egil.SystemTextJson.Migration/src/Egil.SystemTextJson.Migration/JsonMigratableAttribute.cs
@@ -3,6 +3,18 @@ namespace Egil.SystemTextJson.Migration;
 /// <summary>
 /// Marks a type as migration-aware during JSON serialization and deserialization.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This attribute cannot be combined with <c>[JsonPolymorphic]</c> / <c>[JsonDerivedType]</c>
+/// on the same type hierarchy. System.Text.Json's polymorphic infrastructure requires every
+/// converter in a polymorphic hierarchy to support its internal metadata protocol, which is
+/// not extensible from outside the runtime assembly. Attempting to combine the two throws
+/// <see cref="NotSupportedException"/> at type-info configuration or (de)serialization time.
+/// </para>
+/// <para>
+/// See the <c>polymorphism.md</c> recipe for details and recommended workarounds.
+/// </para>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
 public sealed class JsonMigratableAttribute : Attribute
 {


### PR DESCRIPTION
## Summary

Document the current limitation that `[JsonMigratable]` cannot be combined with System.Text.Json's `[JsonPolymorphic]` / `[JsonDerivedType]` on the same type hierarchy.

## Why this limitation exists

STJ's polymorphic infrastructure requires every converter in a polymorphic hierarchy to support its internal metadata protocol, gated by the `internal virtual JsonConverter.CanHaveMetadata` property. That property defaults to `false` for all custom `JsonConverter<T>` implementations and is not extensible from outside the runtime assembly (tracked upstream in [dotnet/runtime#118900](https://github.com/dotnet/runtime/issues/118900)). The migration converter therefore trips `PolymorphicTypeResolver`'s check and STJ throws:

```
The converter for derived type 'X' does not support metadata writes or reads.
```

Empirical investigation confirmed this fails in every combination of `[JsonMigratable]` placement (base type, derived `[JsonDerivedType]` entries, or both). Only pure-STJ polymorphism with no `[JsonMigratable]` anywhere in the hierarchy works.

## Changes

- **New recipe**: `Egil.SystemTextJson.Migration/docs/recipes/polymorphism.md` — explains the limitation, the underlying STJ check, the exact exception users will see, and three recommended workarounds (use `[JsonMigratable]` discriminator dispatch instead, keep `[JsonPolymorphic]` and migrate at the leaves, or wrap migratable types behind a non-polymorphic boundary). Also notes the .NET 11 `JsonTypeClassifier` API proposal as a possible future path.
- **Cross-links** from `docs/recipes/README.md` and `docs/recipes/stj-features.md`.
- **XML docs remark** on `JsonMigratableAttribute` pointing to the recipe.

## Verification

`dotnet build Egil.SystemTextJson.Migration.slnx -c Release` — clean, 0 warnings, 0 errors.

No production behavior changes; no test changes needed.