### PR TITLE
fix(build): tolerate sparse package inventory rows [skip notes]

### DIFF
--- a/scripts/maintenance/inventory.ps1
+++ b/scripts/maintenance/inventory.ps1
@@ -162,11 +162,20 @@ function Get-ObjectPropertyValue {
     }
 
     $property = $Object.PSObject.Properties[$Name]
-    if ($null -eq $property -or $null -eq $property.Value) {
+    if ($null -eq $property) {
         return $Default
     }
 
-    return [string]$property.Value
+    $value = $property.Value
+    if ($null -eq $value) {
+        return $Default
+    }
+
+    if ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) {
+        return $Default
+    }
+
+    return [string]$value
 }
 
 function Get-JsonFromCommandOutput {

--- a/scripts/maintenance/inventory.ps1
+++ b/scripts/maintenance/inventory.ps1
@@ -150,6 +150,25 @@ function Get-XmlAttributeValue {
     return [string]$Node.Attributes[$Name].Value
 }
 
+function Get-ObjectPropertyValue {
+    param(
+        [object] $Object,
+        [string] $Name,
+        [string] $Default = ""
+    )
+
+    if ($null -eq $Object) {
+        return $Default
+    }
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return $Default
+    }
+
+    return [string]$property.Value
+}
+
 function Get-JsonFromCommandOutput {
     param([string] $Text)
 
@@ -188,13 +207,13 @@ function Get-PackageRows {
 
                     $row = [ordered]@{
                         scope = $Scope
-                        project = [string]$project.path
-                        framework = [string]$framework.framework
+                        project = Get-ObjectPropertyValue -Object $project -Name "path"
+                        framework = Get-ObjectPropertyValue -Object $framework -Name "framework" -Default "(unknown framework)"
                         package = $id
                         kind = $Kind
-                        requested = [string]$package.requestedVersion
-                        resolved = [string]$package.resolvedVersion
-                        latest = [string]$package.latestVersion
+                        requested = Get-ObjectPropertyValue -Object $package -Name "requestedVersion"
+                        resolved = Get-ObjectPropertyValue -Object $package -Name "resolvedVersion"
+                        latest = Get-ObjectPropertyValue -Object $package -Name "latestVersion"
                         collection = $collectionName
                     }
 
@@ -536,11 +555,16 @@ if (-not $SkipPackageQueries) {
             $scope = ($_.Name -split ", ")[0]
             $kind = ($_.Name -split ", ")[1]
             $details = ($_.Group | Sort-Object package, framework | Select-Object -First 30 | ForEach-Object {
+                $packageName = Get-ObjectPropertyValue -Object $_ -Name "package" -Default "(unknown package)"
+                $framework = Get-ObjectPropertyValue -Object $_ -Name "framework" -Default "(unknown framework)"
+                $resolved = Get-ObjectPropertyValue -Object $_ -Name "resolved" -Default "(unknown)"
+                $latest = Get-ObjectPropertyValue -Object $_ -Name "latest" -Default "(unknown)"
+                $reason = Get-ObjectPropertyValue -Object $_ -Name "reason"
                 $versionText = switch ($kind) {
-                    "outdated" { "$(Format-MarkdownCode $_.resolved) -> $(Format-MarkdownCode $_.latest)" }
-                    default { "$(Format-MarkdownCode $_.resolved) $($_.reason)" }
+                    "outdated" { "$(Format-MarkdownCode $resolved) -> $(Format-MarkdownCode $latest)" }
+                    default { "$(Format-MarkdownCode $resolved) $reason" }
                 }
-                "- $($_.package) $versionText in $(Format-MarkdownCode $_.framework)"
+                "- $packageName $versionText in $(Format-MarkdownCode $framework)"
             }) -join "`n"
 
             Add-FindingDetail `


### PR DESCRIPTION
## Summary

Fixes the `maintenance-inventory` workflow failure when `dotnet package list` emits package rows without all expected version fields.

## Changes

- Adds a safe optional-property reader for package-list JSON rows.
- Uses fallback values when rendering dependency issue details.
- Keeps strict mode enabled while avoiding crashes on sparse package inventory rows.

## Validation

- Parsed `scripts/maintenance/inventory.ps1` with PowerShell parser.
- Ran `./scripts/maintenance/inventory.ps1 -OutputDirectory ./artifacts/maintenance-fix-test -SkipPackageQueries`.
- Ran `./scripts/maintenance/inventory.ps1 -OutputDirectory ./artifacts/maintenance-fix-full-test`.
- Ran `git diff --check`.