### PR TITLE
build(om): upgrade Microsoft.Orleans packages to 10.3.1

### DIFF
--- a/Egil.Orleans.Messaging/Directory.Packages.props
+++ b/Egil.Orleans.Messaging/Directory.Packages.props
@@ -18,13 +18,13 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
   </ItemGroup>
   <ItemGroup Label="Orleans">
-    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.TestingHost" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.3.1" />
+    <PackageVersion Include="Microsoft.Orleans.TestingHost" Version="10.3.1" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -344,6 +344,12 @@ streamManager = this.RegisterStreamManager(state.State!.Tracker)
         useTrackedResumeToken: false);
 ```
 
+Orleans 10.3 lets `[StatelessWorker]` grains consume streams, but such
+consumers use provider-managed live delivery and reject any non-null resume
+token. When a stateless worker registers a stream manager with a tracker
+snapshot, set `useTrackedResumeToken: false` on its subscriptions, or omit the
+snapshot, or Orleans throws `InvalidOperationException` during attach.
+
 ```csharp
 this.RegisterStreamManager()
     .ConfigureImplicitSubscription<PriceChanged>(
@@ -376,6 +382,24 @@ The core package can consume provider-specific token metadata through
 Custom stream providers that expose custom `StreamSequenceToken` types should
 register a `JsonConverter<TToken>` with `StreamSequenceTokenJsonConverters`
 during startup.
+
+## JSON Grain Storage
+
+`Outbox<T>`, `OutboxMessageEnvelope<T>`, `OutboxSequenceToken`,
+`MessageTracker`, and `StreamCursor` carry `[JsonConverter]` attributes, so
+they round-trip through any System.Text.Json-based grain storage — including
+the Orleans 10.3 `siloBuilder.UseSystemTextJsonGrainStorageSerializer()` —
+without extra `JsonSerializerOptions` configuration. Orleans' own
+System.Text.Json `StreamSequenceToken` converter only handles
+`EventSequenceToken`/`EventSequenceTokenV2`; tokens stored inside
+`MessageTracker` or `StreamCursor` bypass it and use the
+`StreamSequenceTokenJsonConverters` registry instead, so provider tokens such
+as `EnrichedEventHubSequenceToken` persist correctly.
+
+Orleans' default Newtonsoft.Json storage serializer is not supported by these
+converters. All library state types are `[GenerateSerializer]`, so they pass
+the Orleans 10.3 JSON `$type` allow-list, but the payload shape is not
+guaranteed; use a System.Text.Json serializer or the Orleans binary serializer.
 
 ## Scope
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.Streams.EventHubs/EventHubs/EnrichedEventHubAdapter.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.Streams.EventHubs/EventHubs/EnrichedEventHubAdapter.cs
@@ -137,8 +137,8 @@ public class EnrichedEventHubAdapter : EventHubDataAdapter
     /// <typeparam name="T">The type of stream events.</typeparam>
     /// <param name="streamId">The target stream identity.</param>
     /// <param name="events">The events to publish.</param>
-    /// <param name="token">The sequence token (must be <c>null</c> for Event Hubs).</param>
-    /// <param name="requestContext">The Orleans request context dictionary.</param>
+    /// <param name="token">The sequence token; Event Hubs always passes <c>null</c>.</param>
+    /// <param name="requestContext">The Orleans request context dictionary, or <c>null</c> when no request context is flowing.</param>
     /// <returns>
     /// An <see cref="Azure.Messaging.EventHubs.EventData"/> with the
     /// <c>traceparent</c> property stamped if an <see cref="Activity"/>

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.Streams.EventHubs/EventHubs/EnrichedEventHubAdapter.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.Streams.EventHubs/EventHubs/EnrichedEventHubAdapter.cs
@@ -147,8 +147,8 @@ public class EnrichedEventHubAdapter : EventHubDataAdapter
     public override Azure.Messaging.EventHubs.EventData ToQueueMessage<T>(
         StreamId streamId,
         IEnumerable<T> events,
-        StreamSequenceToken token,
-        Dictionary<string, object> requestContext)
+        StreamSequenceToken? token,
+        Dictionary<string, object>? requestContext)
     {
         var queueMessage = base.ToQueueMessage(streamId, events, token, requestContext);
         if (Activity.Current?.Id is { } traceParent)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Streams.EventHubs.Tests/EventHubs/EnrichedEventHubAdapterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Streams.EventHubs.Tests/EventHubs/EnrichedEventHubAdapterTests.cs
@@ -159,6 +159,7 @@ public sealed class EnrichedEventHubAdapterTests
         var serialized = serializer.SerializeToArray<IBatchContainer>(
             adapter.GetBatchContainer(ref cachedMessage));
         var container = serializer.Deserialize<IBatchContainer>(serialized);
+        Assert.NotNull(container);
         var delivered = container.GetEvents<string>().ToArray();
 
         Assert.Equal(["event-1", "event-2"], delivered.Select(item => item.Item1));

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
@@ -16,6 +16,7 @@ public sealed class OutboxTests
         using var serviceProvider = services.BuildServiceProvider();
         var copied = serviceProvider.GetRequiredService<DeepCopier>().Copy(outbox);
 
+        Assert.NotNull(copied);
         var next = copied.Add("second", later);
 
         Assert.Equal(2, next.Count);


### PR DESCRIPTION
Orleans 10.3 shipped with several changes in areas Egil.Orleans.Messaging wraps (persistent state, stream subscriptions, reminders, Event Hubs adapters, JSON storage serialization). This PR upgrades the package to 10.3.1 and records the outcome of reviewing those changes against each tool in the toolbox.

## What changed

- All `Microsoft.Orleans.*` packages bumped 10.1.0 -> 10.3.1.
- `EnrichedEventHubAdapter.ToQueueMessage` override updated for the now-nullable `token` and `requestContext` parameters on `EventHubDataAdapter` (the only production compile break).
- Two tests add `Assert.NotNull` because `DeepCopier.Copy<T>` and `Serializer.Deserialize<T>` now return `T?`.
- README notes: `[StatelessWorker]` stream consumers reject tracked resume tokens (use `useTrackedResumeToken: false`), and the library's `[JsonConverter]`-attributed state types work with the new `UseSystemTextJsonGrainStorageSerializer()` without configuration.

## Review outcome (no behavioral changes required)

- **StateManager**: `IPersistentState<T>` signatures unchanged. Orleans now serializes overlapping Read/Write/Clear internally; the recovery read after a failed write still hits storage, so the documented recovery matrix holds.
- **StreamManager**: consumer API unchanged. The new "reject active implicit rewinds" check only fires when re-resuming a handle that already has an observer and completed a delivery; our `OnSubscribed -> Create<T>().ResumeAsync(observer, token)` path uses fresh observerless handles, which Orleans explicitly still supports.
- **OutboxProcessor**: reminder/timer APIs unchanged. Unregister now leaves a tombstone (no stale-refresh ticks) and register/unregister remain available during shutdown.
- **EventHubs adapter**: nullable annotations only; `UseAzureTableCheckpointer` moved static class but stays source-compatible.
- **Serialization**: all state types carry `[GenerateSerializer]`, so the new Newtonsoft `$type` allow-list is satisfied; STJ converters are unaffected.

Release build: 0 warnings. 245/245 tests pass across all three test projects.