### PR TITLE
feat(om)!: support payload postmen and constructor-safe state registration

### DIFF
--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -179,9 +179,11 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
 ```
 
 `AddPostman` callbacks take `(message)`, `(message, token)`, or
-`(message, token, cancellationToken)`. All return `ValueTask`; ordinary async
-lambdas work without casts. Wrap an existing `Task` method in an async lambda,
-as above. The second argument is always the delivery `OutboxSequenceToken`,
+`(message, token, cancellationToken)`. Both `Task` and `ValueTask` handlers work
+without adapters. On C# 13 or newer, overload priority selects `ValueTask` for
+ordinary async lambdas; Task-returning method groups and expressions select the
+Task overload. Older compilers need an explicitly typed delegate or lambda return
+type when a lambda could fit both. See [overload priority](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-13.0/overload-resolution-priority). The second argument is always the delivery `OutboxSequenceToken`,
 and cancellation is always third. Capture a grain factory when needed, or use
 `AddGrainPostman` to resolve the destination. The processor builds that token from the stored
 `OutboxMessageId` and its owning grain ID, preserving sequence, epoch and append
@@ -297,9 +299,25 @@ outboxProcessor
 
 The projection creates an application-owned transport contract, not a stored outbox
 envelope. Stream selection also has a token-aware overload. Cancellable grain
-invocations can receive `(grain, message, token, cancellationToken)`. All grain
-invocation callbacks return `ValueTask`; stream selectors and projections remain
+invocations can receive `(grain, message, token, cancellationToken)`. Grain
+invocation callbacks support both `Task` and `ValueTask`, with the same priority; stream selectors and projections remain
 synchronous, with optional token arguments.
+
+Group registrations that use the same configured provider:
+
+```csharp
+processor.ForStreamProvider("events")
+    .AddStreamPostman<OrderSubmitted>(
+        message => StreamId.Create("submitted-orders", message.OrderId))
+    .AddStreamPostman<OrderCancelled>(
+        message => StreamId.Create("cancelled-orders", message.OrderId));
+```
+
+The group supports the same projections and token-aware selectors as direct
+`AddStreamPostman` calls. Each call registers immediately on the original
+processor, so registration order remains first-match-wins across both forms.
+`ForStreamProvider` selects an existing Orleans provider; it does not install one.
+Continue unrelated registrations through the original `processor` variable.
 
 ## Receiver Dedup
 
@@ -453,7 +471,7 @@ The constructor-registration and payload-postman changes tracked in
 - Outboxes persist a UUIDv7 `Revision`. JSON requires a non-empty revision; previous beta snapshots need migration or reset. Independently constructed snapshots no longer compare equal based on matching contents.
 - Stored envelopes expose `Id` (`OutboxMessageId`); delivery tokens are supplied to handlers by the processor.
 - Use `OutboxProcessor<TPayload>` and `OutboxProcessorOptions<TPayload>`, not envelope generic arguments.
-- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Direct `AddPostman` callbacks take one, two, or three arguments and return `ValueTask`. Grain callbacks also return `ValueTask`. Replace `AddPostmanWithToken` with `AddPostman`; move cancellation to the third argument and capture a grain factory rather than receiving it as a callback argument.
+- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Direct `AddPostman` callbacks take one, two, or three arguments. Direct and grain callbacks accept both `Task` and `ValueTask`, preferring `ValueTask` for async lambdas on C# 13+. Replace `AddPostmanWithToken` with `AddPostman`; move cancellation to the third argument and capture a grain factory rather than receiving it as a callback argument.
 - Supply state factories for types without a public parameterless constructor. Custom `IStateManagerFactory` implementations receive the initial-state factory and runtime configuration callback.
 - Pass a tracker accessor to `RegisterStreamManager`, for example `() => state.State.Tracker`. It is evaluated when attaching/resuming subscriptions, after hydration, and observes later state replacement.
 

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -210,9 +210,13 @@ with plain `IPersistentState<T>` writes, the pipeline stays at-least-once on
 its own: items only leave durable state when the grain removes them in
 `AcknowledgePostedAsync` after a successful post, so a failed or ambiguous
 state write leaves them pending and at worst causes duplicate delivery, never
-loss. Be aware that `Outbox<T>.Equals` is an O(1) fingerprint (sequence metadata, count, and first/last pending IDs), not deep payload
-equality — safe for dirty-checks and write recovery, but not a substitute for
-comparing message contents item by item.
+loss. `Outbox<T>.Revision` is a persisted UUIDv7 that acts as an outbox-specific ETag.
+Each mutation creates a new revision; operations that change nothing preserve it.
+`Equals` compares the revision, sequence metadata, count, and first/last pending
+IDs in O(1), without scanning payloads. Competing snapshots remain distinct even
+when their append timestamps match. Serialization preserves the revision so
+recovery can confirm a successful save whose response was lost. Revisions are
+compared for equality, not order, and do not change message IDs or delivery tokens.
 
 If a post run fails before reconciliation completes — for example when the
 run exceeds `ProcessingTimeout` or an acknowledgement callback throws — the
@@ -441,6 +445,7 @@ The constructor-registration and payload-postman changes tracked in
 [issue #179](https://github.com/egil/framework/issues/179) are breaking changes:
 
 - Replace `Outbox<T>.Create(grainId)` with `Outbox<T>.Create()`.
+- Outboxes persist a UUIDv7 `Revision`. JSON requires a non-empty revision; previous beta snapshots need migration or reset. Independently constructed snapshots no longer compare equal based on matching contents.
 - Stored envelopes expose `Id` (`OutboxMessageId`); delivery tokens are supplied to handlers by the processor.
 - Use `OutboxProcessor<TPayload>` and `OutboxProcessorOptions<TPayload>`, not envelope generic arguments.
 - Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Use `AddPostmanWithToken` for direct handlers needing delivery metadata; both `Task` and `ValueTask` handlers are supported.

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -112,7 +112,12 @@ state = this.RegisterStateManager("state", storage,
 ```
 
 This callback configures runtime dependencies; it must not change business data
-or perform storage I/O. It is deferred during constructor registration.
+or perform storage I/O. It is deferred during constructor registration. The manager
+and raw storage facet expose the adopted snapshot before the callback runs. If the
+callback fails, its exception reaches the caller and the adopted snapshot remains
+visible. A successful storage operation is not retried because configuration failed.
+After a successful recovery read, invalid state and factory/configuration failures
+are reported directly; only a failed storage read preserves the original storage error.
 
 State types must be reference types and implement `IEquatable<T>`. For
 non-trivial state graphs, inherit from `VersionedState` so the recovery path
@@ -319,6 +324,23 @@ processor, so registration order remains first-match-wins across both forms.
 `ForStreamProvider` selects an existing Orleans provider; it does not install one.
 Continue unrelated registrations through the original `processor` variable.
 
+Routing and projection choose their token arguments independently. Both direct
+and grouped registration support token-aware routing with no projection:
+
+```csharp
+processor.AddStreamPostman<OrderSubmitted>("events",
+    (message, token) => StreamId.Create("orders-by-sender", token.Sender.ToString()));
+```
+
+Or use a projection that only needs the payload:
+
+```csharp
+processor.ForStreamProvider("events")
+    .AddStreamPostman<OrderCancelled, CancelledDelivery>(
+        (message, token) => StreamId.Create("cancelled-by-sender", token.Sender.ToString()),
+        message => new CancelledDelivery(message.OrderId));
+```
+
 ## Receiver Dedup
 
 `MessageTracker` accepts a message only when its stream token, stream cursor, or outbox token advances the stored high-water mark:
@@ -341,7 +363,11 @@ The tracker can also evict old sender or stream entries when your retention poli
 
 ## Streams
 
-Use `StreamManager` to configure stream subscriptions from `OnActivateAsync`. Pass a tracker snapshot when you want persisted resume tokens, or omit it when the grain does not track stream positions:
+Register `StreamManager` in the grain constructor or `OnActivateAsync` and configure
+its subscriptions. Supply a tracker accessor for persisted resume tokens, or omit
+it when the grain does not track stream positions. The accessor runs when attaching
+or resuming subscriptions, after hydration, and returns the current tracker after
+state replacement. Attach explicit subscriptions from `OnActivateAsync`:
 
 ```csharp
 streamManager = this.RegisterStreamManager(() => state.State.Tracker)
@@ -389,7 +415,7 @@ stream ids. Recreate existing durable subscriptions and update publishers
 together, or preserve the previous id through the explicit `StreamId` overload.
 
 Tracked resume tokens are a per-subscription choice. The default is to pass
-the previous token when a tracker snapshot is supplied. Opt out when a
+the previous token when the tracker accessor returns a tracked cursor. Opt out when a
 subscription should attach without a resume token:
 
 ```csharp

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -173,14 +173,17 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
             });
         }
     })
-    .AddPostman<OrderSubmitted>(PublishSubmittedAsync)
-    .AddPostman<OrderCancelled>(PublishCancelledAsync);
+    .AddPostman<OrderSubmitted>(async message => await PublishSubmittedAsync(message))
+    .AddPostman<OrderCancelled>(async message => await PublishCancelledAsync(message));
 }
 ```
 
-Postman handlers receive domain payloads. `AddPostmanWithToken` callbacks receive
-the payload and `OutboxSequenceToken`, with an optional cancellation token when the destination needs delivery
-identity or deduplication. The processor builds that token from the stored
+`AddPostman` callbacks take `(message)`, `(message, token)`, or
+`(message, token, cancellationToken)`. All return `ValueTask`; ordinary async
+lambdas work without casts. Wrap an existing `Task` method in an async lambda,
+as above. The second argument is always the delivery `OutboxSequenceToken`,
+and cancellation is always third. Capture a grain factory when needed, or use
+`AddGrainPostman` to resolve the destination. The processor builds that token from the stored
 `OutboxMessageId` and its owning grain ID, preserving sequence, epoch and append
 timestamp across retries and reactivation. No sender identity is stored in the outbox.
 
@@ -276,7 +279,7 @@ outboxProcessor = this.RegisterOutboxProcessor(options)
 outboxProcessor = this.RegisterOutboxProcessor(options)
     .AddGrainPostman<OrderSubmitted, IOrderProjectionGrain>(
         (message, grainFactory) => grainFactory.GetGrain<IOrderProjectionGrain>(message.OrderId),
-        (grain, message) => grain.ApplyAsync(message));
+        async (grain, message) => await grain.ApplyAsync(message));
 ```
 
 Token-aware stream projections and grain calls also operate on payloads:
@@ -289,12 +292,14 @@ outboxProcessor
         (message, token) => new SubmittedDelivery(message, token))
     .AddGrainPostman<OrderCancelled, IOrderProjectionGrain>(
         (message, grains) => grains.GetGrain<IOrderProjectionGrain>(message.OrderId),
-        (grain, message, token) => grain.ApplyAsync(message, token));
+        async (grain, message, token) => await grain.ApplyAsync(message, token));
 ```
 
 The projection creates an application-owned transport contract, not a stored outbox
 envelope. Stream selection also has a token-aware overload. Cancellable grain
-invocations can receive `(grain, message, token, cancellationToken)`.
+invocations can receive `(grain, message, token, cancellationToken)`. All grain
+invocation callbacks return `ValueTask`; stream selectors and projections remain
+synchronous, with optional token arguments.
 
 ## Receiver Dedup
 
@@ -448,7 +453,7 @@ The constructor-registration and payload-postman changes tracked in
 - Outboxes persist a UUIDv7 `Revision`. JSON requires a non-empty revision; previous beta snapshots need migration or reset. Independently constructed snapshots no longer compare equal based on matching contents.
 - Stored envelopes expose `Id` (`OutboxMessageId`); delivery tokens are supplied to handlers by the processor.
 - Use `OutboxProcessor<TPayload>` and `OutboxProcessorOptions<TPayload>`, not envelope generic arguments.
-- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Use `AddPostmanWithToken` for direct handlers needing delivery metadata; both `Task` and `ValueTask` handlers are supported.
+- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Direct `AddPostman` callbacks take one, two, or three arguments and return `ValueTask`. Grain callbacks also return `ValueTask`. Replace `AddPostmanWithToken` with `AddPostman`; move cancellation to the third argument and capture a grain factory rather than receiving it as a callback argument.
 - Supply state factories for types without a public parameterless constructor. Custom `IStateManagerFactory` implementations receive the initial-state factory and runtime configuration callback.
 - Pass a tracker accessor to `RegisterStreamManager`, for example `() => state.State.Tracker`. It is evaluated when attaching/resuming subscriptions, after hydration, and observes later state replacement.
 

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -212,8 +212,8 @@ its own: items only leave durable state when the grain removes them in
 state write leaves them pending and at worst causes duplicate delivery, never
 loss. `Outbox<T>.Revision` is a persisted UUIDv7 that acts as an outbox-specific ETag.
 Each mutation creates a new revision; operations that change nothing preserve it.
-`Equals` compares the revision, sequence metadata, count, and first/last pending
-IDs in O(1), without scanning payloads. Competing snapshots remain distinct even
+`Equals` compares only the revision in O(1), without scanning payloads.
+`GetHashCode` also uses only the revision. Competing snapshots remain distinct even
 when their append timestamps match. Serialization preserves the revision so
 recovery can confirm a successful save whose response was lost. Revisions are
 compared for equality, not order, and do not change message IDs or delivery tokens.

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -178,8 +178,8 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
 }
 ```
 
-Postman handlers receive domain payloads. Overloads can also receive the
-`OutboxSequenceToken` and cancellation token when the destination needs delivery
+Postman handlers receive domain payloads. `AddPostmanWithToken` callbacks receive
+the payload and `OutboxSequenceToken`, with an optional cancellation token when the destination needs delivery
 identity or deduplication. The processor builds that token from the stored
 `OutboxMessageId` and its owning grain ID, preserving sequence, epoch and append
 timestamp across retries and reactivation. No sender identity is stored in the outbox.
@@ -443,7 +443,7 @@ The constructor-registration and payload-postman changes tracked in
 - Replace `Outbox<T>.Create(grainId)` with `Outbox<T>.Create()`.
 - Stored envelopes expose `Id` (`OutboxMessageId`); delivery tokens are supplied to handlers by the processor.
 - Use `OutboxProcessor<TPayload>` and `OutboxProcessorOptions<TPayload>`, not envelope generic arguments.
-- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`.
+- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`. Use `AddPostmanWithToken` for direct handlers needing delivery metadata; both `Task` and `ValueTask` handlers are supported.
 - Supply state factories for types without a public parameterless constructor. Custom `IStateManagerFactory` implementations receive the initial-state factory and runtime configuration callback.
 - Pass a tracker accessor to `RegisterStreamManager`, for example `() => state.State.Tracker`. It is evaluated when attaching/resuming subscriptions, after hydration, and observes later state replacement.
 

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -5,7 +5,7 @@ Composable messaging infrastructure for Microsoft Orleans grains.
 `Egil.Orleans.Messaging` provides building blocks for grains that need durable state changes and durable message handoff to move together:
 
 - `IStateManager<T>` wraps `IPersistentState<T>` so a grain does not keep observing uncommitted state after ambiguous write failures.
-- `Outbox<T>` stores messages alongside grain state and assigns durable sender sequence tokens.
+- `Outbox<T>` stores messages alongside grain state and assigns durable message IDs; processors add sender identity at delivery.
 - `OutboxProcessor<T>` dispatches pending outbox items through registered postmen, with retry, reminder forwarding, failure reconciliation, and telemetry.
 - `MessageTracker` records receiver-side high-water marks for outbox messages and Orleans streams.
 - `StreamManager` gives grains a fluent subscription facade with resume-token and handler-error support.
@@ -68,36 +68,51 @@ recovery read. Ambiguous or transient outcomes, including HTTP 503
 `ServerBusy`, HTTP 500 `OperationTimedOut`, HTTP 429 throttling, no-response
 failures, and timeout exceptions, still use read-back recovery.
 
-Then wrap the Orleans persistent state facet during activation:
+Register the manager in the grain constructor and keep it in a readonly field:
 
 ```csharp
-public sealed class OrderGrain(
-    [PersistentState("state", "Default")] IPersistentState<OrderState> storage)
-    : Grain, IOrderGrain
+public sealed class OrderGrain : Grain, IOrderGrain
 {
-    private IStateManager<OrderState> state = default!;
+    private readonly IStateManager<OrderState> state;
 
-    private OrderState CurrentState =>
-        state.State ?? throw new InvalidOperationException("Order state is not initialized.");
-
-    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderState> storage)
     {
-        state = this.RegisterStateManager("state", storage);
-        return Task.CompletedTask;
+        state = this.RegisterStateManager("state", storage, () => new OrderState());
     }
 
-    public async Task RenameAsync(string name)
-    {
-        await state.WriteAsync(CurrentState with { Name = name });
-    }
+    public Task RenameAsync(string name) =>
+        state.WriteAsync(state.State with { Name = name });
 }
 ```
 
-`State` is nullable because persistent storage can expose no value, including
-after `ClearAsync`. Initialize missing state or guard it before dereferencing,
-as `CurrentState` does above. Later snippets use `state.State!` only to keep
-their focus narrow and assume the surrounding grain has already established
-that invariant.
+The overload without a factory requires `TState : new()`. Constructor registration
+returns immediately, but the provider-specific manager and default state are
+created only after Orleans has hydrated storage, before `OnActivateAsync`.
+Accessing `State` before then throws a lifecycle error. Registration in
+`OnActivateAsync` remains supported for callers that do not need readonly fields.
+
+`State` is non-null: activation and `ReadAsync` use the configured default when
+no persisted record exists, and a successful `ClearAsync` exposes a fresh default.
+The factory takes precedence over a provider-created default for a missing record.
+An existing record with a null value, or a factory returning null, is rejected.
+**Creating a default does not write it to storage.** The first business operation
+can persist its resulting state with `WriteAsync`.
+
+`State` stays read-only. It exposes the loaded or successfully written snapshot,
+or the default representing absent storage; interleaved readers cannot observe
+an in-flight write candidate. Do not replace raw `storage.State` after registration.
+
+Use the optional runtime configuration callback to restore transient dependencies
+on each adopted instance, including after reads and recovery:
+
+```csharp
+state = this.RegisterStateManager("state", storage,
+    () => new OrderState(),
+    loaded => loaded.Tracker.RegisterTimeProvider(timeProvider));
+```
+
+This callback configures runtime dependencies; it must not change business data
+or perform storage I/O. It is deferred during constructor registration.
 
 State types must be reference types and implement `IEquatable<T>`. For
 non-trivial state graphs, inherit from `VersionedState` so the recovery path
@@ -115,14 +130,14 @@ public sealed record OrderState : VersionedState
     [Id(0)] public string? Name { get; init; }
 
     [Id(1)] public Outbox<IOrderEvent> Outbox { get; init; } =
-        Outbox<IOrderEvent>.Create(GrainId.Create("order", "example"));
+        Outbox<IOrderEvent>.Create();
 }
 
 public async Task SubmitAsync()
 {
-    var next = state.State! with
+    var next = state.State with
     {
-        Outbox = state.State!.Outbox.Add(new OrderSubmitted())
+        Outbox = state.State.Outbox.Add(new OrderSubmitted())
     };
 
     await state.WriteAsync(next);
@@ -136,45 +151,44 @@ at the call site and pass the instant with
 the provider, so serialization and state rehydration need no clock
 re-registration.
 
-Use `OutboxProcessor<T>` to dispatch pending items and acknowledge only the items that were posted successfully. Use `OutboxMessageEnvelope<T>` as the processor item type so the acknowledgement callback can remove exactly the posted items by token:
+Use `OutboxProcessor<T>` with the **base payload type**, even for polymorphic
+outboxes. Register it in the constructor after the state manager:
 
 ```csharp
-public sealed class OrderGrain : Grain, IOutboxGrain
+private readonly IStateManager<OrderState> state;
+private readonly OutboxProcessor<IOrderEvent> outboxProcessor;
+
+public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderState> storage)
 {
-    private OutboxProcessor<OutboxMessageEnvelope<IOrderEvent>> outboxProcessor = default!;
-
-    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    state = this.RegisterStateManager("state", storage);
+    outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IOrderEvent>
     {
-        outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<IOrderEvent>>
+        PendingItems = () => [.. state.State.Outbox],
+        AcknowledgePostedAsync = async (items, ct) =>
         {
-            PendingItems = () => [.. state.State!.Outbox],
-            AcknowledgePostedAsync = async (items, ct) =>
+            ct.ThrowIfCancellationRequested();
+            await state.WriteAsync(state.State with
             {
-                await state.WriteAsync(state.State! with
-                {
-                    Outbox = state.State!.Outbox.RemoveRange(items.Select(item => item.Token))
-                });
-            },
-            ReconcileFailedAsync = (_, _) => ValueTask.CompletedTask,
-        })
-        .AddPostman<OutboxMessageEnvelope<IOrderEvent>>(
-            envelope => PublishSubmittedAsync(envelope.Message));
-
-        return Task.CompletedTask;
-    }
+                Outbox = state.State.Outbox.RemoveRange(items.Select(item => item.Id))
+            });
+        }
+    })
+    .AddPostman<OrderSubmitted>(PublishSubmittedAsync)
+    .AddPostman<OrderCancelled>(PublishCancelledAsync);
 }
 ```
 
-`AcknowledgePostedAsync` receives exactly the items that posted successfully —
-**not necessarily a contiguous prefix of the pending list**. Different message
-types dispatch through different postmen concurrently, and an item without a
-matching postman fails in place while later items can still succeed. Never
-acknowledge by position (for example `outbox.Take(items.Length)`); that can
-remove a failed item and lose it. When the processor item type is a bare
-message type instead of the envelope, the callback must map each received item
-back to its token — which is only reliable when payloads are unique — so
-prefer the envelope form above unless per-message-type postman registration
-(shown below) is required.
+Postman handlers receive domain payloads. Overloads can also receive the
+`OutboxSequenceToken` and cancellation token when the destination needs delivery
+identity or deduplication. The processor builds that token from the stored
+`OutboxMessageId` and its owning grain ID, preserving sequence, epoch and append
+timestamp across retries and reactivation. No sender identity is stored in the outbox.
+
+`PendingItems`, `AcknowledgePostedAsync`, and `ReconcileFailedAsync` use the original
+stored `OutboxMessageEnvelope<T>` values. Acknowledgment receives exactly the
+successfully delivered items, which need not be a contiguous prefix. Remove them
+by `item.Id` using `RemoveRange`; never remove by position or count. Equal payloads
+can represent different messages and retain distinct stored IDs.
 
 `IOutboxGrain` forwards reminder ticks to the single attached processor.
 Register exactly one processor per grain activation; a second registration
@@ -196,8 +210,7 @@ with plain `IPersistentState<T>` writes, the pipeline stays at-least-once on
 its own: items only leave durable state when the grain removes them in
 `AcknowledgePostedAsync` after a successful post, so a failed or ambiguous
 state write leaves them pending and at worst causes duplicate delivery, never
-loss. Be aware that `Outbox<T>.Equals` is an O(1) fingerprint (sender,
-sequence metadata, count, and first/last pending tokens), not deep payload
+loss. Be aware that `Outbox<T>.Equals` is an O(1) fingerprint (sequence metadata, count, and first/last pending IDs), not deep payload
 equality — safe for dirty-checks and write recovery, but not a substitute for
 comparing message contents item by item.
 
@@ -262,17 +275,34 @@ outboxProcessor = this.RegisterOutboxProcessor(options)
         (grain, message) => grain.ApplyAsync(message));
 ```
 
+Token-aware stream projections and grain calls also operate on payloads:
+
+```csharp
+outboxProcessor
+    .AddStreamPostman<OrderSubmitted, SubmittedDelivery>(
+        "order-streams",
+        message => StreamId.Create("submitted-orders", message.OrderId),
+        (message, token) => new SubmittedDelivery(message, token))
+    .AddGrainPostman<OrderCancelled, IOrderProjectionGrain>(
+        (message, grains) => grains.GetGrain<IOrderProjectionGrain>(message.OrderId),
+        (grain, message, token) => grain.ApplyAsync(message, token));
+```
+
+The projection creates an application-owned transport contract, not a stored outbox
+envelope. Stream selection also has a token-aware overload. Cancellable grain
+invocations can receive `(grain, message, token, cancellationToken)`.
+
 ## Receiver Dedup
 
 `MessageTracker` accepts a message only when its stream token, stream cursor, or outbox token advances the stored high-water mark:
 
 ```csharp
-if (!state.State!.Tracker.ProcessMessage("prices", token, out var tracker))
+if (!state.State.Tracker.ProcessMessage("prices", token, out var tracker))
 {
     return;
 }
 
-await state.WriteAsync(state.State! with { Tracker = tracker });
+await state.WriteAsync(state.State with { Tracker = tracker });
 ```
 
 Use `LatestStreamSequenceToken("prices")` when all you need is the previous
@@ -287,18 +317,18 @@ The tracker can also evict old sender or stream entries when your retention poli
 Use `StreamManager` to configure stream subscriptions from `OnActivateAsync`. Pass a tracker snapshot when you want persisted resume tokens, or omit it when the grain does not track stream positions:
 
 ```csharp
-streamManager = this.RegisterStreamManager(state.State!.Tracker)
+streamManager = this.RegisterStreamManager(() => state.State.Tracker)
     .ConfigureExplicitSubscription<PriceChanged>(
         "StreamProvider",
         "prices",
         async (message, cursor) =>
         {
-            if (!state.State!.Tracker.ProcessMessage(cursor, out var tracker))
+            if (!state.State.Tracker.ProcessMessage(cursor, out var tracker))
             {
                 return;
             }
 
-            await state.WriteAsync(state.State! with { Tracker = tracker });
+            await state.WriteAsync(state.State with { Tracker = tracker });
         });
 
 await streamManager.EnsureExplicitSubscriptionsAsync(cancellationToken);
@@ -320,7 +350,7 @@ must survive grain-type changes, or when a custom grain identity cannot
 round-trip through Orleans' textual `GrainId` representation:
 
 ```csharp
-streamManager = this.RegisterStreamManager(state.State!.Tracker)
+streamManager = this.RegisterStreamManager(() => state.State.Tracker)
     .ConfigureExplicitSubscription<PriceChanged>(
         "StreamProvider",
         StreamId.Create("prices", customerId),
@@ -336,7 +366,7 @@ the previous token when a tracker snapshot is supplied. Opt out when a
 subscription should attach without a resume token:
 
 ```csharp
-streamManager = this.RegisterStreamManager(state.State!.Tracker)
+streamManager = this.RegisterStreamManager(() => state.State.Tracker)
     .ConfigureExplicitSubscription<PriceChanged>(
         "StreamProvider",
         "prices",
@@ -385,7 +415,7 @@ during startup.
 
 ## JSON Grain Storage
 
-`Outbox<T>`, `OutboxMessageEnvelope<T>`, `OutboxSequenceToken`,
+`Outbox<T>`, `OutboxMessageEnvelope<T>`, `OutboxMessageId`, `OutboxSequenceToken`,
 `MessageTracker`, and `StreamCursor` carry `[JsonConverter]` attributes, so
 they round-trip through any System.Text.Json-based grain storage — including
 the Orleans 10.3 `siloBuilder.UseSystemTextJsonGrainStorageSerializer()` —
@@ -404,3 +434,17 @@ guaranteed; use a System.Text.Json serializer or the Orleans binary serializer.
 ## Scope
 
 This package is messaging infrastructure, not an event-sourcing or CQRS framework. It wraps Orleans state, outbox dispatch, receiver deduplication, and stream subscription management while leaving domain modeling, read models, transport targets, and operational policy to the application.
+
+## Beta API changes
+
+The constructor-registration and payload-postman changes tracked in
+[issue #179](https://github.com/egil/framework/issues/179) are breaking changes:
+
+- Replace `Outbox<T>.Create(grainId)` with `Outbox<T>.Create()`.
+- Stored envelopes expose `Id` (`OutboxMessageId`); delivery tokens are supplied to handlers by the processor.
+- Use `OutboxProcessor<TPayload>` and `OutboxProcessorOptions<TPayload>`, not envelope generic arguments.
+- Register payload subtypes with `AddPostman`, `AddStreamPostman`, and `AddGrainPostman`.
+- Supply state factories for types without a public parameterless constructor. Custom `IStateManagerFactory` implementations receive the initial-state factory and runtime configuration callback.
+- Pass a tracker accessor to `RegisterStreamManager`, for example `() => state.State.Tracker`. It is evaluated when attaching/resuming subscriptions, after hydration, and observes later state replacement.
+
+The stored outbox JSON shape changes. Migration of earlier beta data is not provided.

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -119,6 +119,14 @@ visible. A successful storage operation is not retried because configuration fai
 After a successful recovery read, invalid state and factory/configuration failures
 are reported directly; only a failed storage read preserves the original storage error.
 
+
+`ClearAsync` deletes storage before calling the default-state factory. The factory
+must return a valid, non-null state. If it throws or returns null, the error
+propagates and the deletion remains completed. A null result is rejected with
+`InvalidOperationException` as a diagnostic. After this factory contract violation,
+the manager has no guaranteed usable state: `State` may still reference the previous
+snapshot and must not be treated as the current persisted state.
+
 State types must be reference types and implement `IEquatable<T>`. For
 non-trivial state graphs, inherit from `VersionedState` so the recovery path
 compares a library-stamped version rather than relying on structural

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -410,13 +410,20 @@ The outbox can grow unbounded if postman targets are down. Mitigation:
 - **Documentation:** storage providers have entity size limits (e.g.
   Azure Table = 1MB). Document the risk of unbounded growth.
 
-### O(1) sequence equality
+### O(1) snapshot equality
 
-Equality uses `(LatestSequenceNumber, Epoch, Count, first ID, last ID)`, including
-ID timestamps. It is a recovery fingerprint, not payload equality. Removal can
-leave gaps, so matching endpoints does not imply a contiguous sequence. See the
-source documentation for the existing removal-divergence and exact-timestamp-tie
-tradeoffs; this change preserves those semantics while removing sender identity.
+`Revision` is a persisted UUIDv7, an outbox-specific ETag. `Create` and each
+mutation that changes the outbox assign a fresh revision. No-op operations
+preserve the existing snapshot and revision. JSON and Orleans serialization
+preserve the revision; JSON requires it to be non-empty.
+
+Equality uses `(Revision, LatestSequenceNumber, Epoch, Count, first ID, last ID)`.
+It remains O(1) without scanning payloads. Two competing appends or removals
+have different revisions even when endpoint IDs and sequence metadata match.
+A deserialized copy of the saved snapshot retains its revision, allowing recovery
+to confirm a successful write with a lost response. Independently constructed
+snapshots are unequal even when their contents match. Recovery uses revision
+equality, never revision ordering. Message IDs and delivery tokens are unchanged.
 
 ### Why these choices
 

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -1435,12 +1435,17 @@ callbacks, not passive notifications:
 
 `TOutbox` is the base payload type. All handler families operate on payloads;
 stored envelopes are confined to pending snapshots and reconciliation callbacks.
-Token-aware `AddPostmanWithToken` overloads accept `(message, token)` or
-`(message, token, cancellationToken)`, returning either `Task` or `ValueTask`.
-The separate method name keeps unused lambda parameters unambiguous with
-cancellation-aware and grain-factory callbacks. Stream projections and selectors can receive
-`(message, token)`, and grain invocations can receive
-`(grain, message, token[, cancellationToken])`. These adapters retain the original
+`AddPostman` callbacks take `(message)`, `(message, token)`, or
+`(message, token, cancellationToken)`, returning `ValueTask` in all cases.
+Argument count selects the overload. There are no competing `Task` overloads,
+so ordinary async lambdas are unambiguous. Existing `Task` methods can be awaited
+inside a lambda. Grain factories are captured or supplied through the resolver
+of `AddGrainPostman`; the second direct-callback argument is always a delivery token.
+
+Stream projections and selectors remain synchronous and can receive `(message, token)`.
+Grain invocations take `(grain, message)`, `(grain, message, token)`, or
+`(grain, message, token, cancellationToken)` and return `ValueTask`.
+These adapters retain the original
 stored item for acknowledgment. A covariant envelope interface is unnecessary.
 
 ```csharp
@@ -1450,11 +1455,9 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, ValueTask> postman) where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, Task> postman) where TSub : TOutbox;
+        Func<TSub, OutboxSequenceToken, ValueTask> postman) where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, CancellationToken, Task> postman) where TSub : TOutbox;
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, IGrainFactory, CancellationToken, ValueTask> postman)
+        Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
         where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         string postmanName) where TSub : TOutbox;
@@ -1469,7 +1472,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
-        Func<TGrain, TSub, Task> call)
+        Func<TGrain, TSub, ValueTask> call)
         where TSub : TOutbox
         where TGrain : IGrain;
 

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -1427,8 +1427,10 @@ callbacks, not passive notifications:
 
 `TOutbox` is the base payload type. All handler families operate on payloads;
 stored envelopes are confined to pending snapshots and reconciliation callbacks.
-Token-aware `AddPostman` overloads accept `(message, token)` or
-`(message, token, cancellationToken)`. Stream projections and selectors can receive
+Token-aware `AddPostmanWithToken` overloads accept `(message, token)` or
+`(message, token, cancellationToken)`, returning either `Task` or `ValueTask`.
+The separate method name keeps unused lambda parameters unambiguous with
+cancellation-aware and grain-factory callbacks. Stream projections and selectors can receive
 `(message, token)`, and grain invocations can receive
 `(grain, message, token[, cancellationToken])`. These adapters retain the original
 stored item for acknowledgment. A covariant envelope interface is unnecessary.

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -417,7 +417,8 @@ mutation that changes the outbox assign a fresh revision. No-op operations
 preserve the existing snapshot and revision. JSON and Orleans serialization
 preserve the revision; JSON requires it to be non-empty.
 
-Equality uses `(Revision, LatestSequenceNumber, Epoch, Count, first ID, last ID)`.
+Equality and hashing use only `Revision`; distinct snapshots with an empty
+revision cannot compare equal.
 It remains O(1) without scanning payloads. Two competing appends or removals
 have different revisions even when endpoint IDs and sequence metadata match.
 A deserialized copy of the saved snapshot retains its revision, allowing recovery
@@ -1649,7 +1650,7 @@ explicit `null` roots remain valid empty collections.
 
 `Outbox<T>` and `MessageTracker` are sealed classes with private
 backing fields. Exposing them via `[JsonInclude]` would leak internals
-and weaken the fingerprint invariant. Custom converters keep
+and allow malformed snapshot identity. Custom converters keep
 encapsulation intact and control the exact wire format.
 
 **`VersionedState` exception:** `Version` is a single `Guid` property

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -1436,15 +1436,24 @@ callbacks, not passive notifications:
 `TOutbox` is the base payload type. All handler families operate on payloads;
 stored envelopes are confined to pending snapshots and reconciliation callbacks.
 `AddPostman` callbacks take `(message)`, `(message, token)`, or
-`(message, token, cancellationToken)`, returning `ValueTask` in all cases.
-Argument count selects the overload. There are no competing `Task` overloads,
-so ordinary async lambdas are unambiguous. Existing `Task` methods can be awaited
-inside a lambda. Grain factories are captured or supplied through the resolver
+`(message, token, cancellationToken)`, with both `Task` and `ValueTask` overloads.
+Argument count selects the parameter shape. `OverloadResolutionPriority(1)` on
+each ValueTask overload selects it when an ordinary async lambda fits both return
+types; Task method groups and expressions remain applicable to the Task adapter.
+This compiler support requires C# 13 or newer. Older compilers need explicit
+delegate or lambda return types for otherwise ambiguous lambdas. Grain factories are captured or supplied through the resolver
 of `AddGrainPostman`; the second direct-callback argument is always a delivery token.
 
 Stream projections and selectors remain synchronous and can receive `(message, token)`.
 Grain invocations take `(grain, message)`, `(grain, message, token)`, or
-`(grain, message, token, cancellationToken)` and return `ValueTask`.
+`(grain, message, token, cancellationToken)` with the same Task/ValueTask overload
+priority.
+`ForStreamProvider(name)` returns an `OutboxStreamProviderBuilder<TOutbox>` with
+chainable `AddStreamPostman` overloads matching the direct registrations, except
+that the provider name is supplied once. Registration forwards immediately to the
+original processor; there is no separate dispatch registry, acknowledgment state,
+or retry lifecycle. Provider configuration is still performed in Orleans setup.
+
 These adapters retain the original
 stored item for acknowledgment. A covariant envelope interface is unnecessary.
 
@@ -1452,12 +1461,22 @@ stored item for acknowledgment. A covariant envelope interface is unnecessary.
 public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     where TOutbox : notnull
 {
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, ValueTask> postman) where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, Task> postman) where TSub : TOutbox;
+    [OverloadResolutionPriority(1)]
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, OutboxSequenceToken, ValueTask> postman) where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, OutboxSequenceToken, Task> postman) where TSub : TOutbox;
+    [OverloadResolutionPriority(1)]
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
+        where TSub : TOutbox;
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
         where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         string postmanName) where TSub : TOutbox;
@@ -1470,6 +1489,8 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         Func<TSub, StreamId> streamId,
         Func<TSub, TEvent> project)
         where TSub : TOutbox;
+    public OutboxStreamProviderBuilder<TOutbox> ForStreamProvider(string streamProviderName);
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
         Func<TGrain, TSub, ValueTask> call)

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -10,6 +10,9 @@ only when a new constraint surfaces.
 Status legend: **Settled** = won't change without a new force; **Open** =
 still under design; **Deferred** = explicitly postponed past the spike.
 
+Constructor registration, absent-state defaults, and payload-level postmen follow
+[issue #179](https://github.com/egil/framework/issues/179). These are intentional beta breaking changes.
+
 ---
 
 ## 0. Scope & packaging
@@ -117,7 +120,7 @@ stale `storage.State` after a failed write.
 ```csharp
 public interface IStateManager<T> where T : class, IEquatable<T>
 {
-    T? State { get; }
+    T State { get; }
     Task ReadAsync();
     Task WriteAsync(T newState);
     Task ClearAsync();
@@ -147,28 +150,23 @@ Users pick one of two paths for `T`:
 
 See §3a for `VersionedState` and why the generic layer was removed.
 
-### Activation: state is auto-populated
+### Activation and absent state
 
-`IStateManager<T>` behaves like `IPersistentState<T>` from the grain's
-point of view: by the time `OnActivateAsync` runs, `State` already
-reflects what is durably stored. Grain code does **not** call `ReadAsync`
-during activation.
+Registration in the grain constructor returns a stable handle. At lifecycle stage
+`SetupState + 1`, after Orleans hydration and before `OnActivateAsync`, that handle
+creates the configured provider-specific manager. Even custom manager factories
+therefore see hydrated storage. Access before initialization throws clearly.
+Registration in `OnActivateAsync` remains supported and creates the manager immediately.
 
-`State` is nullable because storage can expose no value, including after a
-successful `ClearAsync`. The manager cannot construct an arbitrary `T` as a
-fallback. Grain code must initialize missing state or guard it before
-dereferencing.
+`State` is non-null and read-only. Activation and `ReadAsync` adopt the stored value
+when `RecordExists` is true; otherwise they invoke `createInitialState`, even if
+the provider created its own default. Successful `ClearAsync` exposes a fresh
+configured default. Defaults are never automatically written. An existing null
+record or a null factory result is an error.
 
-This is achieved by composition rather than reimplementation: the
-default `StateManager<T>` wraps an `IPersistentState<T>` facet that
-Orleans hydrates during the `SetupState` grain-lifecycle stage. The
-manager exposes `State` as a proxy onto that underlying storage, so it
-sees the hydrated value the moment Orleans's lifecycle hook fires —
-before `OnActivateAsync` is invoked.
-
-`ReadAsync` is retained for the rare case where the grain wants to
-force a re-read of authoritative state mid-activation (e.g. after a
-known external mutation). It is not required by the activation flow.
+The optional `configureState` callback restores runtime dependencies, such as the
+tracker's clock, on each adopted instance. It must not change business data or
+perform storage I/O. It applies after reads and recovery as well as initial hydration.
 
 ### `WriteAsync` semantics
 
@@ -178,54 +176,11 @@ derives from it, the manager stamps a fresh `Guid Version` before every
 write and uses that version for the recovery-path equality check;
 otherwise it falls back to `T.Equals(...)`.
 
-```csharp
-internal sealed class StateManager<T>(IPersistentState<T> storage) : IStateManager<T>
-    where T : class, IEquatable<T>
-{
-    public T? State => storage.State;
-
-    public Task ReadAsync() => storage.ReadStateAsync();
-
-    public async Task WriteAsync(T newState)
-    {
-        var previous = storage.State;
-
-        if (newState is VersionedState versioned)
-        {
-            versioned.Version = Guid.CreateVersion7();
-        }
-
-        storage.State = newState;
-
-        try
-        {
-            await storage.WriteStateAsync();
-        }
-        catch (Exception ex)
-        {
-            try { await storage.ReadStateAsync(); }
-            catch
-            {
-                storage.State = previous;
-                throw;
-            }
-
-            if (ex is not InconsistentStateException && IsEquivalent(storage.State, newState))
-            {
-                return; // write actually persisted; lost-response, swallow
-            }
-
-            throw;
-        }
-    }
-
-    private static bool IsEquivalent(T? persisted, T attempted) =>
-        persisted is not null
-        && (persisted is VersionedState pv && attempted is VersionedState av
-            ? pv.Version.Equals(av.Version)
-            : persisted.Equals(attempted));
-}
-```
+The manager retains a separate observable snapshot. It assigns the write candidate
+to storage, awaits persistence, then adopts the successful value. A recovery read
+adopts the server value (or an absent-record default) while retaining the refreshed
+ETag. Equivalence can confirm a lost response only when a persisted record exists;
+a reconstructed default must never be mistaken for proof that a write landed.
 
 Behaviour matrix:
 
@@ -234,7 +189,7 @@ Behaviour matrix:
 | Success                            | `State == newState`, returns                     |
 | Timeout, write actually persisted  | `State == newState`, returns (silent recovery)   |
 | Timeout, write did not persist     | `State == server's value`, throws original ex    |
-| Recovery read exposes `null`       | `State == null`, throws original ex              |
+| Recovery read finds no record     | `State == configured default`, throws original ex |
 | 5xx / transient                    | Same as timeout — re-read decides                |
 | `InconsistentStateException`       | `State == server's value`, **always rethrows**   |
 | Re-read also fails (double failure)| `storage.State` reverted, throws original ex     |
@@ -321,8 +276,8 @@ The wrapper was debated — recovery logic is stateless, could be an
 extension method on `IPersistentState<T>`. But the wrapper does a fourth
 thing extensions cannot: **it hides `IPersistentState<T>.State`**.
 
-`IStateManager<T>.State` exposes only the **committed** snapshot, or
-`null` when the storage provider exposes no value. During an in-flight write,
+`IStateManager<T>.State` exposes the loaded or **committed** snapshot, or
+the configured default for absent storage. During an in-flight write,
 `IPersistentState<T>.State` already holds the uncommitted value. Read
 methods marked `[AlwaysInterleave]` that access `storage.State` directly
 could observe uncommitted state — and if the write fails, they returned
@@ -335,40 +290,23 @@ Extension methods can't provide this fence because the grain still holds
 ### Grain wiring
 
 ```csharp
-// User injects IPersistentState<T> as normal, registers wrapper in activation.
-[PersistentState("state")] IPersistentState<MyState> storage;
-IStateManager<MyState> stateManager;
+private readonly IStateManager<MyState> stateManager;
 
-public override Task OnActivateAsync(CancellationToken ct)
+public MyGrain([PersistentState("state")] IPersistentState<MyState> storage, TimeProvider time)
 {
-    stateManager = this.RegisterStateManager("state", storage);
-    // ...
+    stateManager = this.RegisterStateManager("state", storage,
+        () => new MyState(),
+        state => state.Tracker.RegisterTimeProvider(time));
 }
 ```
 
-`RegisterStateManager()` is an extension method on `IGrainBase`. Internally:
+`RegisterStateManager(storageName, storage, createInitialState, configureState?)`
+requires `TState : class, IEquatable<TState>`. The two-argument convenience overload
+requires `new()` and creates `new TState()` only when needed.
 
-```csharp
-public static IStateManager<TState> RegisterStateManager<TGrain, TState>(
-    this TGrain grain,
-    string storageName,
-    IPersistentState<TState> storage)
-    where TGrain : IGrainBase
-    where TState : class, IEquatable<TState>
-```
-
-The silo must register a keyed `IStateManagerFactory<T>` for each storage
-name used by grains:
-
-```csharp
-siloBuilder.AddDefaultStateManager("state");
-```
-
-Provider-specific overrides can be supplied with `AddStateManagerFactory(...)`.
-The activation-time `RegisterStateManager(...)` call mirrors
-`RegisterStreamManager(...)` and `RegisterGrainTimer(...)`: the grain registers
-the runtime helper once during activation and uses the returned manager for
-all subsequent state reads and writes.
+Register a keyed `IStateManagerFactory` with `AddDefaultStateManager`,
+`AddAzureStorageStateManager`, or `AddStateManagerFactory`. Its `Create<T>` method
+receives storage, the default factory, and optional runtime configuration.
 
 ---
 
@@ -414,7 +352,7 @@ The collection behaves like `ImmutableArray<OutboxMessageEnvelope<T>>`
 — read-only iteration, indexer, value semantics, mutators return new
 instances — with three additions:
 
-- A baked-in `Sender` (grain id).
+- A sender-free stored `OutboxMessageId` for each item.
 - A monotonic `LatestSequenceNumber` that persists independently of the
   message array contents.
 - `Add` mutators that own sequence assignment and either sample system
@@ -422,80 +360,41 @@ instances — with three additions:
 
 ### Shape
 
+`OutboxMessageId` stores `(SequenceNumber, Timestamp, Epoch)`. The stored envelope
+contains `Id` and `Message`. The processor combines that ID with the owning grain's
+identity to construct the delivery `OutboxSequenceToken`; it never writes the sender
+back into the outbox. Tokens remain identical across retries and reactivation.
+
 ```csharp
-[GenerateSerializer]
-public sealed record OutboxSequenceToken(
-    [property: Id(0)] long SequenceNumber,
-    [property: Id(1)] GrainId Sender,
-    [property: Id(2)] DateTimeOffset Timestamp,
-    [property: Id(3)] DateTimeOffset Epoch);
+public sealed record OutboxMessageId(long SequenceNumber, DateTimeOffset Timestamp, DateTimeOffset Epoch);
+public sealed record OutboxMessageEnvelope<T>(OutboxMessageId Id, T Message);
 
-[GenerateSerializer]
-public sealed record OutboxMessageEnvelope<T>(
-    [property: Id(0)] OutboxSequenceToken Token,
-    [property: Id(1)] T Message);
-
-[GenerateSerializer]
-public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquatable<Outbox<T>>
-{
-    [Id(0)] private readonly GrainId sender;
-    [Id(1)] private readonly long latestSequenceNumber;
-    [Id(2)] private readonly ImmutableArray<OutboxMessageEnvelope<T>> items;
-    [Id(3)] private readonly DateTimeOffset? epoch;
-
-    internal Outbox(
-        GrainId sender,
-        long latestSequenceNumber,
-        ImmutableArray<OutboxMessageEnvelope<T>> items,
-        DateTimeOffset? epoch)
-    {
-        this.sender = sender;
-        this.latestSequenceNumber = latestSequenceNumber;
-        this.items = items;
-        this.epoch = epoch;
-    }
-
-    public static Outbox<T> Create(GrainId sender) =>
-        new(sender, latestSequenceNumber: 0, items: [], epoch: null);
-
-    public GrainId Sender => sender;
-    public long LatestSequenceNumber => latestSequenceNumber;
-    public DateTimeOffset? Epoch => epoch;
-    public int Count => items.Length;
-    public bool IsEmpty => items.IsDefaultOrEmpty;
-    public OutboxMessageEnvelope<T> this[int index] => items[index];
-
-    public IEnumerator<OutboxMessageEnvelope<T>> GetEnumerator()
-        => ((IEnumerable<OutboxMessageEnvelope<T>>)items).GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    public Outbox<T> Add(T message) { /* delegates with system UTC */ }
-    public Outbox<T> Add(T message, DateTimeOffset utcNow)
-        { /* increments seq, stamps epoch on first call */ }
-    public Outbox<T> Remove(OutboxSequenceToken token) { /* removes FIFO head if token matches */ }
-    public Outbox<T> RemoveRange(IEnumerable<OutboxSequenceToken> tokens) { /* removes matching FIFO prefix */ }
-    public Outbox<T> Clear() { /* removes all items, preserves LatestSequenceNumber + Epoch */ }
-
-    // O(1) sequence equality — see below.
-    public bool Equals(Outbox<T>? other) { /* metadata + first/last sequence check */ }
-    public override bool Equals(object? obj) => obj is Outbox<T> o && Equals(o);
-    public override int GetHashCode() { /* metadata + first/last sequence hash */ }
-}
+// Public collection operations; mutations return new immutable instances.
+Outbox<T>.Create();
+outbox.Add(message);
+outbox.Add(message, utcNow);
+outbox.Remove(id);          // Removes only a matching FIFO head.
+outbox.RemoveRange(ids);    // Removes matching IDs anywhere, preserving remaining order.
+outbox.Clear();             // Preserves sequence high-water mark and epoch.
 ```
+
+The actual types carry Orleans serialization metadata and JSON support. Each stored
+ID field is required in JSON so malformed data cannot silently acquire default
+sequence metadata. This beta changes the stored shape without a legacy migration.
 
 ### Epoch semantics
 
-- `Create(sender)` → `epoch = null`, `LatestSequenceNumber = 0`.
+- `Create()` → `epoch = null`, `LatestSequenceNumber = 0`.
 - First `Add()` → stamps `epoch = now`. Persisted with state.
 - Subsequent `Add()` → same epoch, incrementing sequence number.
 - `Clear()` → removes items, **preserves** `LatestSequenceNumber` and
   `Epoch`. This is the normal "postman drained successfully" path.
-- `Create(sender)` again → **resets both** epoch (to null) and sequence
+- `Create()` again → **resets both** epoch (to null) and sequence
   number (to 0). This is the nuclear option — the next `Add` starts a
   fresh epoch. Receivers see `token.Epoch > stored.Epoch` and accept.
 
 **`Clear()` is the normal path.** Grains should almost never call
-`Create(sender)` on an active outbox. `Create` is for construction-time
+`Create()` on an active outbox. `Create` is for construction-time
 initialisation and deliberate ops-level sequence-space resets.
 Document and warn.
 
@@ -513,21 +412,11 @@ The outbox can grow unbounded if postman targets are down. Mitigation:
 
 ### O(1) sequence equality
 
-Two `Outbox<T>` values are equal when
-`(Sender, LatestSequenceNumber, Epoch, Count, first sequence number, last sequence number)`
-matches. Constant-time regardless of `items.Length`.
-
-This relies on the outbox invariant that sequence numbers are assigned
-only by `Add` and pending items are removed only in FIFO order. Under
-that invariant, matching first and last sequence numbers with matching
-count identifies the same contiguous pending sequence window. Equality
-therefore stays independent of outbox depth and does not need a separate
-persisted fingerprint field.
-
-If two outboxes have the same sender, epoch, high-water mark, count, and
-sequence-window endpoints but different payloads, the outbox was used in
-a way that broke encapsulation/invariants. Equality does not attempt to
-detect that invalid state.
+Equality uses `(LatestSequenceNumber, Epoch, Count, first ID, last ID)`, including
+ID timestamps. It is a recovery fingerprint, not payload equality. Removal can
+leave gaps, so matching endpoints does not imply a contiguous sequence. See the
+source documentation for the existing removal-divergence and exact-timestamp-tie
+tradeoffs; this change preserves those semantics while removing sender identity.
 
 ### Why these choices
 
@@ -542,9 +431,8 @@ detect that invalid state.
   clock reference and require no post-deserialization registration.
 - **Lazy `Epoch`.** A grain that never sends doesn't burn a fresh epoch
   on storage.
-- **`Remove(token)` not `Remove(envelope)`.** Token is the identity, but
-  removal is constrained to the FIFO head to preserve the contiguous
-  pending-sequence invariant.
+- **`Remove(id)` and `RemoveRange(ids)`.** Single removal checks the FIFO head;
+  batch acknowledgment removes the successful stored IDs even across gaps.
 - **`LatestSequenceNumber` is a separate field.** After flush, items are
   empty; high-water mark persists independently.
 
@@ -584,7 +472,7 @@ User state:
 [GenerateSerializer]
 public sealed record MyState : VersionedState
 {
-    [Id(1)] public Outbox<MyEvent> Outbox { get; init; } = Outbox<MyEvent>.Create(sender);
+    [Id(1)] public Outbox<MyEvent> Outbox { get; init; } = Outbox<MyEvent>.Create();
     [Id(2)] public ImmutableArray<Something> Items { get; init; } = [];
 }
 ```
@@ -697,7 +585,7 @@ public sealed class MessageTracker
 
 ### Identity model (no OriginId)
 
-- Outbox identity: `OutboxSequenceToken.Sender` in the envelope.
+- Outbox identity: `OutboxSequenceToken.Sender` supplied by the processor at delivery.
   Payloads stay clean.
 - Stream identity: stream namespace, plus provider name when available.
   Stream keys are intentionally not part of `MessageTracker` state because
@@ -876,7 +764,7 @@ public static class StreamManagerExtensions
 {
     public static StreamManager RegisterStreamManager<TGrain>(
         this TGrain grain,
-        MessageTracker? trackerSnapshot = null)
+        Func<MessageTracker?>? getTracker = null)
         where TGrain : IGrainBase;
 }
 
@@ -897,7 +785,7 @@ custom identity which does not round-trip through `GrainId.TryParse`. Use the
 
 `RegisterStreamManager()` can be called without a `MessageTracker` when the
 grain does not persist stream high-water marks. In that mode the manager
-attaches handlers without supplying resume tokens. Pass the activation-time
+attaches handlers without supplying resume tokens. Pass an accessor for the hydrated
 tracker snapshot only when the grain wants `StreamManager` to resume from
 persisted cursors.
 
@@ -917,7 +805,7 @@ public override async Task OnActivateAsync(CancellationToken ct)
     var state = await stateManager.ReadAsync();
     state.Tracker.RegisterTimeProvider(timeProvider);
 
-    this.RegisterStreamManager(state.Tracker)
+    this.RegisterStreamManager(() => state.Tracker)
         .ConfigureImplicitSubscription("electricity-prices", HandlePriceTickAsync, LogStreamError)
         .ConfigureImplicitSubscription("tariff-events", HandleTariffChangedAsync, useTrackedResumeToken: false);
 }
@@ -952,7 +840,7 @@ public override async Task OnActivateAsync(CancellationToken ct)
     var state = await stateManager.ReadAsync();
     state.Tracker.RegisterTimeProvider(timeProvider);
 
-    streamManager = this.RegisterStreamManager(state.Tracker)
+    streamManager = this.RegisterStreamManager(() => state.Tracker)
         .ConfigureExplicitSubscription("StreamProvider", "tariff-events", HandleTariffChangedAsync);
 
     await streamManager.EnsureExplicitSubscriptionsAsync(ct);
@@ -975,7 +863,7 @@ the stream id. Use the `StreamId` overload when the target stream needs an
 application-owned identity or is not keyed by the receiving grain:
 
 ```csharp
-streamManager = this.RegisterStreamManager(state.Tracker)
+streamManager = this.RegisterStreamManager(() => state.Tracker)
     .ConfigureExplicitSubscription<PriceChanged>(
         "StreamProvider",
         StreamId.Create("tariff-events", customerId),
@@ -1277,8 +1165,8 @@ in the `Clever.PricingEngine` codebase.
 ### Postman dispatch
 
 The grain registers one or more postmen via `AddPostman<TSub>(...)`, each
-handling a subtype of `TOutbox`. Matching is first-registered-wins against
-the item's runtime type — order from most specific to least specific (like a
+handling a payload subtype of `TOutbox`. Matching is first-registered-wins against
+the payload's runtime type — order from most specific to least specific (like a
 `switch`).
 
 Postmen can be inline callbacks for local/simple cases, or keyed
@@ -1332,12 +1220,10 @@ public static class OutboxPostmanServiceCollectionExtensions
   with attempt count (in-memory, resets on reactivation) — the grain
   decides: leave item in state to retry, or remove to dead-letter after
   N attempts.
-- Pending items dispatch concurrently within a single drain. The processor
-  starts all matching postman calls, waits for all of them, then invokes
-  `AcknowledgePostedAsync` with successful items in original pending order
-  and `ReconcileFailedAsync` with failed items. This avoids head-of-line
-  blocking between independent postmen while keeping durable reconciliation
-  batched and ordered.
+- Different postmen dispatch concurrently. Each postman processes its matching
+  items sequentially and stops after a failure. Reconciliation receives original
+  stored envelopes, with acknowledgment containing only successful items; do not
+  assume a contiguous prefix or global ordering across groups.
 - Each item dispatches to exactly **one** postman (first-registered-wins).
   Items whose runtime type matches no postman → reported as failed with
   `NoPostmanRegisteredException`.
@@ -1474,17 +1360,17 @@ extension<TGrain>(TGrain grain) where TGrain : IOutboxGrain, IGrainBase
 public sealed class OutboxProcessorOptions<TOutbox> where TOutbox : notnull
 {
     /// Snapshot of pending items. Called once per post run from a grain turn.
-    public required Func<ImmutableArray<TOutbox>> PendingItems { get; init; }
+    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>> PendingItems { get; init; }
 
     /// Acknowledges successfully posted items.
     /// Expected to remove those items from the durable outbox state.
-    public required Func<ImmutableArray<TOutbox>, CancellationToken, ValueTask>
+    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>, CancellationToken, ValueTask>
         AcknowledgePostedAsync { get; init; }
 
     /// Failed items with exception and attempt count (in-memory, resets on
     /// reactivation). Grain decides: leave to retry, or remove to
     /// dead-letter after N attempts. If null, failed items retry silently.
-    public Func<ImmutableArray<(TOutbox Item, Exception Error, int Attempt)>,
+    public Func<ImmutableArray<(OutboxMessageEnvelope<TOutbox> Item, Exception Error, int Attempt)>,
         CancellationToken, ValueTask>? ReconcileFailedAsync { get; init; }
 
     /// Max time per post run. Set below grain's response timeout.
@@ -1539,6 +1425,14 @@ callbacks, not passive notifications:
 
 ### `OutboxProcessor<TOutbox>`
 
+`TOutbox` is the base payload type. All handler families operate on payloads;
+stored envelopes are confined to pending snapshots and reconciliation callbacks.
+Token-aware `AddPostman` overloads accept `(message, token)` or
+`(message, token, cancellationToken)`. Stream projections and selectors can receive
+`(message, token)`, and grain invocations can receive
+`(grain, message, token[, cancellationToken])`. These adapters retain the original
+stored item for acknowledgment. A covariant envelope interface is unnecessary.
+
 ```csharp
 public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     where TOutbox : notnull
@@ -1591,10 +1485,10 @@ internal interface IOutboxComponent
 
 ### Grain author experience
 
-Two obligations (both compiler-enforced):
+Two obligations (registration is checked at runtime):
 
 1. Implement `IOutboxGrain`.
-2. Call `RegisterOutboxProcessor(...)` in `OnActivateAsync`.
+2. Call `RegisterOutboxProcessor(...)` in the constructor or `OnActivateAsync`.
 
 No `ReceiveReminder` override needed (DIM handles it). No manual retry
 lifecycle. No telemetry wiring.
@@ -1860,7 +1754,7 @@ Dedicated tests for every type with `[GenerateSerializer]`:
 - Catches: missing `[Id]`, wrong `[Alias]`, `ImmutableArray<T>` edge
   cases, version-tolerance regressions, STJ converter bugs.
 
-Types covered: `Outbox<T>`, `OutboxMessageEnvelope<T>`,
+Types covered: `Outbox<T>`, `OutboxMessageId`, `OutboxMessageEnvelope<T>`,
 `MessageTracker`, `OutboxSequenceToken`, `StreamCursor`,
 `VersionedState` subtypes.
 

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -167,6 +167,14 @@ record or a null factory result is an error.
 The optional `configureState` callback restores runtime dependencies, such as the
 tracker's clock, on each adopted instance. It must not change business data or
 perform storage I/O. It applies after reads and recovery as well as initial hydration.
+The manager and raw storage facet adopt the new snapshot before configuration.
+If configuration fails, that snapshot stays visible and the callback exception
+propagates. Configuration after a successful write/clear runs outside storage
+recovery, so a callback failure never causes an extra recovery read or silent retry.
+After successful recovery reads, state validation, default factories, and configuration
+also run outside the storage-read catch. Their errors propagate rather than being
+replaced by the original write/clear exception. Failed recovery reads still restore
+the previous local snapshot and preserve the original storage error.
 
 ### `WriteAsync` semantics
 
@@ -1444,7 +1452,10 @@ This compiler support requires C# 13 or newer. Older compilers need explicit
 delegate or lambda return types for otherwise ambiguous lambdas. Grain factories are captured or supplied through the resolver
 of `AddGrainPostman`; the second direct-callback argument is always a delivery token.
 
-Stream projections and selectors remain synchronous and can receive `(message, token)`.
+Stream projections and selectors remain synchronous and independently choose
+`(message)` or `(message, token)`. Token-aware routing also supports forwarding the
+original payload without an identity projection. Direct and grouped registration
+provide the same combinations.
 Grain invocations take `(grain, message)`, `(grain, message, token)`, or
 `(grain, message, token, cancellationToken)` with the same Task/ValueTask overload
 priority.
@@ -1484,9 +1495,18 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         string streamProviderName,
         Func<TSub, StreamId> streamId)
         where TSub : TOutbox;
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub>(
+        string streamProviderName,
+        Func<TSub, OutboxSequenceToken, StreamId> streamId)
+        where TSub : TOutbox;
     public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
         string streamProviderName,
         Func<TSub, StreamId> streamId,
+        Func<TSub, TEvent> project)
+        where TSub : TOutbox;
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
+        string streamProviderName,
+        Func<TSub, OutboxSequenceToken, StreamId> streamId,
         Func<TSub, TEvent> project)
         where TSub : TOutbox;
     public OutboxStreamProviderBuilder<TOutbox> ForStreamProvider(string streamProviderName);

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -164,6 +164,14 @@ the provider created its own default. Successful `ClearAsync` exposes a fresh
 configured default. Defaults are never automatically written. An existing null
 record or a null factory result is an error.
 
+
+`ClearAsync` deletes storage before calling the default-state factory. The factory
+must return a valid, non-null state. If it throws or returns null, the error
+propagates and the deletion remains completed. A null result is rejected with
+`InvalidOperationException` as a diagnostic. After this factory contract violation,
+the manager has no guaranteed usable state: `State` may still reference the previous
+snapshot and must not be treated as the current persisted state.
+
 The optional `configureState` callback restores runtime dependencies, such as the
 tracker's clock, on each adopted instance. It must not change business data or
 perform storage I/O. It applies after reads and recovery as well as initial hydration.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.State.AzureStorage/AzureStorage/AzureStorageStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.State.AzureStorage/AzureStorage/AzureStorageStateManager.cs
@@ -14,8 +14,11 @@ public sealed class AzureStorageStateManager<T> : StateManagerBase<T>
     /// <summary>
     /// Creates a state manager around an Orleans Azure Storage-backed state facet.
     /// </summary>
-    public AzureStorageStateManager(IPersistentState<T> storage)
-        : base(storage)
+    public AzureStorageStateManager(
+        IPersistentState<T> storage,
+        Func<T> createInitialState,
+        Action<T>? configureState = null)
+        : base(storage, createInitialState, configureState)
     {
     }
 
@@ -40,11 +43,11 @@ public sealed class AzureStorageStateManager<T> : StateManagerBase<T>
 public sealed class AzureStorageStateManagerFactory : IStateManagerFactory
 {
     /// <inheritdoc/>
-    public IStateManager<T> Create<T>(IPersistentState<T> storage)
+    public IStateManager<T> Create<T>(IPersistentState<T> storage, Func<T> createInitialState, Action<T>? configureState = null)
         where T : class, IEquatable<T>
     {
         ArgumentNullException.ThrowIfNull(storage);
-        return new AzureStorageStateManager<T>(storage);
+        return new AzureStorageStateManager<T>(storage, createInitialState, configureState);
     }
 }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/NoPostmanRegisteredException.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/NoPostmanRegisteredException.cs
@@ -2,7 +2,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 
 /// <summary>
 /// Thrown (internally, via <see cref="OutboxProcessorOptions{TOutbox}.ReconcileFailedAsync"/>)
-/// when an outbox item's runtime type does not match any registered postman.
+/// when an outbox payload's runtime type does not match any registered postman.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -15,7 +15,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// <b>Common cause:</b> A new subtype of the outbox base type was added but no
 /// corresponding <see cref="OutboxProcessor{TOutbox}.AddPostman{TSub}(Func{TSub, ValueTask})"/>
 /// call was registered. Fix by adding the missing postman registration in
-/// <c>OnActivateAsync</c>.
+/// the grain constructor or <c>OnActivateAsync</c>.
 /// </para>
 /// <para>
 /// <b>Postman ordering:</b> Postmen are matched first-registered-wins. If a

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
@@ -40,18 +40,12 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// Grains should almost never call <see cref="Create()"/> on an active outbox.
 /// </para>
 /// <para>
-/// <b>Equality:</b> Two <see cref="Outbox{T}"/> instances are equal when
-/// sequence metadata, epoch, count, and the full first and last
-/// pending IDs are equal. Equality is O(1) and ignores message payloads —
-/// it is a fingerprint, not deep content equality. Within a single history
-/// lineage every mutation changes the fingerprint (<see cref="Add(T)"/> changes
-/// the last token, removals change the count or tokens), so dirty-check
-/// "skip write if unchanged" logic is safe. Outboxes from <em>divergent</em>
-/// histories (duplicate activations of the same grain) can compare equal when
-/// they diverged only by removals; treating them as interchangeable
-/// re-delivers already posted items but never loses pending ones. See
-/// <see cref="Equals(Outbox{T}?)"/> for the full contract before relying on
-/// equality for anything beyond dirty-checks or write recovery.
+/// <b>Equality:</b> Snapshot identity and sequence metadata are compared in O(1),
+/// without scanning payloads. Each changed snapshot receives a fresh UUIDv7
+/// <see cref="Revision"/>. Serialization preserves it, while no-op mutations
+/// return the existing snapshot. This permits recovery to confirm a saved
+/// snapshot without mistaking a competing append or removal for the same write.
+/// Independently constructed snapshots are unequal even with identical contents.
 /// </para>
 /// <para>
 /// <b>Unbounded growth risk:</b> If postman targets are down, the outbox grows
@@ -84,6 +78,12 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     [Id(3)] private readonly DateTimeOffset? epoch;
 
     /// <summary>
+    /// UUIDv7 identity of this snapshot, used as an outbox-specific ETag for recovery.
+    /// Changes with each mutation and survives serialization. It is not a delivery token.
+    /// </summary>
+    [Id(4)] public Guid Revision { get; }
+
+    /// <summary>
     /// Internal constructor used by mutation methods to produce new instances.
     /// Not user-callable — use <see cref="Create()"/> to create the
     /// initial outbox, then <see cref="Add(T)"/> to append messages.
@@ -91,11 +91,13 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     internal Outbox(
         long latestSequenceNumber,
         ImmutableArray<OutboxMessageEnvelope<T>> items,
-        DateTimeOffset? epoch)
+        DateTimeOffset? epoch,
+        Guid revision)
     {
         this.latestSequenceNumber = latestSequenceNumber;
         this.items = items;
         this.epoch = epoch;
+        Revision = revision;
     }
 
     /// <summary>
@@ -111,7 +113,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// "postman drained" path.
     /// </remarks>
     public static Outbox<T> Create() =>
-        new(latestSequenceNumber: 0, items: [], epoch: null);
+        new(latestSequenceNumber: 0, items: [], epoch: null, revision: Guid.CreateVersion7());
 
     /// <summary>
     /// The highest sequence number ever assigned in this outbox, including
@@ -197,7 +199,8 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         return new Outbox<T>(
             sequenceNumber,
             items.Add(new OutboxMessageEnvelope<T>(token, message)),
-            epoch);
+            epoch,
+            Guid.CreateVersion7());
     }
 
     /// <summary>
@@ -221,7 +224,8 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         return new Outbox<T>(
             latestSequenceNumber,
             items.RemoveAt(0),
-            epoch);
+            epoch,
+            Guid.CreateVersion7());
     }
 
     /// <summary>
@@ -260,7 +264,8 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         return new Outbox<T>(
             latestSequenceNumber,
             remaining,
-            epoch);
+            epoch,
+            Guid.CreateVersion7());
     }
 
     /// <summary>
@@ -284,56 +289,27 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         return new Outbox<T>(
             latestSequenceNumber,
             [],
-            epoch);
+            epoch,
+            Guid.CreateVersion7());
     }
 
     /// <summary>
-    /// O(1) equality over the outbox identity and sequence fingerprint:
-    /// latest sequence number, epoch, count, and the full first and
-    /// last pending tokens (including their timestamps).
+    /// O(1) snapshot equality using the revision and sequence fingerprint.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// This equality is the contract the state-manager write recovery relies
-    /// on: after an ambiguous storage write (the call threw but the write may
-    /// have landed, e.g. a timeout or lost response), the state manager reads
-    /// the persisted state back and uses <c>Equals</c> to decide between
-    /// "lost response — the write landed, swallow the error" and "the write
-    /// did not land — rethrow so the caller retries". A false positive here
-    /// would make recovery adopt a foreign state and silently drop pending
-    /// messages, so the fingerprint must never compare equal for a history
-    /// that is missing items this instance added.
-    /// </para>
-    /// <para>
-    /// The fingerprint intentionally does not compare message payloads, to
-    /// avoid an O(n) scan on every recovery. It is still loss-safe because
-    /// items are only ever appended at the tail: two histories that diverged
-    /// by <em>adding</em> different messages — for example duplicate grain
-    /// activations of the same grain in two silos racing an ambiguous write —
-    /// always differ in count or in their highest pending token. The token
-    /// timestamp is stamped by the producing activation's clock, which also
-    /// distinguishes same-count races unless both activations produced the
-    /// exact same timestamp.
-    /// </para>
-    /// <para>
-    /// Note that direct optimistic-concurrency conflicts are not handled
-    /// here: when the storage provider reports an ETag conflict
-    /// (<c>InconsistentStateException</c>) the state manager rethrows it even
-    /// if the values happen to match, so this equality only decides the
-    /// ambiguous-outcome cases described above.
-    /// </para>
-    /// <para>
-    /// Accepted trade-off: histories that diverged only by <em>removals</em>
-    /// (or the exact-timestamp tie above) can still compare equal. Recovery
-    /// then at worst re-delivers an already posted item — duplicate delivery
-    /// is acceptable under the at-least-once contract, losing a pending
-    /// message is not.
-    /// </para>
+    /// Every mutation assigns a fresh UUIDv7 revision. Recovery can therefore
+    /// distinguish competing snapshots even when append timestamps, sequence
+    /// numbers, and endpoint IDs match. Serialization preserves the revision
+    /// so a successful write with a lost response can still be confirmed.
+    /// Independently constructed snapshots are unequal even with identical payloads.
+    /// Revisions are compared for equality, not order: clock order cannot prove persistence.
     /// </remarks>
     public bool Equals(Outbox<T>? other)
     {
         return ReferenceEquals(this, other)
             || (other is not null
+                && Revision != Guid.Empty
+                && Revision == other.Revision
                 && latestSequenceNumber == other.latestSequenceNumber
                 && epoch == other.epoch
                 && items.Length == other.items.Length
@@ -347,17 +323,15 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// <inheritdoc/>
     public override int GetHashCode()
         => HashCode.Combine(
+            Revision,
             latestSequenceNumber,
             epoch,
             items.Length,
             FirstToken,
             LastToken);
 
-    // Full tokens (sequence number + epoch + timestamp) rather than bare
-    // sequence numbers: the timestamp comes from the producing activation's
-    // clock, so it disambiguates duplicate activations that appended different
-    // items yet reached the same sequence number. See Equals for the recovery
-    // contract this protects.
+    // Retain the sequence fingerprint as a consistency check alongside the
+    // revision. Timestamps alone cannot distinguish competing append histories.
     private OutboxMessageId? FirstToken =>
         items.IsDefaultOrEmpty ? null : items[0].Id;
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
@@ -214,19 +214,19 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     }
 
     /// <summary>
-    /// Removes the message identified by <paramref name="token"/> from the outbox.
+    /// Removes the message identified by <paramref name="id"/> from the outbox.
     /// </summary>
     /// <remarks>
     /// Matches the full <see cref="OutboxMessageId"/> identity against the
-    /// first pending item. If the token is not the FIFO head, returns the same
+    /// first pending item. If the id is not the FIFO head, returns the same
     /// instance unchanged. Does <b>not</b> affect
     /// <see cref="LatestSequenceNumber"/> or <see cref="Epoch"/>.
     /// </remarks>
-    /// <param name="token">The token of the message to remove.</param>
+    /// <param name="id">The stored ID of the message to remove.</param>
     /// <returns>A new outbox without the specified message.</returns>
-    public Outbox<T> Remove(OutboxMessageId token)
+    public Outbox<T> Remove(OutboxMessageId id)
     {
-        if (items.IsDefaultOrEmpty || items[0].Id != token)
+        if (items.IsDefaultOrEmpty || items[0].Id != id)
         {
             return this;
         }
@@ -239,19 +239,19 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     }
 
     /// <summary>
-    /// Batch-removes messages identified by <paramref name="tokens"/>.
+    /// Batch-removes messages identified by <paramref name="ids"/>.
     /// </summary>
     /// <remarks>
-    /// Removes all pending messages whose tokens appear in
-    /// <paramref name="tokens"/> and preserves the original order of messages
-    /// that remain pending. Tokens not found in the outbox are silently ignored.
+    /// Removes all pending messages whose ids appear in
+    /// <paramref name="ids"/> and preserves the original order of messages
+    /// that remain pending. IDs not found in the outbox are silently ignored.
     /// </remarks>
-    /// <param name="tokens">The tokens of the messages to remove.</param>
+    /// <param name="ids">The stored IDs of the messages to remove.</param>
     /// <returns>A new outbox without the specified messages.</returns>
-    public Outbox<T> RemoveRange(IEnumerable<OutboxMessageId> tokens)
+    public Outbox<T> RemoveRange(IEnumerable<OutboxMessageId> ids)
     {
-        var tokenSet = tokens.ToHashSet();
-        if (tokenSet.Count == 0)
+        var idSet = ids.ToHashSet();
+        if (idSet.Count == 0)
         {
             return this;
         }
@@ -259,7 +259,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         var remainingBuilder = ImmutableArray.CreateBuilder<OutboxMessageEnvelope<T>>(items.Length);
         foreach (var item in items)
         {
-            if (!tokenSet.Contains(item.Id))
+            if (!idSet.Contains(item.Id))
             {
                 remainingBuilder.Add(item);
             }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
@@ -20,7 +20,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// </para>
 /// <para>
 /// <b>Sequence ownership:</b> Only <see cref="Add(T)"/> assigns sequence numbers.
-/// Callers supply the payload; the outbox stamps <see cref="OutboxSequenceToken"/>
+/// Callers supply the payload; the outbox stamps <see cref="OutboxMessageId"/>
 /// with a monotonically increasing <see cref="LatestSequenceNumber"/> and the
 /// current <see cref="Epoch"/>. This is a hard invariant — there is no public
 /// constructor that accepts a pre-built sequence number.
@@ -28,7 +28,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// <para>
 /// <b>Epoch semantics:</b>
 /// <list type="bullet">
-/// <item><see cref="Create(GrainId)"/> → <c>Epoch = null</c>,
+/// <item><see cref="Create()"/> → <c>Epoch = null</c>,
 /// <c>LatestSequenceNumber = 0</c>. Use at construction time or for deliberate
 /// ops-level sequence-space resets.</item>
 /// <item>First <see cref="Add(T)"/> → stamps <c>Epoch = now</c>. Persisted with state.</item>
@@ -37,12 +37,12 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// <see cref="LatestSequenceNumber"/> and <see cref="Epoch"/>. This is the normal
 /// "postman drained successfully" path.</item>
 /// </list>
-/// Grains should almost never call <see cref="Create(GrainId)"/> on an active outbox.
+/// Grains should almost never call <see cref="Create()"/> on an active outbox.
 /// </para>
 /// <para>
 /// <b>Equality:</b> Two <see cref="Outbox{T}"/> instances are equal when
-/// sender, sequence metadata, epoch, count, and the full first and last
-/// pending tokens are equal. Equality is O(1) and ignores message payloads —
+/// sequence metadata, epoch, count, and the full first and last
+/// pending IDs are equal. Equality is O(1) and ignores message payloads —
 /// it is a fingerprint, not deep content equality. Within a single history
 /// lineage every mutation changes the fingerprint (<see cref="Add(T)"/> changes
 /// the last token, removals change the count or tokens), so dirty-check
@@ -79,30 +79,27 @@ namespace Egil.Orleans.Messaging.Outboxes;
 [JsonConverter(typeof(OutboxJsonConverterFactory))]
 public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquatable<Outbox<T>>
 {
-    [Id(0)] private readonly GrainId sender;
     [Id(1)] private readonly long latestSequenceNumber;
     [Id(2)] private readonly ImmutableArray<OutboxMessageEnvelope<T>> items;
     [Id(3)] private readonly DateTimeOffset? epoch;
 
     /// <summary>
     /// Internal constructor used by mutation methods to produce new instances.
-    /// Not user-callable — use <see cref="Create(GrainId)"/> to create the
+    /// Not user-callable — use <see cref="Create()"/> to create the
     /// initial outbox, then <see cref="Add(T)"/> to append messages.
     /// </summary>
     internal Outbox(
-        GrainId sender,
         long latestSequenceNumber,
         ImmutableArray<OutboxMessageEnvelope<T>> items,
         DateTimeOffset? epoch)
     {
-        this.sender = sender;
         this.latestSequenceNumber = latestSequenceNumber;
         this.items = items;
         this.epoch = epoch;
     }
 
     /// <summary>
-    /// Creates a fresh, empty outbox for the given <paramref name="sender"/>.
+    /// Creates a fresh, empty outbox without an owning grain identity.
     /// <see cref="Epoch"/> is <c>null</c> and <see cref="LatestSequenceNumber"/>
     /// is <c>0</c>. The next <see cref="Add(T)"/> stamps a new epoch.
     /// </summary>
@@ -113,18 +110,8 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// and accept unconditionally. Prefer <see cref="Clear"/> for the normal
     /// "postman drained" path.
     /// </remarks>
-    /// <param name="sender">
-    /// The <see cref="GrainId"/> of the grain that owns this outbox. Baked
-    /// into every <see cref="OutboxSequenceToken"/> produced by <see cref="Add(T)"/>.
-    /// </param>
-    public static Outbox<T> Create(GrainId sender) =>
-        new(sender, latestSequenceNumber: 0, items: [], epoch: null);
-
-    /// <summary>
-    /// The <see cref="GrainId"/> of the grain that owns this outbox. Baked
-    /// into every <see cref="OutboxSequenceToken"/>.
-    /// </summary>
-    public GrainId Sender => sender;
+    public static Outbox<T> Create() =>
+        new(latestSequenceNumber: 0, items: [], epoch: null);
 
     /// <summary>
     /// The highest sequence number ever assigned in this outbox, including
@@ -135,7 +122,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
 
     /// <summary>
     /// The epoch marker stamped on the first <see cref="Add(T)"/> call. <c>null</c>
-    /// only for a freshly constructed (<see cref="Create(GrainId)"/>) outbox that
+    /// only for a freshly constructed (<see cref="Create()"/>) outbox that
     /// has never had an item added.
     /// </summary>
     public DateTimeOffset? Epoch => epoch;
@@ -206,9 +193,8 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         utcNow = utcNow.ToUniversalTime();
         var epoch = this.epoch ?? utcNow;
         var sequenceNumber = latestSequenceNumber + 1;
-        var token = new OutboxSequenceToken(sequenceNumber, sender, utcNow, epoch);
+        var token = new OutboxMessageId(sequenceNumber, utcNow, epoch);
         return new Outbox<T>(
-            sender,
             sequenceNumber,
             items.Add(new OutboxMessageEnvelope<T>(token, message)),
             epoch);
@@ -218,22 +204,21 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// Removes the message identified by <paramref name="token"/> from the outbox.
     /// </summary>
     /// <remarks>
-    /// Matches the full <see cref="OutboxSequenceToken"/> identity against the
+    /// Matches the full <see cref="OutboxMessageId"/> identity against the
     /// first pending item. If the token is not the FIFO head, returns the same
     /// instance unchanged. Does <b>not</b> affect
     /// <see cref="LatestSequenceNumber"/> or <see cref="Epoch"/>.
     /// </remarks>
     /// <param name="token">The token of the message to remove.</param>
     /// <returns>A new outbox without the specified message.</returns>
-    public Outbox<T> Remove(OutboxSequenceToken token)
+    public Outbox<T> Remove(OutboxMessageId token)
     {
-        if (items.IsDefaultOrEmpty || items[0].Token != token)
+        if (items.IsDefaultOrEmpty || items[0].Id != token)
         {
             return this;
         }
 
         return new Outbox<T>(
-            sender,
             latestSequenceNumber,
             items.RemoveAt(0),
             epoch);
@@ -249,7 +234,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// </remarks>
     /// <param name="tokens">The tokens of the messages to remove.</param>
     /// <returns>A new outbox without the specified messages.</returns>
-    public Outbox<T> RemoveRange(IEnumerable<OutboxSequenceToken> tokens)
+    public Outbox<T> RemoveRange(IEnumerable<OutboxMessageId> tokens)
     {
         var tokenSet = tokens.ToHashSet();
         if (tokenSet.Count == 0)
@@ -260,7 +245,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         var remainingBuilder = ImmutableArray.CreateBuilder<OutboxMessageEnvelope<T>>(items.Length);
         foreach (var item in items)
         {
-            if (!tokenSet.Contains(item.Token))
+            if (!tokenSet.Contains(item.Id))
             {
                 remainingBuilder.Add(item);
             }
@@ -273,7 +258,6 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
 
         var remaining = remainingBuilder.ToImmutable();
         return new Outbox<T>(
-            sender,
             latestSequenceNumber,
             remaining,
             epoch);
@@ -298,7 +282,6 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         }
 
         return new Outbox<T>(
-            sender,
             latestSequenceNumber,
             [],
             epoch);
@@ -306,7 +289,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
 
     /// <summary>
     /// O(1) equality over the outbox identity and sequence fingerprint:
-    /// sender, latest sequence number, epoch, count, and the full first and
+    /// latest sequence number, epoch, count, and the full first and
     /// last pending tokens (including their timestamps).
     /// </summary>
     /// <remarks>
@@ -351,7 +334,6 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     {
         return ReferenceEquals(this, other)
             || (other is not null
-                && sender.Equals(other.sender)
                 && latestSequenceNumber == other.latestSequenceNumber
                 && epoch == other.epoch
                 && items.Length == other.items.Length
@@ -365,7 +347,6 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// <inheritdoc/>
     public override int GetHashCode()
         => HashCode.Combine(
-            sender,
             latestSequenceNumber,
             epoch,
             items.Length,
@@ -377,9 +358,9 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     // clock, so it disambiguates duplicate activations that appended different
     // items yet reached the same sequence number. See Equals for the recovery
     // contract this protects.
-    private OutboxSequenceToken? FirstToken =>
-        items.IsDefaultOrEmpty ? null : items[0].Token;
+    private OutboxMessageId? FirstToken =>
+        items.IsDefaultOrEmpty ? null : items[0].Id;
 
-    private OutboxSequenceToken? LastToken =>
-        items.IsDefaultOrEmpty ? null : items[^1].Token;
+    private OutboxMessageId? LastToken =>
+        items.IsDefaultOrEmpty ? null : items[^1].Id;
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
@@ -40,7 +40,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// Grains should almost never call <see cref="Create()"/> on an active outbox.
 /// </para>
 /// <para>
-/// <b>Equality:</b> Snapshot identity and sequence metadata are compared in O(1),
+/// <b>Equality:</b> Snapshot revisions are compared in O(1),
 /// without scanning payloads. Each changed snapshot receives a fresh UUIDv7
 /// <see cref="Revision"/>. Serialization preserves it, while no-op mutations
 /// return the existing snapshot. This permits recovery to confirm a saved
@@ -81,6 +81,13 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// UUIDv7 identity of this snapshot, used as an outbox-specific ETag for recovery.
     /// Changes with each mutation and survives serialization. It is not a delivery token.
     /// </summary>
+    /// <remarks>
+    /// An ambiguous storage failure requires proof that the attempted snapshot was saved.
+    /// Sequence numbers and timestamps cannot provide that proof: competing activations
+    /// can append different payloads with identical IDs. A fresh revision distinguishes
+    /// those snapshots without comparing every payload. No-op operations return this
+    /// instance so they preserve its identity; deserialization restores the stored revision.
+    /// </remarks>
     [Id(4)] public Guid Revision { get; }
 
     /// <summary>
@@ -97,6 +104,9 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
         this.latestSequenceNumber = latestSequenceNumber;
         this.items = items;
         this.epoch = epoch;
+        // Restore the supplied identity instead of generating one here. Deserialization
+        // must preserve it so recovery recognizes a saved snapshot after a lost response.
+        // Creation and successful mutations explicitly supply a fresh UUIDv7 instead.
         Revision = revision;
     }
 
@@ -294,7 +304,7 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     }
 
     /// <summary>
-    /// O(1) snapshot equality using the revision and sequence fingerprint.
+    /// O(1) snapshot equality using the persisted revision.
     /// </summary>
     /// <remarks>
     /// Every mutation assigns a fresh UUIDv7 revision. Recovery can therefore
@@ -303,38 +313,26 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// so a successful write with a lost response can still be confirmed.
     /// Independently constructed snapshots are unequal even with identical payloads.
     /// Revisions are compared for equality, not order: clock order cannot prove persistence.
+    /// First/last IDs, count, and sequence metadata are unnecessary once revisions identify
+    /// snapshots. Those checks previously allowed different payloads with matching metadata
+    /// to appear equal, causing recovery to swallow an error for a write that did not land.
+    /// This contract assumes payloads are not changed in place after enqueueing: callers
+    /// must preserve the snapshot represented by the revision.
     /// </remarks>
     public bool Equals(Outbox<T>? other)
     {
+        // Keep equality reflexive, including for an instance loaded from older binary data.
+        // Distinct instances with a missing revision cannot establish persistence identity;
+        // rejecting them is safer than reporting a competing or unknown save as successful.
         return ReferenceEquals(this, other)
             || (other is not null
                 && Revision != Guid.Empty
-                && Revision == other.Revision
-                && latestSequenceNumber == other.latestSequenceNumber
-                && epoch == other.epoch
-                && items.Length == other.items.Length
-                && Equals(FirstToken, other.FirstToken)
-                && Equals(LastToken, other.LastToken));
+                && Revision == other.Revision);
     }
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Outbox<T> o && Equals(o);
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-        => HashCode.Combine(
-            Revision,
-            latestSequenceNumber,
-            epoch,
-            items.Length,
-            FirstToken,
-            LastToken);
-
-    // Retain the sequence fingerprint as a consistency check alongside the
-    // revision. Timestamps alone cannot distinguish competing append histories.
-    private OutboxMessageId? FirstToken =>
-        items.IsDefaultOrEmpty ? null : items[0].Id;
-
-    private OutboxMessageId? LastToken =>
-        items.IsDefaultOrEmpty ? null : items[^1].Id;
+    public override int GetHashCode() => Revision.GetHashCode();
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxDispatcher.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxDispatcher.cs
@@ -8,7 +8,8 @@ internal sealed class OutboxDispatcher<TOutbox>(
     OutboxPostmanRegistry<TOutbox> postmen,
     ILogger logger,
     string grainType,
-    TimeProvider timeProvider)
+    TimeProvider timeProvider,
+    Func<TOutbox, Type> getMessageType)
     where TOutbox : notnull
 {
     public async Task<ImmutableArray<OutboxDispatchResult<TOutbox>>> DispatchAsync(
@@ -98,7 +99,7 @@ internal sealed class OutboxDispatcher<TOutbox>(
 
     private OutboxDispatchResult<TOutbox> DispatchMissingPostman(TOutbox item)
     {
-        var itemType = item.GetType();
+        var itemType = getMessageType(item);
         var error = new NoPostmanRegisteredException(itemType);
         logger.LogWarning(
             error,
@@ -127,7 +128,7 @@ internal sealed class OutboxDispatcher<TOutbox>(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            var itemType = item.GetType();
+            var itemType = getMessageType(item);
             logger.LogError(
                 ex,
                 "Outbox postman failed for item type {OutboxItemType} on grain {GrainType}.",

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
@@ -16,7 +16,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// </para>
 /// <para>
 /// The converter serializes only the structural data needed to reconstruct
-/// the outbox (epoch, sequence numbers, items) while keeping its
+/// the outbox (revision, epoch, sequence numbers, items) while keeping its
 /// persisted representation encapsulated behind read-only properties.
 /// </para>
 /// </remarks>
@@ -63,6 +63,7 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
                 throw new JsonException($"Expected outbox object, got '{reader.TokenType}'.");
             }
 
+            Guid revision = Guid.Empty;
             long latestSequenceNumber = 0;
             var hasLatestSequenceNumber = false;
             DateTimeOffset? epoch = null;
@@ -78,7 +79,8 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
                             ? latestSequenceNumber
                             : throw new JsonException("Missing LatestSequenceNumber."),
                         hasItems ? items : throw new JsonException("Missing Items."),
-                        epoch);
+                        epoch,
+                        revision != Guid.Empty ? revision : throw new JsonException("Missing or empty Revision."));
                 }
 
                 if (reader.TokenType is not JsonTokenType.PropertyName)
@@ -94,6 +96,9 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
 
                 switch (propertyName)
                 {
+                    case nameof(Outbox<T>.Revision):
+                        revision = reader.GetGuid();
+                        break;
                     case nameof(Outbox<T>.LatestSequenceNumber):
                         latestSequenceNumber = reader.GetInt64();
                         hasLatestSequenceNumber = true;
@@ -122,6 +127,7 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
             JsonSerializerOptions options)
         {
             writer.WriteStartObject();
+            writer.WriteString(nameof(Outbox<T>.Revision), value.Revision);
             writer.WriteNumber(nameof(Outbox<T>.LatestSequenceNumber), value.LatestSequenceNumber);
             writer.WritePropertyName(nameof(Outbox<T>.Epoch));
             if (value.Epoch is { } epoch)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
@@ -74,6 +74,9 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
             {
                 if (reader.TokenType is JsonTokenType.EndObject)
                 {
+                    // Never manufacture a revision during a read: it would prevent a
+                    // saved snapshot from matching the attempted write during recovery.
+                    // Missing identity requires migration rather than guessed equality.
                     return new Outbox<T>(
                         hasLatestSequenceNumber
                             ? latestSequenceNumber

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
@@ -16,7 +16,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// </para>
 /// <para>
 /// The converter serializes only the structural data needed to reconstruct
-/// the outbox (sender, epoch, sequence numbers, items) while keeping its
+/// the outbox (epoch, sequence numbers, items) while keeping its
 /// persisted representation encapsulated behind read-only properties.
 /// </para>
 /// </remarks>
@@ -63,7 +63,6 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
                 throw new JsonException($"Expected outbox object, got '{reader.TokenType}'.");
             }
 
-            GrainId? sender = null;
             long latestSequenceNumber = 0;
             var hasLatestSequenceNumber = false;
             DateTimeOffset? epoch = null;
@@ -75,7 +74,6 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
                 if (reader.TokenType is JsonTokenType.EndObject)
                 {
                     return new Outbox<T>(
-                        sender ?? throw new JsonException("Missing Sender."),
                         hasLatestSequenceNumber
                             ? latestSequenceNumber
                             : throw new JsonException("Missing LatestSequenceNumber."),
@@ -96,11 +94,6 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
 
                 switch (propertyName)
                 {
-                    case nameof(Outbox<T>.Sender):
-                        sender = reader.TokenType is JsonTokenType.Null
-                            ? null
-                            : GrainIdJsonConverter.Instance.Read(ref reader, typeof(GrainId), options);
-                        break;
                     case nameof(Outbox<T>.LatestSequenceNumber):
                         latestSequenceNumber = reader.GetInt64();
                         hasLatestSequenceNumber = true;
@@ -129,8 +122,6 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
             JsonSerializerOptions options)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName(nameof(Outbox<T>.Sender));
-            GrainIdJsonConverter.Instance.Write(writer, value.Sender, options);
             writer.WriteNumber(nameof(Outbox<T>.LatestSequenceNumber), value.LatestSequenceNumber);
             writer.WritePropertyName(nameof(Outbox<T>.Epoch));
             if (value.Epoch is { } epoch)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageEnvelope.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageEnvelope.cs
@@ -4,15 +4,15 @@ namespace Egil.Orleans.Messaging.Outboxes;
 
 /// <summary>
 /// Wraps a user-defined message <typeparamref name="T"/> with its
-/// <see cref="OutboxSequenceToken"/>, forming the unit of storage and
-/// dispatch within an <see cref="Outbox{T}"/>.
+/// <see cref="OutboxMessageId"/>, forming the unit of storage and
+/// acknowledgment within an <see cref="Outbox{T}"/>.
 /// </summary>
 /// <remarks>
 /// <para>
 /// <b>Immutability:</b> Envelopes are immutable records. Retry diagnostics
 /// (attempt count, last exception) are <em>not</em> stored on the envelope —
 /// the <see cref="OutboxProcessor{TOutbox}"/> tracks attempts in-memory,
-/// keyed by <see cref="Token"/>. On grain reactivation, attempt counts
+/// keyed by stored item equality. On grain reactivation, attempt counts
 /// restart from zero.
 /// </para>
 /// <para>
@@ -45,28 +45,28 @@ public sealed record OutboxMessageEnvelope<T>
     [SetsRequiredMembers]
     public OutboxMessageEnvelope()
     {
-        Token = new OutboxSequenceToken();
+        Id = new OutboxMessageId(0, default, default);
         Message = default!;
     }
 
     /// <summary>
-    /// Creates an envelope for the given token and message payload.
+    /// Creates an envelope for the given stored identity and message payload.
     /// </summary>
     [SetsRequiredMembers]
-    public OutboxMessageEnvelope(OutboxSequenceToken token, T message)
+    public OutboxMessageEnvelope(OutboxMessageId id, T message)
     {
-        ArgumentNullException.ThrowIfNull(token);
+        ArgumentNullException.ThrowIfNull(id);
 
-        Token = token;
+        Id = id;
         Message = message;
     }
 
     /// <summary>
-    /// The sequence token identifying this message. Assigned by
+    /// The sender-free identity of this stored message. Assigned by
     /// <see cref="Outbox{T}.Add(T)"/> — never user-constructed.
     /// </summary>
     [Id(0)]
-    public required OutboxSequenceToken Token { get; init; }
+    public required OutboxMessageId Id { get; init; }
 
     /// <summary>
     /// The user-defined message payload.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageEnvelopeJsonConverterFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageEnvelopeJsonConverterFactory.cs
@@ -56,7 +56,7 @@ internal sealed class OutboxMessageEnvelopeJsonConverterFactory : JsonConverterF
                 throw new JsonException($"Expected outbox message envelope object, got '{reader.TokenType}'.");
             }
 
-            OutboxSequenceToken? token = null;
+            OutboxMessageId? token = null;
             T? message = default;
             var hasMessage = false;
             while (reader.Read())
@@ -64,7 +64,7 @@ internal sealed class OutboxMessageEnvelopeJsonConverterFactory : JsonConverterF
                 if (reader.TokenType is JsonTokenType.EndObject)
                 {
                     return new OutboxMessageEnvelope<T>(
-                        token ?? throw new JsonException("Missing Token."),
+                        token ?? throw new JsonException("Missing Id."),
                         hasMessage ? message! : throw new JsonException("Missing Message."));
                 }
 
@@ -81,16 +81,8 @@ internal sealed class OutboxMessageEnvelopeJsonConverterFactory : JsonConverterF
 
                 switch (propertyName)
                 {
-                    case nameof(OutboxMessageEnvelope<T>.Token):
-                        try
-                        {
-                            token = JsonSerializer.Deserialize<OutboxSequenceToken>(ref reader, options);
-                        }
-                        catch (JsonException exception) when (exception.Message == "Missing Sender.")
-                        {
-                            throw new JsonException("Missing Token.Sender.", exception);
-                        }
-
+                    case nameof(OutboxMessageEnvelope<T>.Id):
+                        token = JsonSerializer.Deserialize<OutboxMessageId>(ref reader, options);
                         break;
                     case nameof(OutboxMessageEnvelope<T>.Message):
                         message = reader.TokenType is JsonTokenType.Null
@@ -113,8 +105,8 @@ internal sealed class OutboxMessageEnvelopeJsonConverterFactory : JsonConverterF
             JsonSerializerOptions options)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName(nameof(OutboxMessageEnvelope<T>.Token));
-            JsonSerializer.Serialize(writer, value.Token, options);
+            writer.WritePropertyName(nameof(OutboxMessageEnvelope<T>.Id));
+            JsonSerializer.Serialize(writer, value.Id, options);
             writer.WritePropertyName(nameof(OutboxMessageEnvelope<T>.Message));
             if (value.Message is null)
             {

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageId.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxMessageId.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Egil.Orleans.Messaging.Outboxes;
+
+/// <summary>
+/// Durable identity of an item within an outbox. Sender identity is supplied
+/// by the processor only when constructing a delivery token.
+/// </summary>
+/// <param name="SequenceNumber">The monotonic sequence within the epoch.</param>
+/// <param name="Timestamp">The original append time, preserved during retries.</param>
+/// <param name="Epoch">The sequence-space epoch, preserved when an outbox drains.</param>
+[GenerateSerializer]
+[Alias("egil.orleans.messaging.OutboxMessageId")]
+public sealed record OutboxMessageId(
+    [property: Id(0), JsonRequired] long SequenceNumber,
+    [property: Id(1), JsonRequired] DateTimeOffset Timestamp,
+    [property: Id(2), JsonRequired] DateTimeOffset Epoch)
+{
+    internal OutboxSequenceToken ForSender(GrainId sender) =>
+        new(SequenceNumber, sender, Timestamp, Epoch);
+}

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxPostmanRegistry.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxPostmanRegistry.cs
@@ -5,13 +5,12 @@ internal sealed class OutboxPostmanRegistry<TOutbox>
 {
     private readonly List<OutboxPostmanRegistration<TOutbox>> postmen = [];
 
-    public void Add<TSub>(Func<TSub, CancellationToken, ValueTask> postman)
-        where TSub : TOutbox
+    public void Add(
+        Type messageType,
+        Func<TOutbox, bool> matches,
+        Func<TOutbox, CancellationToken, ValueTask> postman)
     {
-        postmen.Add(new OutboxPostmanRegistration<TOutbox>(
-            item => item is TSub,
-            (item, cancellationToken) => postman((TSub)item, cancellationToken),
-            typeof(TSub)));
+        postmen.Add(new OutboxPostmanRegistration<TOutbox>(matches, postman, messageType));
     }
 
     public OutboxPostmanRegistration<TOutbox>? Find(TOutbox item)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -12,6 +12,11 @@ public sealed partial class OutboxProcessor<TOutbox>
     /// Postman matching is first-match-wins, like a switch statement. Register
     /// more specific message types before base interfaces or catch-all types.
     /// Each outbox item is dispatched to at most one postman.
+    /// Callbacks take the payload, optionally followed by its delivery token and
+    /// cancellation token. Argument count selects the overload, even for unused
+    /// lambda parameters. All callbacks return ValueTask: adding equivalent Task
+    /// overloads would make ordinary async lambdas ambiguous. Wrap an existing
+    /// Task-returning method in an async lambda when registering it.
     /// </remarks>
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, ValueTask> postman) where TSub : TOutbox
@@ -21,30 +26,22 @@ public sealed partial class OutboxProcessor<TOutbox>
         return this;
     }
 
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, Task> postman) where TSub : TOutbox
+    /// <summary>Registers a ValueTask payload handler that also receives the stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, ValueTask> postman)
+        where TSub : TOutbox
     {
         ArgumentNullException.ThrowIfNull(postman);
-        AddPayloadPostman<TSub>((item, _) => new ValueTask(postman(item)));
-        return this;
+        return AddPostman<TSub>((message, token, _) => postman(message, token));
     }
 
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, CancellationToken, Task> postman) where TSub : TOutbox
+    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
+        where TSub : TOutbox
     {
         ArgumentNullException.ThrowIfNull(postman);
-        AddPayloadPostman<TSub>((item, cancellationToken) => new ValueTask(postman(item, cancellationToken)));
-        return this;
-    }
-
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, IGrainFactory, CancellationToken, ValueTask> postman) where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        AddPayloadPostman<TSub>((item, cancellationToken) => postman(item, grainFactory, cancellationToken));
+        postmen.Add(typeof(TSub), item => item.Message is TSub,
+            (item, cancellationToken) => postman((TSub)item.Message,
+                item.Id.ForSender(owner.GrainContext.GrainId), cancellationToken));
         return this;
     }
 
@@ -104,51 +101,21 @@ public sealed partial class OutboxProcessor<TOutbox>
     /// <summary>
     /// Registers a postman that resolves a grain for each item and invokes it.
     /// </summary>
+    /// <remarks>
+    /// Like AddPostman, grain invocation callbacks have one ValueTask return shape.
+    /// Additional arguments supply the delivery token and then cancellation. Await
+    /// Task-returning grain methods inside an async lambda to avoid return-type overloads.
+    /// </remarks>
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
-        Func<TGrain, TSub, Task> call)
+        Func<TGrain, TSub, ValueTask> call)
         where TSub : TOutbox
         where TGrain : IGrain
     {
         ArgumentNullException.ThrowIfNull(resolveGrain);
         ArgumentNullException.ThrowIfNull(call);
 
-        AddPayloadPostman<TSub>((message, _) => new ValueTask(call(resolveGrain(message, grainFactory), message)));
-        return this;
-    }
-
-    /// <summary>Registers a payload handler that also receives the stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, Task> postman)
-        where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        return AddPostmanWithToken<TSub>((message, token, _) => new ValueTask(postman(message, token)));
-    }
-
-    /// <summary>Registers a ValueTask payload handler that also receives the stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, ValueTask> postman)
-        where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        return AddPostmanWithToken<TSub>((message, token, _) => postman(message, token));
-    }
-
-    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
-        where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        return AddPostmanWithToken<TSub>((message, token, cancellationToken) => new ValueTask(postman(message, token, cancellationToken)));
-    }
-
-    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
-        where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        postmen.Add(typeof(TSub), item => item.Message is TSub,
-            (item, cancellationToken) => postman((TSub)item.Message,
-                item.Id.ForSender(owner.GrainContext.GrainId), cancellationToken));
+        AddPayloadPostman<TSub>((message, _) => call(resolveGrain(message, grainFactory), message));
         return this;
     }
 
@@ -175,7 +142,7 @@ public sealed partial class OutboxProcessor<TOutbox>
         ArgumentNullException.ThrowIfNull(project);
         var streamProvider = owner.GrainContext.ActivationServices
             .GetRequiredKeyedService<IStreamProvider>(streamProviderName);
-        return AddPostmanWithToken<TSub>((message, token, cancellationToken) =>
+        return AddPostman<TSub>((message, token, cancellationToken) =>
         {
             cancellationToken.ThrowIfCancellationRequested();
             return new ValueTask(streamProvider.GetStream<TEvent>(streamId(message, token))
@@ -186,13 +153,13 @@ public sealed partial class OutboxProcessor<TOutbox>
     /// <summary>Registers a grain invocation that can forward the delivery token for deduplication.</summary>
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
-        Func<TGrain, TSub, OutboxSequenceToken, Task> call)
+        Func<TGrain, TSub, OutboxSequenceToken, ValueTask> call)
         where TSub : TOutbox
         where TGrain : IGrain
     {
         ArgumentNullException.ThrowIfNull(call);
         return AddGrainPostman<TSub, TGrain>(resolveGrain,
-            (grain, message, token, _) => new ValueTask(call(grain, message, token)));
+            (grain, message, token, _) => call(grain, message, token));
     }
 
     /// <summary>Registers a cancellable grain invocation with payload and delivery token.</summary>
@@ -204,7 +171,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     {
         ArgumentNullException.ThrowIfNull(resolveGrain);
         ArgumentNullException.ThrowIfNull(call);
-        return AddPostmanWithToken<TSub>((message, token, cancellationToken) =>
+        return AddPostman<TSub>((message, token, cancellationToken) =>
             call(resolveGrain(message, grainFactory), message, token, cancellationToken));
     }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Streams;
 
@@ -14,10 +15,12 @@ public sealed partial class OutboxProcessor<TOutbox>
     /// Each outbox item is dispatched to at most one postman.
     /// Callbacks take the payload, optionally followed by its delivery token and
     /// cancellation token. Argument count selects the overload, even for unused
-    /// lambda parameters. All callbacks return ValueTask: adding equivalent Task
-    /// overloads would make ordinary async lambdas ambiguous. Wrap an existing
-    /// Task-returning method in an async lambda when registering it.
+    /// lambda parameters. Task and ValueTask callbacks are both supported. With C# 13
+    /// or newer, overload priority prefers ValueTask for ordinary async lambdas,
+    /// while Task-returning method groups and expressions use the Task adapters.
+    /// Older compilers require an explicitly typed delegate or lambda return type.
     /// </remarks>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddPostman<TSub>(
         Func<TSub, ValueTask> postman) where TSub : TOutbox
     {
@@ -27,6 +30,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     }
 
     /// <summary>Registers a ValueTask payload handler that also receives the stable delivery token.</summary>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, ValueTask> postman)
         where TSub : TOutbox
     {
@@ -35,6 +39,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     }
 
     /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
         where TSub : TOutbox
     {
@@ -43,6 +48,45 @@ public sealed partial class OutboxProcessor<TOutbox>
             (item, cancellationToken) => postman((TSub)item.Message,
                 item.Id.ForSender(owner.GrainContext.GrainId), cancellationToken));
         return this;
+    }
+
+    // Priority is applied to the ValueTask overloads, not these adapters. C# first
+    // filters applicable candidates, so Task method groups still reach these methods.
+    // When an async lambda fits both return types, priority selects ValueTask instead.
+    // https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-13.0/overload-resolution-priority
+    /// <summary>Registers a Task payload handler.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostman<TSub>(message => new ValueTask(postman(message)));
+    }
+
+    /// <summary>Registers a Task payload handler with its delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostman<TSub>((message, token) => new ValueTask(postman(message, token)));
+    }
+
+    /// <summary>Registers a cancellable Task payload handler with its delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostman<TSub>((message, token, cancellationToken) => new ValueTask(postman(message, token, cancellationToken)));
+    }
+
+    /// <summary>Selects an existing stream provider for a group of postman registrations.</summary>
+    /// <remarks>
+    /// This does not install an Orleans provider or create another processor. Each
+    /// nested registration immediately joins this processor's first-match registry.
+    /// </remarks>
+    public OutboxStreamProviderBuilder<TOutbox> ForStreamProvider(string streamProviderName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
+        return new(this, streamProviderName);
     }
 
     /// <summary>
@@ -102,10 +146,12 @@ public sealed partial class OutboxProcessor<TOutbox>
     /// Registers a postman that resolves a grain for each item and invokes it.
     /// </summary>
     /// <remarks>
-    /// Like AddPostman, grain invocation callbacks have one ValueTask return shape.
-    /// Additional arguments supply the delivery token and then cancellation. Await
-    /// Task-returning grain methods inside an async lambda to avoid return-type overloads.
+    /// Like AddPostman, grain invocation callbacks support Task and ValueTask.
+    /// Additional arguments supply the delivery token and then cancellation.
+    /// ValueTask overload priority keeps ordinary async lambdas unambiguous on C# 13+;
+    /// Task-returning grain methods can also be registered directly.
     /// </remarks>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
         Func<TGrain, TSub, ValueTask> call)
@@ -151,6 +197,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     }
 
     /// <summary>Registers a grain invocation that can forward the delivery token for deduplication.</summary>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
         Func<TGrain, TSub, OutboxSequenceToken, ValueTask> call)
@@ -163,6 +210,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     }
 
     /// <summary>Registers a cancellable grain invocation with payload and delivery token.</summary>
+    [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,
         Func<TGrain, TSub, OutboxSequenceToken, CancellationToken, ValueTask> call)
@@ -173,6 +221,42 @@ public sealed partial class OutboxProcessor<TOutbox>
         ArgumentNullException.ThrowIfNull(call);
         return AddPostman<TSub>((message, token, cancellationToken) =>
             call(resolveGrain(message, grainFactory), message, token, cancellationToken));
+    }
+
+    /// <summary>Registers a Task grain invocation for each payload.</summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, Task> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(call);
+        return AddGrainPostman<TSub, TGrain>(resolveGrain,
+            (grain, message) => new ValueTask(call(grain, message)));
+    }
+
+    /// <summary>Registers a Task grain invocation with its delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, OutboxSequenceToken, Task> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(call);
+        return AddGrainPostman<TSub, TGrain>(resolveGrain,
+            (grain, message, token) => new ValueTask(call(grain, message, token)));
+    }
+
+    /// <summary>Registers a cancellable Task grain invocation with its delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, OutboxSequenceToken, CancellationToken, Task> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(call);
+        return AddGrainPostman<TSub, TGrain>(resolveGrain,
+            (grain, message, token, cancellationToken) => new ValueTask(call(grain, message, token, cancellationToken)));
     }
 
     private void AddPayloadPostman<TSub>(Func<TSub, CancellationToken, ValueTask> postman)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -1,0 +1,207 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams;
+
+namespace Egil.Orleans.Messaging.Outboxes;
+
+public sealed partial class OutboxProcessor<TOutbox>
+{
+    /// <summary>
+    /// Registers a postman that handles payloads of type <typeparamref name="TSub"/>.
+    /// </summary>
+    /// <remarks>
+    /// Postman matching is first-match-wins, like a switch statement. Register
+    /// more specific message types before base interfaces or catch-all types.
+    /// Each outbox item is dispatched to at most one postman.
+    /// </remarks>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, ValueTask> postman) where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        AddPayloadPostman<TSub>((item, _) => postman(item));
+        return this;
+    }
+
+    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, Task> postman) where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        AddPayloadPostman<TSub>((item, _) => new ValueTask(postman(item)));
+        return this;
+    }
+
+    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, CancellationToken, Task> postman) where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        AddPayloadPostman<TSub>((item, cancellationToken) => new ValueTask(postman(item, cancellationToken)));
+        return this;
+    }
+
+    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(
+        Func<TSub, IGrainFactory, CancellationToken, ValueTask> postman) where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        AddPayloadPostman<TSub>((item, cancellationToken) => postman(item, grainFactory, cancellationToken));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a keyed <see cref="IPostman{TMessage}"/> service that handles
+    /// items of type <typeparamref name="TSub"/>.
+    /// </summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(string postmanName)
+        where TSub : TOutbox
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(postmanName);
+
+        var postman = owner.GrainContext.ActivationServices
+            .GetRequiredKeyedService<IPostman<TSub>>(postmanName);
+
+        AddPayloadPostman<TSub>(postman.PostAsync);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a postman that publishes each item to an Orleans stream.
+    /// </summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub>(
+        string streamProviderName,
+        Func<TSub, StreamId> streamId)
+        where TSub : TOutbox =>
+        AddStreamPostman<TSub, TSub>(
+            streamProviderName,
+            streamId,
+            static message => message);
+
+    /// <summary>
+    /// Registers a postman that projects each item and publishes the projected
+    /// event to an Orleans stream.
+    /// </summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
+        string streamProviderName,
+        Func<TSub, StreamId> streamId,
+        Func<TSub, TEvent> project)
+        where TSub : TOutbox
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
+        ArgumentNullException.ThrowIfNull(streamId);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var streamProvider = owner.GrainContext.ActivationServices
+            .GetRequiredKeyedService<IStreamProvider>(streamProviderName);
+
+        AddPayloadPostman<TSub>((message, _) =>
+        {
+            var stream = streamProvider.GetStream<TEvent>(streamId(message));
+            return new ValueTask(stream.OnNextAsync(project(message)));
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a postman that resolves a grain for each item and invokes it.
+    /// </summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, Task> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(resolveGrain);
+        ArgumentNullException.ThrowIfNull(call);
+
+        AddPayloadPostman<TSub>((message, _) => new ValueTask(call(resolveGrain(message, grainFactory), message)));
+        return this;
+    }
+
+    /// <summary>Registers a payload handler that also receives the stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostman<TSub>((message, token, _) => new ValueTask(postman(message, token)));
+    }
+
+    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostman<TSub>((message, token, cancellationToken) => new ValueTask(postman(message, token, cancellationToken)));
+    }
+
+    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        postmen.Add(typeof(TSub), item => item.Message is TSub,
+            (item, cancellationToken) => postman((TSub)item.Message,
+                item.Id.ForSender(owner.GrainContext.GrainId), cancellationToken));
+        return this;
+    }
+
+    /// <summary>Registers a stream projection which can include delivery metadata in its event.</summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
+        string streamProviderName,
+        Func<TSub, StreamId> streamId,
+        Func<TSub, OutboxSequenceToken, TEvent> project)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(streamId);
+        return AddStreamPostman<TSub, TEvent>(streamProviderName, (message, _) => streamId(message), project);
+    }
+
+    /// <summary>Registers token-aware stream selection and projection for a payload.</summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
+        string streamProviderName,
+        Func<TSub, OutboxSequenceToken, StreamId> streamId,
+        Func<TSub, OutboxSequenceToken, TEvent> project)
+        where TSub : TOutbox
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
+        ArgumentNullException.ThrowIfNull(streamId);
+        ArgumentNullException.ThrowIfNull(project);
+        var streamProvider = owner.GrainContext.ActivationServices
+            .GetRequiredKeyedService<IStreamProvider>(streamProviderName);
+        return AddPostman<TSub>((message, token, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return new ValueTask(streamProvider.GetStream<TEvent>(streamId(message, token))
+                .OnNextAsync(project(message, token)));
+        });
+    }
+
+    /// <summary>Registers a grain invocation that can forward the delivery token for deduplication.</summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, OutboxSequenceToken, Task> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(call);
+        return AddGrainPostman<TSub, TGrain>(resolveGrain,
+            (grain, message, token, _) => new ValueTask(call(grain, message, token)));
+    }
+
+    /// <summary>Registers a cancellable grain invocation with payload and delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
+        Func<TSub, IGrainFactory, TGrain> resolveGrain,
+        Func<TGrain, TSub, OutboxSequenceToken, CancellationToken, ValueTask> call)
+        where TSub : TOutbox
+        where TGrain : IGrain
+    {
+        ArgumentNullException.ThrowIfNull(resolveGrain);
+        ArgumentNullException.ThrowIfNull(call);
+        return AddPostman<TSub>((message, token, cancellationToken) =>
+            call(resolveGrain(message, grainFactory), message, token, cancellationToken));
+    }
+
+    private void AddPayloadPostman<TSub>(Func<TSub, CancellationToken, ValueTask> postman)
+        where TSub : TOutbox =>
+        postmen.Add(typeof(TSub), item => item.Message is TSub,
+            (item, cancellationToken) => postman((TSub)item.Message, cancellationToken));
+}

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -117,6 +117,26 @@ public sealed partial class OutboxProcessor<TOutbox>
             streamId,
             static message => message);
 
+    /// <summary>Publishes the original payload to a stream selected using its delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub>(
+        string streamProviderName,
+        Func<TSub, OutboxSequenceToken, StreamId> streamId)
+        where TSub : TOutbox =>
+        AddStreamPostman<TSub, TSub>(streamProviderName, streamId, static message => message);
+
+    /// <summary>Uses the delivery token for routing while projecting only the payload.</summary>
+    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
+        string streamProviderName,
+        Func<TSub, OutboxSequenceToken, StreamId> streamId,
+        Func<TSub, TEvent> project)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        // Routing metadata and the event contract are independent. Reuse the token-aware
+        // delivery path without requiring callers to add an unused projection parameter.
+        return AddStreamPostman<TSub, TEvent>(streamProviderName, streamId, (message, _) => project(message));
+    }
+
     /// <summary>
     /// Registers a postman that projects each item and publishes the projected
     /// event to an Orleans stream.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -118,23 +118,31 @@ public sealed partial class OutboxProcessor<TOutbox>
     }
 
     /// <summary>Registers a payload handler that also receives the stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, Task> postman)
+    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, Task> postman)
         where TSub : TOutbox
     {
         ArgumentNullException.ThrowIfNull(postman);
-        return AddPostman<TSub>((message, token, _) => new ValueTask(postman(message, token)));
+        return AddPostmanWithToken<TSub>((message, token, _) => new ValueTask(postman(message, token)));
     }
 
-    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
+    /// <summary>Registers a ValueTask payload handler that also receives the stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, ValueTask> postman)
         where TSub : TOutbox
     {
         ArgumentNullException.ThrowIfNull(postman);
-        return AddPostman<TSub>((message, token, cancellationToken) => new ValueTask(postman(message, token, cancellationToken)));
+        return AddPostmanWithToken<TSub>((message, token, _) => postman(message, token));
     }
 
     /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
+    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, Task> postman)
+        where TSub : TOutbox
+    {
+        ArgumentNullException.ThrowIfNull(postman);
+        return AddPostmanWithToken<TSub>((message, token, cancellationToken) => new ValueTask(postman(message, token, cancellationToken)));
+    }
+
+    /// <summary>Registers a cancellable payload handler with its stable delivery token.</summary>
+    public OutboxProcessor<TOutbox> AddPostmanWithToken<TSub>(Func<TSub, OutboxSequenceToken, CancellationToken, ValueTask> postman)
         where TSub : TOutbox
     {
         ArgumentNullException.ThrowIfNull(postman);
@@ -167,7 +175,7 @@ public sealed partial class OutboxProcessor<TOutbox>
         ArgumentNullException.ThrowIfNull(project);
         var streamProvider = owner.GrainContext.ActivationServices
             .GetRequiredKeyedService<IStreamProvider>(streamProviderName);
-        return AddPostman<TSub>((message, token, cancellationToken) =>
+        return AddPostmanWithToken<TSub>((message, token, cancellationToken) =>
         {
             cancellationToken.ThrowIfCancellationRequested();
             return new ValueTask(streamProvider.GetStream<TEvent>(streamId(message, token))
@@ -196,7 +204,7 @@ public sealed partial class OutboxProcessor<TOutbox>
     {
         ArgumentNullException.ThrowIfNull(resolveGrain);
         ArgumentNullException.ThrowIfNull(call);
-        return AddPostman<TSub>((message, token, cancellationToken) =>
+        return AddPostmanWithToken<TSub>((message, token, cancellationToken) =>
             call(resolveGrain(message, grainFactory), message, token, cancellationToken));
     }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Orleans.Streams;
 
 namespace Egil.Orleans.Messaging.Outboxes;
 
@@ -33,9 +31,9 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     private readonly IGrainFactory grainFactory;
     private readonly OutboxProcessorOptions<TOutbox> options;
     private readonly object drainGate = new();
-    private readonly OutboxPostmanRegistry<TOutbox> postmen = new();
-    private readonly OutboxDispatcher<TOutbox> dispatcher;
-    private readonly OutboxReconciler<TOutbox> reconciler;
+    private readonly OutboxPostmanRegistry<OutboxMessageEnvelope<TOutbox>> postmen = new();
+    private readonly OutboxDispatcher<OutboxMessageEnvelope<TOutbox>> dispatcher;
+    private readonly OutboxReconciler<OutboxMessageEnvelope<TOutbox>> reconciler;
     private readonly ILogger logger;
     private readonly string grainType;
     private readonly string reminderName;
@@ -43,7 +41,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     private IGrainTimer? reconciliationTimer;
     private IGrainReminder? reminder;
     private bool checkedForExistingReminder;
-    private OutboxReconciliationBatch<TOutbox>? pendingReconciliation;
+    private OutboxReconciliationBatch<OutboxMessageEnvelope<TOutbox>>? pendingReconciliation;
     private TaskCompletionSource? activeDrain;
     private bool drainRequested;
 
@@ -75,125 +73,14 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         this.logger = logger;
         grainType = owner.GetType().Name;
         reminderName = ReminderPrefix + typeof(TOutbox).FullName;
-        dispatcher = new OutboxDispatcher<TOutbox>(postmen, logger, grainType, options.TimeProvider);
-        reconciler = new OutboxReconciler<TOutbox>(
+        dispatcher = new OutboxDispatcher<OutboxMessageEnvelope<TOutbox>>(postmen, logger, grainType, options.TimeProvider,
+            static item => item.Message is { } message ? message.GetType() : typeof(TOutbox));
+        reconciler = new OutboxReconciler<OutboxMessageEnvelope<TOutbox>>(
             options.AcknowledgePostedAsync,
             options.ReconcileFailedAsync);
     }
 
     internal string ReminderName => reminderName;
-
-    /// <summary>
-    /// Registers a postman that handles items of type <typeparamref name="TSub"/>.
-    /// </summary>
-    /// <remarks>
-    /// Postman matching is first-match-wins, like a switch statement. Register
-    /// more specific message types before base interfaces or catch-all types.
-    /// Each outbox item is dispatched to at most one postman.
-    /// </remarks>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, ValueTask> postman) where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        postmen.Add<TSub>((item, _) => postman(item));
-        return this;
-    }
-
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, Task> postman) where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        postmen.Add<TSub>((item, _) => new ValueTask(postman(item)));
-        return this;
-    }
-
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, CancellationToken, Task> postman) where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        postmen.Add<TSub>((item, cancellationToken) => new ValueTask(postman(item, cancellationToken)));
-        return this;
-    }
-
-    /// <inheritdoc cref="AddPostman{TSub}(Func{TSub, ValueTask})"/>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(
-        Func<TSub, IGrainFactory, CancellationToken, ValueTask> postman) where TSub : TOutbox
-    {
-        ArgumentNullException.ThrowIfNull(postman);
-        postmen.Add<TSub>((item, cancellationToken) => postman(item, grainFactory, cancellationToken));
-        return this;
-    }
-
-    /// <summary>
-    /// Registers a keyed <see cref="IPostman{TMessage}"/> service that handles
-    /// items of type <typeparamref name="TSub"/>.
-    /// </summary>
-    public OutboxProcessor<TOutbox> AddPostman<TSub>(string postmanName)
-        where TSub : TOutbox
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(postmanName);
-
-        var postman = owner.GrainContext.ActivationServices
-            .GetRequiredKeyedService<IPostman<TSub>>(postmanName);
-
-        postmen.Add<TSub>(postman.PostAsync);
-        return this;
-    }
-
-    /// <summary>
-    /// Registers a postman that publishes each item to an Orleans stream.
-    /// </summary>
-    public OutboxProcessor<TOutbox> AddStreamPostman<TSub>(
-        string streamProviderName,
-        Func<TSub, StreamId> streamId)
-        where TSub : TOutbox =>
-        AddStreamPostman<TSub, TSub>(
-            streamProviderName,
-            streamId,
-            static message => message);
-
-    /// <summary>
-    /// Registers a postman that projects each item and publishes the projected
-    /// event to an Orleans stream.
-    /// </summary>
-    public OutboxProcessor<TOutbox> AddStreamPostman<TSub, TEvent>(
-        string streamProviderName,
-        Func<TSub, StreamId> streamId,
-        Func<TSub, TEvent> project)
-        where TSub : TOutbox
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
-        ArgumentNullException.ThrowIfNull(streamId);
-        ArgumentNullException.ThrowIfNull(project);
-
-        var streamProvider = owner.GrainContext.ActivationServices
-            .GetRequiredKeyedService<IStreamProvider>(streamProviderName);
-
-        postmen.Add<TSub>((message, _) =>
-        {
-            var stream = streamProvider.GetStream<TEvent>(streamId(message));
-            return new ValueTask(stream.OnNextAsync(project(message)));
-        });
-        return this;
-    }
-
-    /// <summary>
-    /// Registers a postman that resolves a grain for each item and invokes it.
-    /// </summary>
-    public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
-        Func<TSub, IGrainFactory, TGrain> resolveGrain,
-        Func<TGrain, TSub, Task> call)
-        where TSub : TOutbox
-        where TGrain : IGrain
-    {
-        ArgumentNullException.ThrowIfNull(resolveGrain);
-        ArgumentNullException.ThrowIfNull(call);
-
-        postmen.Add<TSub>((message, _) => new ValueTask(call(resolveGrain(message, grainFactory), message)));
-        return this;
-    }
 
     /// <summary>
     /// Posts one pending snapshot by dispatching each item to its matching
@@ -441,7 +328,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         }
     }
 
-    private async Task<OutboxReconciliationBatch<TOutbox>> ProcessPendingItemsAsync(
+    private async Task<OutboxReconciliationBatch<OutboxMessageEnvelope<TOutbox>>> ProcessPendingItemsAsync(
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -463,7 +350,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     }
 
     private async Task ReconcileAsync(
-        OutboxReconciliationBatch<TOutbox> reconciliation,
+        OutboxReconciliationBatch<OutboxMessageEnvelope<TOutbox>> reconciliation,
         CancellationToken cancellationToken)
     {
         await reconciler.ReconcileAsync(reconciliation, cancellationToken);

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
@@ -15,7 +15,7 @@ public static class OutboxProcessorExtensions
     {
         /// <summary>
         /// Creates and attaches an <see cref="OutboxProcessor{TOutbox}"/> to the
-        /// grain. Call in <c>OnActivateAsync</c> and chain
+        /// grain. Call in its constructor or <c>OnActivateAsync</c> and chain
         /// <see cref="OutboxProcessor{TOutbox}.AddPostman{TSub}(Func{TSub, ValueTask})"/>
         /// calls on the result.
         /// </summary>
@@ -34,17 +34,15 @@ public static class OutboxProcessorExtensions
         /// <para>
         /// <b>Usage:</b>
         /// <code>
-        /// public override async Task OnActivateAsync(CancellationToken ct)
+        /// public MyGrain()
         /// {
         ///     outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions&lt;IMyEvent&gt;
         ///     {
-        ///         PendingItems = () => (stateManager.State
-        ///             ?? throw new InvalidOperationException("State is not initialized.")).Outbox
-        ///             .Select(e => e.Message).ToImmutableArray(),
+        ///         PendingItems = () => stateManager.State.Outbox.ToImmutableArray(),
         ///         AcknowledgePostedAsync = async (items, ct) =>
         ///         {
         ///             // remove exactly the delivered items (match items or their
-        ///             // tokens, never positions) and persist
+        ///             // stored IDs, never positions) and persist
         ///         },
         ///         ReconcileFailedAsync = async (failures, ct) =>
         ///         {
@@ -57,7 +55,7 @@ public static class OutboxProcessorExtensions
         /// </code>
         /// </para>
         /// </remarks>
-        /// <typeparam name="TOutbox">The base type of outbox items.</typeparam>
+        /// <typeparam name="TOutbox">The base payload type of outbox messages.</typeparam>
         /// <param name="options">Processor configuration.</param>
         /// <returns>
         /// The processor instance. Chain <c>AddPostman</c> calls on it, then store

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
@@ -8,7 +8,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// retry work.
 /// </summary>
 /// <typeparam name="TOutbox">
-/// The base type of outbox items. Must match the type parameter of the
+/// The base payload type of outbox messages. Must match the type parameter of the
 /// <see cref="OutboxProcessor{TOutbox}"/> this options instance configures.
 /// </typeparam>
 public sealed class OutboxProcessorOptions<TOutbox>
@@ -18,7 +18,7 @@ public sealed class OutboxProcessorOptions<TOutbox>
     /// Snapshot of pending items. Called once before each post run and again
     /// after reconciliation to decide whether retry work remains.
     /// </summary>
-    public required Func<ImmutableArray<TOutbox>> PendingItems { get; init; }
+    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>> PendingItems { get; init; }
 
     /// <summary>
     /// Called with items that were successfully dispatched by their postmen.
@@ -31,12 +31,11 @@ public sealed class OutboxProcessorOptions<TOutbox>
     /// <see cref="PendingItems"/> snapshot: different postmen dispatch their
     /// groups concurrently, and an item without a matching postman fails in
     /// place while later items can still succeed. Remove the received items
-    /// themselves (for example by their <c>OutboxSequenceToken</c> when
-    /// <typeparamref name="TOutbox"/> is <c>OutboxMessageEnvelope&lt;T&gt;</c>),
+    /// by their <see cref="OutboxMessageEnvelope{T}.Id"/>,
     /// never by position or count — positional removal can drop a failed,
     /// undelivered item and lose it.
     /// </remarks>
-    public required Func<ImmutableArray<TOutbox>, CancellationToken, ValueTask> AcknowledgePostedAsync { get; init; }
+    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>, CancellationToken, ValueTask> AcknowledgePostedAsync { get; init; }
 
     /// <summary>
     /// Called with items that failed dispatch, along with the exception and
@@ -52,7 +51,7 @@ public sealed class OutboxProcessorOptions<TOutbox>
     /// survive activation restarts (max attempts before dead-letter, etc.)
     /// should persist their own counters on the items or grain state.
     /// </remarks>
-    public Func<ImmutableArray<(TOutbox Item, Exception Error, int Attempt)>, CancellationToken, ValueTask>? ReconcileFailedAsync { get; init; }
+    public Func<ImmutableArray<(OutboxMessageEnvelope<TOutbox> Item, Exception Error, int Attempt)>, CancellationToken, ValueTask>? ReconcileFailedAsync { get; init; }
 
     /// <summary>
     /// Maximum time per post run. Default: 20 seconds.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxSequenceToken.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxSequenceToken.cs
@@ -4,7 +4,7 @@ using Egil.Orleans.Messaging.Tracking;
 namespace Egil.Orleans.Messaging.Outboxes;
 
 /// <summary>
-/// Identifies a specific message within an <see cref="Outbox{T}"/>. Combines a
+/// Identifies a delivered message from an <see cref="Outbox{T}"/>. The processor combines a
 /// monotonic sequence number with the sender's identity and timing information
 /// to form a globally unique, totally ordered token per sender.
 /// </summary>
@@ -65,8 +65,8 @@ public sealed record OutboxSequenceToken
 
     /// <summary>
     /// Monotonically increasing sequence number within a single <see cref="Epoch"/>.
-    /// Assigned by <see cref="Outbox{T}.Add(T)"/> — callers cannot fabricate or choose
-    /// sequence numbers. Starts at 1 for each new epoch.
+    /// Assigned to the stored item by <see cref="Outbox{T}.Add(T)"/> and copied
+    /// by the processor into this delivery token. Starts at 1 for each new epoch.
     /// </summary>
     [Id(0)]
     public required long SequenceNumber { get; init; }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxStreamProviderBuilder.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxStreamProviderBuilder.cs
@@ -26,6 +26,24 @@ public sealed class OutboxStreamProviderBuilder<TOutbox> where TOutbox : notnull
         return this;
     }
 
+    /// <summary>Publishes original payloads to streams selected using their delivery tokens.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub>(
+        Func<TSub, OutboxSequenceToken, StreamId> streamId)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId);
+        return this;
+    }
+
+    /// <summary>Uses delivery tokens for routing while projecting only the payload.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub, TEvent>(
+        Func<TSub, OutboxSequenceToken, StreamId> streamId, Func<TSub, TEvent> project)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId, project);
+        return this;
+    }
+
     /// <summary>Projects matching payloads and publishes them to their selected streams.</summary>
     public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub, TEvent>(
         Func<TSub, StreamId> streamId, Func<TSub, TEvent> project)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxStreamProviderBuilder.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxStreamProviderBuilder.cs
@@ -1,0 +1,56 @@
+namespace Egil.Orleans.Messaging.Outboxes;
+
+/// <summary>Groups stream postmen that use the same configured Orleans provider.</summary>
+/// <remarks>
+/// This builder stores only registration context. It forwards every call immediately
+/// to the original processor, preserving registration order across grouped and direct
+/// postmen. Delivery, retry, and acknowledgment remain owned by that processor.
+/// </remarks>
+/// <typeparam name="TOutbox">The processor's base payload type.</typeparam>
+public sealed class OutboxStreamProviderBuilder<TOutbox> where TOutbox : notnull
+{
+    private readonly OutboxProcessor<TOutbox> processor;
+    private readonly string streamProviderName;
+
+    internal OutboxStreamProviderBuilder(OutboxProcessor<TOutbox> processor, string streamProviderName)
+    {
+        this.processor = processor;
+        this.streamProviderName = streamProviderName;
+    }
+
+    /// <summary>Publishes matching payloads to their selected streams.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub>(Func<TSub, StreamId> streamId)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId);
+        return this;
+    }
+
+    /// <summary>Projects matching payloads and publishes them to their selected streams.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub, TEvent>(
+        Func<TSub, StreamId> streamId, Func<TSub, TEvent> project)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId, project);
+        return this;
+    }
+
+    /// <summary>Projects payloads with their delivery tokens before publishing them.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub, TEvent>(
+        Func<TSub, StreamId> streamId, Func<TSub, OutboxSequenceToken, TEvent> project)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId, project);
+        return this;
+    }
+
+    /// <summary>Selects streams and projects payloads using their delivery tokens.</summary>
+    public OutboxStreamProviderBuilder<TOutbox> AddStreamPostman<TSub, TEvent>(
+        Func<TSub, OutboxSequenceToken, StreamId> streamId,
+        Func<TSub, OutboxSequenceToken, TEvent> project)
+        where TSub : TOutbox
+    {
+        processor.AddStreamPostman(streamProviderName, streamId, project);
+        return this;
+    }
+}

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/ActivationStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/ActivationStateManager.cs
@@ -1,0 +1,33 @@
+namespace Egil.Orleans.Messaging.State;
+
+// The stable constructor-time handle delays provider-specific manager creation.
+// Those managers may inspect storage in their constructors, so deferring only
+// the default factory would still let custom factories capture unhydrated state.
+internal sealed class ActivationStateManager<T> : IStateManager<T>
+    where T : class, IEquatable<T>
+{
+    private IStateManager<T>? manager;
+
+    public ActivationStateManager(IGrainLifecycle lifecycle, Func<IStateManager<T>> create)
+    {
+        // A distinct stage is essential: callbacks at SetupState can run in
+        // parallel with Orleans' persistent-state hydration.
+        lifecycle.Subscribe(GetType().FullName!, GrainLifecycleStage.SetupState + 1, cancellationToken =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            manager = create();
+            return Task.CompletedTask;
+        });
+    }
+
+    private IStateManager<T> Manager => manager
+        ?? throw new InvalidOperationException("State is not initialized. Access it after persistent state hydration, starting in OnActivateAsync.");
+
+    public T State => Manager.State;
+
+    public Task ReadAsync() => Manager.ReadAsync();
+
+    public Task WriteAsync(T newState) => Manager.WriteAsync(newState);
+
+    public Task ClearAsync() => Manager.ClearAsync();
+}

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/DefaultStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/DefaultStateManager.cs
@@ -15,8 +15,11 @@ public sealed class DefaultStateManager<T> : StateManagerBase<T>
     /// because general providers give no reliable signal that a write was
     /// rejected before persisting.
     /// </summary>
-    public DefaultStateManager(IPersistentState<T> storage)
-        : base(storage)
+    public DefaultStateManager(
+        IPersistentState<T> storage,
+        Func<T> createInitialState,
+        Action<T>? configureState = null)
+        : base(storage, createInitialState, configureState)
     {
     }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/DefaultStateManagerFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/DefaultStateManagerFactory.cs
@@ -6,10 +6,10 @@ namespace Egil.Orleans.Messaging.State;
 public sealed class DefaultStateManagerFactory : IStateManagerFactory
 {
     /// <inheritdoc/>
-    public IStateManager<T> Create<T>(IPersistentState<T> storage)
+    public IStateManager<T> Create<T>(IPersistentState<T> storage, Func<T> createInitialState, Action<T>? configureState = null)
         where T : class, IEquatable<T>
     {
         ArgumentNullException.ThrowIfNull(storage);
-        return new DefaultStateManager<T>(storage);
+        return new DefaultStateManager<T>(storage, createInitialState, configureState);
     }
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
@@ -2,14 +2,14 @@ namespace Egil.Orleans.Messaging.State;
 
 /// <summary>
 /// A thin wrapper around <see cref="IPersistentState{TState}"/> that guarantees
-/// the grain's observable <see cref="State"/> is never out of sync with what is
-/// durably persisted, even when <see cref="WriteAsync"/> fails ambiguously
+/// the grain's observable <see cref="State"/> exposes the loaded or committed
+/// snapshot (or a default for absent storage), even when <see cref="WriteAsync"/> fails ambiguously
 /// (timeout, network drop, server 5xx, ETag conflict).
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Committed-state fence:</b> <see cref="State"/> exposes only the last
-/// successfully written value. During an in-flight write, the underlying
+/// <b>Committed-state fence:</b> <see cref="State"/> exposes the loaded or last
+/// successfully written value, or a configured default for a missing record. During an in-flight write, the underlying
 /// <see cref="IPersistentState{TState}"/>.State already holds the uncommitted
 /// value. Methods marked <c>[AlwaysInterleave]</c> that read <see cref="State"/>
 /// through this interface are guaranteed to never observe uncommitted state.
@@ -18,7 +18,7 @@ namespace Egil.Orleans.Messaging.State;
 /// </para>
 /// <para>
 /// <b>Usage:</b> Inject <see cref="IPersistentState{TState}"/> as normal via
-/// <c>[PersistentState]</c>, then initialize it during <c>OnActivateAsync</c>:
+/// <c>[PersistentState]</c>, then register the manager in the grain constructor:
 /// <code>
 /// stateManager = this.RegisterStateManager("state", storage);
 /// </code>
@@ -77,21 +77,21 @@ public interface IStateManager<T>
     where T : class, IEquatable<T>
 {
     /// <summary>
-    /// Gets the last successfully committed state snapshot, or
-    /// <see langword="null"/> when the underlying persistent state contains
-    /// no value.
+    /// Gets the loaded or successfully written state, or a configured default
+    /// when no persisted record exists. Defaults are not automatically written.
     /// </summary>
     /// <remarks>
     /// Safe to read from <c>[AlwaysInterleave]</c> methods — returns only
-    /// committed values, never in-flight uncommitted state. This is the
+    /// loaded/committed values or missing-record defaults, never in-flight writes. This is the
     /// committed-state fence that justifies the wrapper over raw
     /// <see cref="IPersistentState{TState}"/>.
     /// </remarks>
-    T? State { get; }
+    T State { get; }
 
     /// <summary>
     /// Re-reads state from durable storage, replacing the current
-    /// <see cref="State"/> snapshot.
+    /// <see cref="State"/> snapshot. Missing records use the configured default
+    /// without writing it. Runtime configuration applies to the adopted instance.
     /// </summary>
     /// <remarks>
     /// Not required during activation — <see cref="IPersistentState{TState}"/>
@@ -133,7 +133,7 @@ public interface IStateManager<T>
 
     /// <summary>
     /// Clears the persisted state. On success, <see cref="State"/> reflects
-    /// the storage provider's cleared value and may be <see langword="null"/>.
+    /// a fresh configured default without writing that default to storage.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
@@ -149,6 +149,14 @@ public interface IStateManager<T>
     /// though this method throws. If recovery also fails, <see cref="State"/>
     /// reverts to its pre-clear value.
     /// </para>
+    /// <para>
+    /// Storage is cleared before the default-state factory runs. The factory must
+    /// return a valid, non-null state. If it throws or returns null, the exception
+    /// propagates and the completed deletion is not undone. No usable-state guarantee
+    /// applies after this factory contract violation: State may still reference the
+    /// previous snapshot, which must not be treated as the current persisted state.
+    /// A null result is rejected with an InvalidOperationException for diagnosis.
+    /// </para>
     /// </remarks>
     Task ClearAsync();
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManagerFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManagerFactory.cs
@@ -10,6 +10,6 @@ public interface IStateManagerFactory
     /// Creates an <see cref="IStateManager{T}"/> for the given
     /// <paramref name="storage"/> facet.
     /// </summary>
-    IStateManager<T> Create<T>(IPersistentState<T> storage)
+    IStateManager<T> Create<T>(IPersistentState<T> storage, Func<T> createInitialState, Action<T>? configureState = null)
         where T : class, IEquatable<T>;
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -11,8 +11,8 @@ namespace Egil.Orleans.Messaging.State;
 /// <remarks>
 /// <para>
 /// <b>Committed-state fence:</b> <see cref="State"/> returns the last
-/// committed value, including <see langword="null"/> when no state value
-/// exists. During <see cref="WriteAsync"/>, the underlying
+/// committed value, or the configured default when no record exists. During
+/// <see cref="WriteAsync"/>, the underlying
 /// <see cref="IPersistentState{T}"/>.State is mutated, but the caller's view
 /// is updated only after the write succeeds. On failure, the recovery path
 /// re-reads from storage to determine whether the write actually landed.
@@ -73,22 +73,32 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     where T : class, IEquatable<T>
 {
     private readonly IPersistentState<T> storage;
-    private T? state;
+    private readonly Func<T> createInitialState;
+    private readonly Action<T>? configureState;
+    private T state;
 
     /// <summary>
     /// Initializes the manager over the grain's persistent state facet,
     /// adopting the currently loaded <c>IPersistentState&lt;T&gt;.State</c>
     /// as the committed snapshot.
     /// </summary>
-    protected StateManagerBase(IPersistentState<T> storage)
+    protected StateManagerBase(
+        IPersistentState<T> storage,
+        Func<T> createInitialState,
+        Action<T>? configureState = null)
     {
         ArgumentNullException.ThrowIfNull(storage);
+        ArgumentNullException.ThrowIfNull(createInitialState);
         this.storage = storage;
-        state = storage.State;
+        this.createInitialState = createInitialState;
+        this.configureState = configureState;
+        state = ResolveLoadedState();
+        configureState?.Invoke(state);
+        storage.State = state;
     }
 
     /// <inheritdoc/>
-    public T? State
+    public T State
     {
         get => state;
     }
@@ -97,7 +107,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     public async Task ReadAsync()
     {
         await storage.ReadStateAsync();
-        state = storage.State;
+        Adopt(ResolveLoadedState());
     }
 
     /// <inheritdoc/>
@@ -117,7 +127,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         try
         {
             await storage.WriteStateAsync();
-            state = storage.State;
+            Adopt(storage.State);
             return;
         }
         catch (Exception ex)
@@ -139,9 +149,9 @@ public abstract class StateManagerBase<T> : IStateManager<T>
                 await storage.ReadStateAsync();
                 T? persisted = storage.State;
                 recoveryReadSucceeded = true;
-                state = persisted;
+                Adopt(ResolveLoadedState());
 
-                if (ex is not InconsistentStateException && IsEquivalent(persisted, newState))
+                if (ex is not InconsistentStateException && storage.RecordExists && IsEquivalent(persisted, newState))
                 {
                     // Lost-response case: write landed, but acknowledgement failed.
                     // The committed fence already reflects the persisted value.
@@ -174,7 +184,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         try
         {
             await storage.ClearStateAsync();
-            state = storage.State;
+            Adopt(CreateInitialState());
             return;
         }
         catch (Exception ex)
@@ -196,7 +206,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
                 // local state should represent "cleared" or the previous value.
                 await storage.ReadStateAsync();
                 recoveryReadSucceeded = true;
-                state = storage.State;
+                Adopt(ResolveLoadedState());
 
                 // A missing record confirms an ambiguous clear, but it cannot
                 // hide a real concurrency conflict caused by another writer.
@@ -267,11 +277,26 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         return persisted.Equals(attempted);
     }
 
-    private void RestoreState(T? previousState)
+    private T ResolveLoadedState() => storage.RecordExists
+        ? storage.State ?? throw new InvalidOperationException("An existing state record contained null.")
+        : CreateInitialState();
+
+    private T CreateInitialState() => createInitialState()
+        ?? throw new InvalidOperationException("The initial state factory returned null.");
+
+    private void Adopt(T value)
+    {
+        // Runtime dependencies belong to the newly adopted instance. Configuring
+        // a previous snapshot would lose them after deserialization or recovery.
+        configureState?.Invoke(value);
+        storage.State = value;
+        state = value;
+    }
+
+    private void RestoreState(T previousState)
     {
         state = previousState;
 
-        // Orleans annotates State as non-null even though clearing reference state can make it null.
-        storage.State = previousState!;
+        storage.State = previousState;
     }
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -259,7 +259,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     /// must never return <c>true</c> when the persisted state is missing data
     /// the attempted write contained, or recovery would adopt a foreign state
     /// and silently lose that data. <c>Outbox&lt;T&gt;.Equals</c> documents
-    /// how its O(1) fingerprint satisfies this contract.
+    /// how its persisted revision and O(1) fingerprint satisfy this contract.
     /// </remarks>
     private static bool IsEquivalent(T? persisted, T attempted)
     {

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -93,8 +93,8 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         this.createInitialState = createInitialState;
         this.configureState = configureState;
         state = ResolveLoadedState();
-        configureState?.Invoke(state);
         storage.State = state;
+        configureState?.Invoke(state);
     }
 
     /// <inheritdoc/>
@@ -127,8 +127,6 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         try
         {
             await storage.WriteStateAsync();
-            Adopt(storage.State);
-            return;
         }
         catch (Exception ex)
         {
@@ -141,31 +139,18 @@ public abstract class StateManagerBase<T> : IStateManager<T>
                 throw;
             }
 
-            var recoveryReadSucceeded = false;
-            try
+            if (!await TryReadForRecoveryAsync(previousState))
             {
-                // Unknown outcome: write may have persisted despite the exception.
-                // Read back from storage to distinguish "lost response" from "real failure."
-                await storage.ReadStateAsync();
-                T? persisted = storage.State;
-                recoveryReadSucceeded = true;
-                Adopt(ResolveLoadedState());
-
-                if (ex is not InconsistentStateException && storage.RecordExists && IsEquivalent(persisted, newState))
-                {
-                    // Lost-response case: write landed, but acknowledgement failed.
-                    // The committed fence already reflects the persisted value.
-                    return;
-                }
+                throw;
             }
-            catch
+
+            // The read succeeded. Validation and user configuration are not storage
+            // failures: let them propagate instead of hiding them behind the write error.
+            T? persisted = storage.State;
+            Adopt(ResolveLoadedState());
+            if (ex is not InconsistentStateException && storage.RecordExists && IsEquivalent(persisted, newState))
             {
-                if (!recoveryReadSucceeded)
-                {
-                    // A failed read yields no trustworthy durable value. Restore
-                    // the pre-write snapshot; the original write error is rethrown below.
-                    RestoreState(previousState);
-                }
+                return;
             }
 
             // A mismatch proves the write did not land. A concurrency conflict
@@ -173,65 +158,63 @@ public abstract class StateManagerBase<T> : IStateManager<T>
             // succeeds, keep the server value paired with its refreshed ETag.
             throw;
         }
+
+        // The write is complete. A callback failure must not trigger another storage
+        // read or be mistaken for a lost response and silently retried.
+        Adopt(storage.State);
     }
 
     /// <inheritdoc/>
     public async Task ClearAsync()
     {
         var previousState = state;
-        var recoveryReadSucceeded = false;
-
         try
         {
             await storage.ClearStateAsync();
-            Adopt(CreateInitialState());
-            return;
         }
         catch (Exception ex)
         {
-            var failureKind = ClassifyClearFailure(ex);
-            if (failureKind is StorageFailureKind.DidNotPersist)
+            if (ClassifyClearFailure(ex) is StorageFailureKind.DidNotPersist)
             {
-                // The provider proved the clear was rejected before it could
-                // persist, so the in-memory view must stay at the pre-clear
-                // state and the original error should be surfaced.
                 RestoreState(previousState);
                 throw;
             }
 
-            try
+            if (!await TryReadForRecoveryAsync(previousState))
             {
-                // Ambiguous failures may have persisted even though the caller
-                // observed an exception. Read back before deciding whether the
-                // local state should represent "cleared" or the previous value.
-                await storage.ReadStateAsync();
-                recoveryReadSucceeded = true;
-                Adopt(ResolveLoadedState());
-
-                // A missing record confirms an ambiguous clear, but it cannot
-                // hide a real concurrency conflict caused by another writer.
-                if (ex is not InconsistentStateException && !storage.RecordExists)
-                {
-                    return;
-                }
-            }
-            catch
-            {
-                // Preserve the original clear exception. A recovery-read
-                // failure tells us nothing useful about whether the clear
-                // landed, so surfacing the original write-path error is the
-                // least surprising failure for the caller.
+                throw;
             }
 
-            if (!recoveryReadSucceeded)
+            // Once storage has returned a record (or confirmed its absence), state
+            // validation and configuration failures belong to the caller, not recovery.
+            Adopt(ResolveLoadedState());
+            if (ex is not InconsistentStateException && !storage.RecordExists)
             {
-                // Without read-back confirmation, keep the local activation
-                // conservative. The next successful read/write can reconcile
-                // against storage.
-                RestoreState(previousState);
+                return;
             }
 
             throw;
+        }
+
+        // Clearing storage and constructing/configuring its replacement are distinct
+        // operations. A bad factory or callback cannot turn a successful clear into
+        // an ambiguous storage failure or cause configuration to be retried.
+        Adopt(CreateInitialState());
+    }
+
+    private async Task<bool> TryReadForRecoveryAsync(T previousState)
+    {
+        try
+        {
+            await storage.ReadStateAsync();
+            return true;
+        }
+        catch
+        {
+            // Only a failed storage read leaves durability unknown. Restore the local
+            // snapshot and let the caller rethrow the original write/clear exception.
+            RestoreState(previousState);
+            return false;
         }
     }
 
@@ -289,11 +272,12 @@ public abstract class StateManagerBase<T> : IStateManager<T>
 
     private void Adopt(T value)
     {
-        // Runtime dependencies belong to the newly adopted instance. Configuring
-        // a previous snapshot would lose them after deserialization or recovery.
-        configureState?.Invoke(value);
+        // Publish the new snapshot before invoking caller code: a callback may read
+        // the manager or raw facet as well as its argument. If configuration fails,
+        // keep the adopted durable snapshot visible and report the callback failure.
         storage.State = value;
         state = value;
+        configureState?.Invoke(value);
     }
 
     private void RestoreState(T previousState)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -259,7 +259,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     /// must never return <c>true</c> when the persisted state is missing data
     /// the attempted write contained, or recovery would adopt a foreign state
     /// and silently lose that data. <c>Outbox&lt;T&gt;.Equals</c> documents
-    /// how its persisted revision and O(1) fingerprint satisfy this contract.
+    /// how its persisted revision satisfies this contract in O(1).
     /// </remarks>
     private static bool IsEquivalent(T? persisted, T attempted)
     {
@@ -274,6 +274,9 @@ public abstract class StateManagerBase<T> : IStateManager<T>
             return persistedVersioned.Version == attemptedVersioned.Version;
         }
 
+        // Outbox equality uses its persisted snapshot revision. Matching sequence windows
+        // alone cannot prove persistence when competing appends share a timestamp. Other
+        // non-versioned state types must provide an equally reliable recovery comparison.
         return persisted.Equals(attempted);
     }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -199,6 +199,10 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         // Clearing storage and constructing/configuring its replacement are distinct
         // operations. A bad factory or callback cannot turn a successful clear into
         // an ambiguous storage failure or cause configuration to be retried.
+        // The clear intentionally happens first: factory failure does not undo the
+        // requested deletion. A valid, non-null default is the caller's contract;
+        // if it is violated, no usable-state guarantee applies to this manager.
+        // In particular, its previous snapshot must not be treated as persisted data.
         Adopt(CreateInitialState());
     }
 

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManagerExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManagerExtensions.cs
@@ -13,20 +13,29 @@ public static class StateManagerExtensions
         where TGrain : IGrainBase
     {
         /// <summary>
+        /// Registers a state manager using a new state instance when no record exists.
+        /// </summary>
+        public IStateManager<TState> RegisterStateManager<TState>(
+            string storageName,
+            IPersistentState<TState> storage)
+            where TState : class, IEquatable<TState>, new() =>
+            grain.RegisterStateManager(storageName, storage, static () => new TState());
+
+        /// <summary>
         /// Creates an <see cref="IStateManager{T}"/> for the given grain using
         /// a keyed <see cref="IStateManagerFactory"/> registration.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// <b>Call site:</b> Typically called once in <c>OnActivateAsync</c>:
+        /// <b>Call site:</b> Call once in the constructor to assign a readonly field,
+        /// or in <c>OnActivateAsync</c> after hydration. Constructor registration
+        /// defers factory invocation until persistent state has loaded:
         /// <code>
-        /// [PersistentState("state")] private readonly IPersistentState&lt;MyState&gt; storage;
-        /// private IStateManager&lt;MyState&gt; stateManager = default!;
+        /// private readonly IStateManager&lt;MyState&gt; stateManager;
         ///
-        /// public override Task OnActivateAsync(CancellationToken ct)
+        /// public MyGrain([PersistentState("state")] IPersistentState&lt;MyState&gt; storage)
         /// {
         ///     stateManager = this.RegisterStateManager("state", storage);
-        ///     // ...
         /// }
         /// </code>
         /// </para>
@@ -47,23 +56,34 @@ public static class StateManagerExtensions
         /// <param name="storage">
         /// The Orleans-managed persistent state facet.
         /// </param>
+        /// <param name="createInitialState">Creates state when no persisted record exists; does not write it.</param>
+        /// <param name="configureState">
+        /// Configures runtime dependencies on each adopted state instance. This
+        /// callback must not change persisted business values or perform storage I/O.
+        /// </param>
         /// <returns>
         /// A keyed <see cref="IStateManager{T}"/> instance.
         /// </returns>
         public IStateManager<TState> RegisterStateManager<TState>(
             string storageName,
-            IPersistentState<TState> storage)
+            IPersistentState<TState> storage,
+            Func<TState> createInitialState,
+            Action<TState>? configureState = null)
             where TState : class, IEquatable<TState>
         {
             ArgumentNullException.ThrowIfNull(grain);
             ArgumentException.ThrowIfNullOrWhiteSpace(storageName);
             ArgumentNullException.ThrowIfNull(storage);
+            ArgumentNullException.ThrowIfNull(createInitialState);
 
             return RegisterStateManagerCore(
                 grain.GrainContext.ActivationServices,
                 storageName,
                 storage,
-                grain.GetType());
+                grain.GetType(),
+                createInitialState,
+                configureState,
+                grain.GrainContext.GrainInstance is null ? grain.GrainContext.ObservableLifecycle : null);
         }
     }
 
@@ -71,7 +91,10 @@ public static class StateManagerExtensions
         IServiceProvider activationServices,
         string storageName,
         IPersistentState<TState> storage,
-        Type grainType)
+        Type grainType,
+        Func<TState> createInitialState,
+        Action<TState>? configureState = null,
+        IGrainLifecycle? lifecycle = null)
         where TState : class, IEquatable<TState>
     {
         ArgumentNullException.ThrowIfNull(activationServices);
@@ -88,6 +111,10 @@ public static class StateManagerExtensions
                 "Register one via AddDefaultStateManager(...) or AddStateManagerFactory(...).");
         }
 
-        return factory.Create<TState>(storage);
+        ArgumentNullException.ThrowIfNull(createInitialState);
+        return lifecycle is null
+            ? factory.Create(storage, createInitialState, configureState)
+            : new ActivationStateManager<TState>(lifecycle,
+                () => factory.Create(storage, createInitialState, configureState));
     }
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManager.cs
@@ -15,7 +15,7 @@ namespace Egil.Orleans.Messaging.Streams;
 public sealed class StreamManager : IStreamManagerComponent
 {
     private readonly IGrainBase owner;
-    private readonly MessageTracker? trackerSnapshot;
+    private readonly Func<MessageTracker?>? getTracker;
     private readonly Func<string, IStreamProvider> getStreamProvider;
     private readonly Func<string, StreamId> getStreamId;
     private readonly ILogger logger;
@@ -26,13 +26,13 @@ public sealed class StreamManager : IStreamManagerComponent
 
     private StreamManager(
         IGrainBase owner,
-        MessageTracker? trackerSnapshot,
+        Func<MessageTracker?>? getTracker,
         Func<string, IStreamProvider> getStreamProvider,
         Func<string, StreamId> getStreamId,
         ILogger logger)
     {
         this.owner = owner;
-        this.trackerSnapshot = trackerSnapshot;
+        this.getTracker = getTracker;
         this.getStreamProvider = getStreamProvider;
         this.getStreamId = getStreamId;
         this.logger = logger;
@@ -43,7 +43,7 @@ public sealed class StreamManager : IStreamManagerComponent
     /// </summary>
     internal static StreamManager Create(
         IGrainBase owner,
-        MessageTracker? trackerSnapshot)
+        Func<MessageTracker?>? getTracker)
     {
         ArgumentNullException.ThrowIfNull(owner);
 
@@ -54,7 +54,7 @@ public sealed class StreamManager : IStreamManagerComponent
 
         var manager = Create(
             owner,
-            trackerSnapshot,
+            getTracker,
             services.GetRequiredKeyedService<IStreamProvider>,
             streamNamespace => CreateStreamId(streamNamespace, owner.GrainContext.GrainId),
             logger);
@@ -65,7 +65,7 @@ public sealed class StreamManager : IStreamManagerComponent
 
     internal static StreamManager Create(
         IGrainBase owner,
-        MessageTracker? trackerSnapshot,
+        Func<MessageTracker?>? getTracker,
         Func<string, IStreamProvider> getStreamProvider,
         Func<string, StreamId> getStreamId,
         ILogger logger)
@@ -75,7 +75,7 @@ public sealed class StreamManager : IStreamManagerComponent
         ArgumentNullException.ThrowIfNull(getStreamId);
         ArgumentNullException.ThrowIfNull(logger);
 
-        return new StreamManager(owner, trackerSnapshot, getStreamProvider, getStreamId, logger);
+        return new StreamManager(owner, getTracker, getStreamProvider, getStreamId, logger);
     }
 
     /// <summary>
@@ -436,6 +436,9 @@ public sealed class StreamManager : IStreamManagerComponent
             return null;
         }
 
+        // Resolve at subscription time: hydration or a later read can replace
+        // the tracker instance captured during grain construction.
+        var trackerSnapshot = getTracker?.Invoke();
         var cursor = string.IsNullOrWhiteSpace(streamProviderName)
             ? trackerSnapshot?.LatestStream(streamNamespace)
             : trackerSnapshot?.LatestStream(streamProviderName, streamNamespace);

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManagerExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManagerExtensions.cs
@@ -18,7 +18,7 @@ public static class StreamManagerExtensions
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Call from <c>OnActivateAsync</c>, then chain
+        /// Call from the grain constructor, then chain
         /// <c>ConfigureImplicitSubscription</c> or
         /// <c>ConfigureExplicitSubscription</c> calls on the returned manager.
         /// </para>
@@ -27,25 +27,25 @@ public static class StreamManagerExtensions
         /// <code>
         /// public override async Task OnActivateAsync(CancellationToken ct)
         /// {
-        ///     streamManager = this.RegisterStreamManager(state.Tracker)
+        ///     streamManager = this.RegisterStreamManager(() => state.Tracker)
         ///         .ConfigureExplicitSubscription("StreamProvider", "electricity-prices", HandlePriceTickAsync);
         ///     await streamManager.EnsureExplicitSubscriptionsAsync(ct);
         /// }
         /// </code>
         /// </para>
         /// </remarks>
-        /// <param name="trackerSnapshot">
-        /// Optional snapshot of the grain's <see cref="MessageTracker"/> at
-        /// activation time. When provided, it is used to look up resume tokens.
+        /// <param name="getTracker">
+        /// Optional accessor for the grain's <see cref="MessageTracker"/> after
+        /// hydration. Evaluated when subscriptions look up resume tokens.
         /// Omit it when the grain does not persist stream tracking state.
         /// </param>
         /// <returns>
         /// The registered <see cref="StreamManager"/>. Store it in a grain field so
         /// configured subscriptions remain rooted for the activation lifetime.
         /// </returns>
-        public StreamManager RegisterStreamManager(MessageTracker? trackerSnapshot = null)
+        public StreamManager RegisterStreamManager(Func<MessageTracker?>? getTracker = null)
         {
-            return StreamManager.Create(grain, trackerSnapshot);
+            return StreamManager.Create(grain, getTracker);
         }
     }
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManagerExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Streams/StreamManagerExtensions.cs
@@ -18,7 +18,7 @@ public static class StreamManagerExtensions
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Call from the grain constructor, then chain
+        /// Call from the grain constructor or OnActivateAsync, then chain
         /// <c>ConfigureImplicitSubscription</c> or
         /// <c>ConfigureExplicitSubscription</c> calls on the returned manager.
         /// </para>

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
@@ -14,7 +14,7 @@ public sealed class AzureStorageStateManagerTests
         {
             WriteException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -35,7 +35,7 @@ public sealed class AzureStorageStateManagerTests
         {
             WriteException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<InvalidOperationException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -57,7 +57,7 @@ public sealed class AzureStorageStateManagerTests
         {
             WriteException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -79,7 +79,7 @@ public sealed class AzureStorageStateManagerTests
         {
             WriteException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -97,7 +97,7 @@ public sealed class AzureStorageStateManagerTests
             WriteException = new RequestFailedException(503, "Server busy."),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.WriteAsync(new TestState("next"));
 
@@ -117,7 +117,7 @@ public sealed class AzureStorageStateManagerTests
                 innerException: null),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.WriteAsync(new TestState("next"));
 
@@ -137,7 +137,7 @@ public sealed class AzureStorageStateManagerTests
                 innerException: null),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.WriteAsync(new TestState("next"));
 
@@ -153,7 +153,7 @@ public sealed class AzureStorageStateManagerTests
             WriteException = new TimeoutException("storage timeout"),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.WriteAsync(new TestState("next"));
 
@@ -174,7 +174,7 @@ public sealed class AzureStorageStateManagerTests
         {
             WriteException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<AggregateException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -202,7 +202,7 @@ public sealed class AzureStorageStateManagerTests
                     innerException: null)),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.WriteAsync(new TestState("next"));
 
@@ -218,7 +218,7 @@ public sealed class AzureStorageStateManagerTests
         {
             ClearException = exception
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
             () => manager.ClearAsync());
@@ -241,13 +241,13 @@ public sealed class AzureStorageStateManagerTests
                 state.RecordExists = false;
             }
         };
-        var manager = new AzureStorageStateManager<TestState>(storage);
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         await manager.ClearAsync();
 
         Assert.Equal(1, storage.ReadCount);
         Assert.False(storage.RecordExists);
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
     }
 
     private sealed record TestState(string Value);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/MessagingTestClusterFixture.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/MessagingTestClusterFixture.cs
@@ -28,12 +28,18 @@ public sealed class MessagingTestClusterFixture : IAsyncLifetime, IGrainActivity
         builder.ConfigureSilo((_, siloBuilder) =>
         {
             siloBuilder.AddMemoryGrainStorage("Default");
+            // Exercise the toolbox's supported STJ storage format across reactivation.
+            siloBuilder.AddMemoryGrainStorage("Payload", options => options.GrainStorageSerializer =
+                new global::Orleans.Storage.SystemTextJsonGrainStorageSerializer(
+                    Microsoft.Extensions.Options.Options.Create(new global::Orleans.Serialization.SystemTextJsonGrainStorageSerializerOptions())));
             siloBuilder.AddMemoryGrainStorage("PubSubStore");
             siloBuilder.UseInMemoryReminderService();
 
             AddStreamProviders(siloBuilder);
             siloBuilder.ConfigureServices(services =>
             {
+                services.AddDefaultStateManager("Default");
+                services.AddDefaultStateManager("Payload");
                 services.AddSingleton(TimeProvider);
                 services
                     .AddOutboxPostman<KeyedOutboxProcessorSuccessPostman>(OutboxProcessorTestPostmanNames.Success)
@@ -41,6 +47,8 @@ public sealed class MessagingTestClusterFixture : IAsyncLifetime, IGrainActivity
                     .AddOutboxPostman<KeyedOutboxProcessorDelayingPostman>(OutboxProcessorTestPostmanNames.Delay);
             });
 
+            // Keep Payload undecorated: the current observer rekeys provider factories,
+            // which would bypass this provider's named serializer configuration.
             siloBuilder.AddGrainActivityCollector(Collector)
                 .CollectStorageActivityFrom("Default");
         });

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
@@ -17,6 +17,7 @@ public sealed class OutboxJsonConverterFactoryTests
 
         Assert.NotNull(roundTripped);
         Assert.Equal(outbox, roundTripped);
+        Assert.Equal(outbox.Revision, roundTripped.Revision);
         Assert.Equal(first, roundTripped[0].Message);
         Assert.Equal(second, roundTripped[1].Message);
     }
@@ -49,6 +50,7 @@ public sealed class OutboxJsonConverterFactoryTests
 
         Assert.NotNull(roundTripped);
         Assert.Equal(outbox, roundTripped);
+        Assert.Equal(outbox.Revision, roundTripped.Revision);
         Assert.Equal("order-17", roundTripped[0].Message.OrderId);
         Assert.Equal(42, roundTripped[0].Message.Quantity);
         Assert.Equal("north", roundTripped[0].Message.Route.Name);
@@ -60,6 +62,7 @@ public sealed class OutboxJsonConverterFactoryTests
     {
         var json = """
             {
+              "Revision": "019931d0-0000-7000-8000-000000000001",
               "LatestSequenceNumber": 0,
               "Epoch": null,
               "Items": []
@@ -76,6 +79,7 @@ public sealed class OutboxJsonConverterFactoryTests
     {
         var json = """
             {
+              "Revision": "019931d0-0000-7000-8000-000000000001",
               "LatestSequenceNumber": 0,
               "Epoch": null
             }
@@ -131,6 +135,24 @@ public sealed class OutboxJsonConverterFactoryTests
         json["Items"]![0]!["Id"]!.AsObject().Remove(field);
 
         Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json.ToJsonString()));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Missing_or_empty_revision_cannot_prove_snapshot_identity(bool includeEmptyRevision)
+    {
+        var json = System.Text.Json.Nodes.JsonNode.Parse(
+            JsonSerializer.Serialize(Outbox<string>.Create()))!.AsObject();
+        json.Remove("Revision");
+        if (includeEmptyRevision)
+        {
+            json["Revision"] = Guid.Empty;
+        }
+
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json.ToJsonString()));
+
+        Assert.Equal("Missing or empty Revision.", exception.Message);
     }
 
     private sealed record ComplexMessage(string OrderId, int Quantity, NestedMessage Route);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
@@ -8,9 +8,8 @@ public sealed class OutboxJsonConverterFactoryTests
     [InlineData("first", "second")]
     public void JsonSerializer_round_trips_outbox_with_string_messages(string first, string second)
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add(first, now).Add(second, now);
 
         var json = JsonSerializer.Serialize(outbox);
@@ -23,11 +22,22 @@ public sealed class OutboxJsonConverterFactoryTests
     }
 
     [Fact]
+    public void Persisted_outbox_does_not_contain_sender_identity()
+    {
+        var outbox = Outbox<string>.Create()
+            .Add("message", new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero));
+
+        var json = JsonSerializer.Serialize(outbox);
+
+        Assert.DoesNotContain("Sender", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("test/sender", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void JsonSerializer_round_trips_outbox_with_complex_messages()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<ComplexMessage>.Create(sender);
+        var outbox = Outbox<ComplexMessage>.Create();
         outbox = outbox.Add(new ComplexMessage(
             "order-17",
             42,
@@ -46,7 +56,7 @@ public sealed class OutboxJsonConverterFactoryTests
     }
 
     [Fact]
-    public void JsonSerializer_throws_json_exception_for_missing_sender()
+    public void JsonSerializer_reads_sender_free_empty_outbox()
     {
         var json = """
             {
@@ -56,8 +66,9 @@ public sealed class OutboxJsonConverterFactoryTests
             }
             """;
 
-        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json));
-        Assert.Equal("Missing Sender.", exception.Message);
+        var outbox = JsonSerializer.Deserialize<Outbox<string>>(json);
+        Assert.NotNull(outbox);
+        Assert.Empty(outbox);
     }
 
     [Fact]
@@ -65,7 +76,6 @@ public sealed class OutboxJsonConverterFactoryTests
     {
         var json = """
             {
-              "Sender": { "Type": "test/sender", "Key": "one" },
               "LatestSequenceNumber": 0,
               "Epoch": null
             }
@@ -80,7 +90,6 @@ public sealed class OutboxJsonConverterFactoryTests
     {
         var json = """
             {
-              "Sender": { "Type": "test/sender", "Key": "one" },
               "LatestSequenceNumber": 1,
               "Epoch": "2026-05-23T12:30:00+00:00",
               "Items": [ null ]
@@ -96,12 +105,11 @@ public sealed class OutboxJsonConverterFactoryTests
     {
         var json = """
             {
-              "Sender": { "Type": "test/sender", "Key": "one" },
               "LatestSequenceNumber": 1,
               "Epoch": "2026-05-23T12:30:00+00:00",
               "Items": [
                 {
-                  "Token": null,
+                  "Id": null,
                   "Message": "order-17"
                 }
               ]
@@ -109,33 +117,20 @@ public sealed class OutboxJsonConverterFactoryTests
             """;
 
         var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json));
-        Assert.Equal("Missing Token.", exception.Message);
+        Assert.Equal("Missing Id.", exception.Message);
     }
 
-    [Fact]
-    public void JsonSerializer_throws_json_exception_for_missing_item_token_sender()
+    [Theory]
+    [InlineData("SequenceNumber")]
+    [InlineData("Timestamp")]
+    [InlineData("Epoch")]
+    public void Missing_stored_identity_fields_are_rejected(string field)
     {
-        var json = """
-            {
-              "Sender": { "Type": "test/sender", "Key": "one" },
-              "LatestSequenceNumber": 1,
-              "Epoch": "2026-05-23T12:30:00+00:00",
-              "Items": [
-                {
-                  "Token": {
-                    "SequenceNumber": 1,
-                    "Sender": null,
-                    "Timestamp": "2026-05-23T12:30:00+00:00",
-                    "Epoch": "2026-05-23T12:30:00+00:00"
-                  },
-                  "Message": "order-17"
-                }
-              ]
-            }
-            """;
+        var outbox = Outbox<string>.Create().Add("message", DateTimeOffset.UnixEpoch);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(outbox))!;
+        json["Items"]![0]!["Id"]!.AsObject().Remove(field);
 
-        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json));
-        Assert.Equal("Missing Token.Sender.", exception.Message);
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json.ToJsonString()));
     }
 
     private sealed record ComplexMessage(string OrderId, int Quantity, NestedMessage Route);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxMessageEnvelopeJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxMessageEnvelopeJsonConverterFactoryTests.cs
@@ -39,9 +39,8 @@ public sealed class OutboxMessageEnvelopeJsonConverterFactoryTests
     [Fact]
     public void JsonSerializer_round_trips_outbox_message_envelope_without_custom_options()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 24, 18, 0, 0, TimeSpan.Zero);
-        var token = new OutboxSequenceToken(11, sender, now, now.AddMinutes(-1));
+        var token = new OutboxMessageId(11, now, now.AddMinutes(-1));
         var envelope = new OutboxMessageEnvelope<string>(token, "hello");
 
         var json = JsonSerializer.Serialize(envelope);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -134,7 +134,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorStreamPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
@@ -145,9 +145,10 @@ public sealed class OutboxProcessorStreamPostmanGrain(
             sink.GetGrainId());
 
         processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddStreamPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(
+            .AddStreamPostman<OutboxProcessorTestEvent, DeliveredOutboxEvent>(
                 OutboxProcessorTestProviderNames.Events,
-                _ => streamId);
+                _ => streamId,
+                static (message, token) => new DeliveredOutboxEvent(message, token));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -162,7 +163,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>> CreateOptions() => new()
+    private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
         PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -177,7 +178,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -192,7 +193,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -202,14 +203,14 @@ public sealed class OutboxProcessorStreamPostmanGrain(
     }
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorProjectedStreamPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorProjectedStreamPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
@@ -220,10 +221,10 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
             sink.GetGrainId());
 
         processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddStreamPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>, OutboxProcessorTestEvent>(
+            .AddStreamPostman<OutboxProcessorTestEvent, OutboxProcessorTestEvent>(
                 OutboxProcessorTestProviderNames.Events,
                 _ => streamId,
-                envelope => envelope.Message);
+                message => message);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -238,7 +239,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>> CreateOptions() => new()
+    private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
         PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -253,7 +254,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -268,7 +269,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -278,7 +279,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
     }
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorProjectedSinkGrain(
@@ -289,7 +290,7 @@ public sealed class OutboxProcessorProjectedSinkGrain(
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        streamManager = this.RegisterStreamManager(state.State.Tracker)
+        streamManager = this.RegisterStreamManager(() => state.State.Tracker)
             .ConfigureExplicitSubscription<OutboxProcessorTestEvent>(
                 OutboxProcessorTestProviderNames.Events,
                 OutboxProcessorTestNamespaces.Events,
@@ -322,16 +323,16 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorGrainPostmanSourceGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
         processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddGrainPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>, IOutboxProcessorGrainPostmanTargetGrain>(
+            .AddGrainPostman<OutboxProcessorTestEvent, IOutboxProcessorGrainPostmanTargetGrain>(
                 (_, grainFactory) => grainFactory.GetGrain<IOutboxProcessorGrainPostmanTargetGrain>(this.GetPrimaryKey()),
-                (target, envelope) => target.ReceiveAsync(envelope.Message.Value));
+                (target, message) => target.ReceiveAsync(message.Value));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -346,7 +347,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>> CreateOptions() => new()
+    private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
         PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -361,7 +362,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -376,7 +377,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -386,7 +387,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
     }
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorGrainPostmanTargetGrain(

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -332,7 +332,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
         processor = this.RegisterOutboxProcessor(CreateOptions())
             .AddGrainPostman<OutboxProcessorTestEvent, IOutboxProcessorGrainPostmanTargetGrain>(
                 (_, grainFactory) => grainFactory.GetGrain<IOutboxProcessorGrainPostmanTargetGrain>(this.GetPrimaryKey()),
-                (target, message) => target.ReceiveAsync(message.Value));
+                async (target, message) => await target.ReceiveAsync(message.Value));
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -35,12 +35,16 @@ public sealed class OutboxPostmanHelperTests(MessagingTestClusterFixture fixture
             ct: TestContext.Current.CancellationToken);
     }
 
-    [Fact]
-    public async Task Projected_stream_postman_delivers_projected_event_and_acknowledges()
+    [Theory]
+    [InlineData("direct-original", "projected-stream-helper")]
+    [InlineData("direct-projection", "projected:projected-stream-helper")]
+    [InlineData("grouped-original", "projected-stream-helper")]
+    [InlineData("grouped-projection", "projected:projected-stream-helper")]
+    public async Task Token_routing_supports_original_and_projected_payloads(string routingMode, string expectedValue)
     {
         var grainKey = Guid.NewGuid();
         var sink = fixture.GrainFactory.GetGrain<IOutboxProcessorProjectedSinkGrain>(grainKey);
-        var source = fixture.GrainFactory.GetGrain<IOutboxProcessorProjectedStreamPostmanGrain>(grainKey);
+        var source = fixture.GrainFactory.GetGrain<IOutboxProcessorProjectedStreamPostmanGrain>(grainKey, routingMode);
         await sink.EnsureActiveAsync();
 
         await source.PublishInBackgroundAsync("projected-stream-helper");
@@ -50,7 +54,7 @@ public sealed class OutboxPostmanHelperTests(MessagingTestClusterFixture fixture
             async () =>
             {
                 var sinkState = await sink.GetStateAsync();
-                Assert.Contains("projected-stream-helper", sinkState.ReceivedValues);
+                Assert.Contains(expectedValue, sinkState.ReceivedValues);
             },
             ct: TestContext.Current.CancellationToken);
 
@@ -102,7 +106,7 @@ public interface IOutboxProcessorStreamPostmanGrain : IGrainWithGuidKey
     Task<OutboxProcessorSourceState> GetStateAsync();
 }
 
-public interface IOutboxProcessorProjectedStreamPostmanGrain : IGrainWithGuidKey
+public interface IOutboxProcessorProjectedStreamPostmanGrain : IGrainWithGuidCompoundKey
 {
     Task PublishInBackgroundAsync(string value);
 
@@ -215,16 +219,34 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
-        var sink = GrainFactory.GetGrain<IOutboxProcessorProjectedSinkGrain>(this.GetPrimaryKey());
+        var key = this.GetPrimaryKey(out var routingMode);
+        var sink = GrainFactory.GetGrain<IOutboxProcessorProjectedSinkGrain>(key);
         var streamId = StreamManager.CreateStreamId(
             OutboxProcessorTestNamespaces.Events,
             sink.GetGrainId());
 
-        processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddStreamPostman<OutboxProcessorTestEvent, OutboxProcessorTestEvent>(
-                OutboxProcessorTestProviderNames.Events,
-                _ => streamId,
-                message => message);
+        processor = this.RegisterOutboxProcessor(CreateOptions());
+        StreamId SelectStream(OutboxProcessorTestEvent _, OutboxSequenceToken token) =>
+            token.Sender == this.GetGrainId() ? streamId : throw new InvalidOperationException("Wrong delivery sender.");
+        static OutboxProcessorTestEvent Project(OutboxProcessorTestEvent message) => new($"projected:{message.Value}");
+
+        switch (routingMode)
+        {
+            case "direct-original":
+                processor.AddStreamPostman<OutboxProcessorTestEvent>(OutboxProcessorTestProviderNames.Events, SelectStream);
+                break;
+            case "direct-projection":
+                processor.AddStreamPostman<OutboxProcessorTestEvent, OutboxProcessorTestEvent>(OutboxProcessorTestProviderNames.Events, SelectStream, Project);
+                break;
+            case "grouped-original":
+                processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events).AddStreamPostman<OutboxProcessorTestEvent>(SelectStream);
+                break;
+            case "grouped-projection":
+                processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events).AddStreamPostman<OutboxProcessorTestEvent, OutboxProcessorTestEvent>(SelectStream, Project);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown routing mode: {routingMode}");
+        }
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -332,7 +332,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
         processor = this.RegisterOutboxProcessor(CreateOptions())
             .AddGrainPostman<OutboxProcessorTestEvent, IOutboxProcessorGrainPostmanTargetGrain>(
                 (_, grainFactory) => grainFactory.GetGrain<IOutboxProcessorGrainPostmanTargetGrain>(this.GetPrimaryKey()),
-                async (target, message) => await target.ReceiveAsync(message.Value));
+                (target, message) => target.ReceiveAsync(message.Value));
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
@@ -497,7 +497,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddPostman<OutboxProcessorTestEvent>(PostAndRequestAnotherDrainAsync);
+            .AddPostman<OutboxProcessorTestEvent>(async (message, _, cancellationToken) => await PostAndRequestAnotherDrainAsync(message, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -577,7 +577,7 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAsync);
+        .AddPostman<OutboxProcessorTestEvent>(async (message, _, cancellationToken) => await PostWithGateAsync(message, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -967,7 +967,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
             RetryDelay = TimeSpan.FromMilliseconds(100),
             InterleaveReconciliationCallbacks = interleaveReconciliation
         })
-        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAsync);
+        .AddPostman<OutboxProcessorTestEvent>(async (message, _, cancellationToken) => await PostWithGateAsync(message, cancellationToken));
 
         state.State.Outbox = EnsureOutbox().Add(new OutboxProcessorTestEvent(value));
         await state.WriteStateAsync();

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
@@ -491,13 +491,13 @@ public sealed class OutboxProcessorReentrantPostGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorReentrantPostGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
     private string? followUpValue;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         processor = this.RegisterOutboxProcessor(CreateOptions())
-            .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PostAndRequestAnotherDrainAsync);
+            .AddPostman<OutboxProcessorTestEvent>(PostAndRequestAnotherDrainAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -515,7 +515,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private async Task PostAndRequestAnotherDrainAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
         CancellationToken cancellationToken)
     {
         if (followUpValue is null)
@@ -529,7 +529,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
         await processor!.PostAsync(cancellationToken);
     }
 
-    private OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>> CreateOptions() => new()
+    private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
         PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -544,7 +544,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -558,7 +558,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
         ValueTask.CompletedTask;
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 [global::Orleans.Concurrency.Reentrant]
@@ -566,18 +566,18 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorConcurrentManualPostGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PostWithGateAsync);
+        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -601,10 +601,10 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
     }
 
     private async Task PostWithGateAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
         CancellationToken cancellationToken)
     {
-        if (envelope.Message.Value != "first")
+        if (envelope.Value != "first")
         {
             return;
         }
@@ -621,7 +621,7 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -635,26 +635,26 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
         ValueTask.CompletedTask;
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorRetryPendingGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorRetryPendingGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
     private bool failPosting = true;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PostItemAsync);
+        .AddPostman<OutboxProcessorTestEvent>(PostItemAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -686,7 +686,7 @@ public sealed class OutboxProcessorRetryPendingGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private ValueTask PostItemAsync(OutboxMessageEnvelope<OutboxProcessorTestEvent> _) =>
+    private ValueTask PostItemAsync(OutboxProcessorTestEvent _) =>
         failPosting
             ? new ValueTask(Task.FromException(new InvalidOperationException("Keep pending for retry.")))
             : ValueTask.CompletedTask;
@@ -698,7 +698,7 @@ public sealed class OutboxProcessorRetryPendingGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -716,25 +716,25 @@ public sealed class OutboxProcessorRetryPendingGrain(
     }
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorReminderCoverageGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorReminderCoverageGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(static _ => ValueTask.CompletedTask);
+        .AddPostman<OutboxProcessorTestEvent>(static _ => ValueTask.CompletedTask);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -763,7 +763,7 @@ public sealed class OutboxProcessorReminderCoverageGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -777,7 +777,7 @@ public sealed class OutboxProcessorReminderCoverageGrain(
         ValueTask.CompletedTask;
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }
 
 public sealed class OutboxProcessorValidationCoverageGrain(
@@ -801,12 +801,12 @@ public sealed class OutboxProcessorValidationCoverageGrain(
     public async Task<OutboxProcessorSourceState> PostPendingThenDefaultAfterAcknowledgeAsync()
     {
         var pending = Outbox<OutboxProcessorTestEvent>
-            .Create(GrainContext.GrainId)
+            .Create()
             .Add(new OutboxProcessorTestEvent("default-after-ack"))
             .ToImmutableArray();
         var returnDefault = false;
 
-        var processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        var processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => returnDefault ? default : pending,
             AcknowledgePostedAsync = (items, _) =>
@@ -818,7 +818,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(static _ => ValueTask.CompletedTask);
+        .AddPostman<OutboxProcessorTestEvent>(static _ => ValueTask.CompletedTask);
 
         await processor.PostAsync();
         return state.State;
@@ -847,7 +847,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
         try
         {
             _ = this.RegisterOutboxProcessor(CreateOptions(() => []))
-                .AddStreamPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(
+                .AddStreamPostman<OutboxProcessorTestEvent>(
                     OutboxProcessorTestProviderNames.Events,
                     null!);
             return Task.FromResult<string?>(null);
@@ -890,7 +890,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
 
     public async Task<string?> RegisterSecondProcessorAndReceiveFirstReminderAsync()
     {
-        var firstProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        var firstProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () =>
             {
@@ -921,7 +921,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>> CreateOptions(
+    private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions(
         Func<ImmutableArray<OutboxMessageEnvelope<OutboxProcessorTestEvent>>> pendingItems,
         TimeSpan? processingTimeout = null,
         TimeSpan? retryDelay = null) => new()
@@ -954,12 +954,12 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorReconciliationSchedulingGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
     private ImmutableArray<string> writes = [];
 
     public async Task PublishInBackgroundAsync(string value, bool interleaveReconciliation)
     {
-        processor ??= this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor ??= this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -967,7 +967,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
             RetryDelay = TimeSpan.FromMilliseconds(100),
             InterleaveReconciliationCallbacks = interleaveReconciliation
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PostWithGateAsync);
+        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAsync);
 
         state.State.Outbox = EnsureOutbox().Add(new OutboxProcessorTestEvent(value));
         await state.WriteStateAsync();
@@ -998,7 +998,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
         Task.FromResult(new OutboxProcessorSchedulingState(state.State.AcknowledgedCount, writes));
 
     private async Task PostWithGateAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
         CancellationToken cancellationToken)
     {
         var gate = OutboxProcessorSchedulingGate.For(this.GetPrimaryKey());
@@ -1017,7 +1017,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -1032,5 +1032,5 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
         ValueTask.CompletedTask;
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox() =>
-        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
 }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
@@ -849,7 +849,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
             _ = this.RegisterOutboxProcessor(CreateOptions(() => []))
                 .AddStreamPostman<OutboxProcessorTestEvent>(
                     OutboxProcessorTestProviderNames.Events,
-                    null!);
+                    (Func<OutboxProcessorTestEvent, StreamId>)null!);
             return Task.FromResult<string?>(null);
         }
         catch (ArgumentNullException ex)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -495,7 +495,7 @@ public sealed class OutboxProcessorSourceGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxProcessorTestEvent>(PublishEnvelopeAsync);
+        .AddPostmanWithToken<OutboxProcessorTestEvent>(PublishEnvelopeAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -482,20 +482,20 @@ public sealed class OutboxProcessorSourceGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorSourceGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PublishEnvelopeAsync);
+        .AddPostman<OutboxProcessorTestEvent>(PublishEnvelopeAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -511,7 +511,8 @@ public sealed class OutboxProcessorSourceGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private Task PublishEnvelopeAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
+        OutboxSequenceToken token,
         CancellationToken cancellationToken)
     {
         var sink = GrainFactory.GetGrain<IOutboxProcessorSinkGrain>(this.GetPrimaryKey());
@@ -519,10 +520,10 @@ public sealed class OutboxProcessorSourceGrain(
             OutboxProcessorTestNamespaces.Events,
             sink.GetGrainId());
         var stream = this.GetStreamProvider(OutboxProcessorTestProviderNames.Events)
-            .GetStream<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(
+            .GetStream<DeliveredOutboxEvent>(
                 streamId);
 
-        _ = stream.OnNextAsync(envelope);
+        _ = stream.OnNextAsync(new DeliveredOutboxEvent(envelope, token));
         return Task.CompletedTask;
     }
 
@@ -533,7 +534,7 @@ public sealed class OutboxProcessorSourceGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -548,7 +549,7 @@ public sealed class OutboxProcessorSourceGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -559,7 +560,7 @@ public sealed class OutboxProcessorSourceGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -567,13 +568,13 @@ public sealed class OutboxProcessorNoPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorNoPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -606,7 +607,7 @@ public sealed class OutboxProcessorNoPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -617,7 +618,7 @@ public sealed class OutboxProcessorNoPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -625,20 +626,20 @@ public sealed class OutboxProcessorFailingPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorFailingPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(FailAsync);
+        .AddPostman<OutboxProcessorTestEvent>(FailAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -653,9 +654,9 @@ public sealed class OutboxProcessorFailingPostmanGrain(
 
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
-    private static ValueTask FailAsync(OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope)
+    private static ValueTask FailAsync(OutboxProcessorTestEvent envelope)
     {
-        throw new InvalidOperationException($"Cannot post {envelope.Message.Value}.");
+        throw new InvalidOperationException($"Cannot post {envelope.Value}.");
     }
 
     private ValueTask AcknowledgePostedAsync(
@@ -670,7 +671,7 @@ public sealed class OutboxProcessorFailingPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -681,7 +682,7 @@ public sealed class OutboxProcessorFailingPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -689,20 +690,20 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorKeyedPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(OutboxProcessorTestPostmanNames.Success);
+        .AddPostman<OutboxProcessorTestEvent>(OutboxProcessorTestPostmanNames.Success);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -724,7 +725,7 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -739,7 +740,7 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -750,7 +751,7 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -758,20 +759,20 @@ public sealed class OutboxProcessorKeyedFailingPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorKeyedFailingPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(OutboxProcessorTestPostmanNames.Failure);
+        .AddPostman<OutboxProcessorTestEvent>(OutboxProcessorTestPostmanNames.Failure);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -798,7 +799,7 @@ public sealed class OutboxProcessorKeyedFailingPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -809,7 +810,7 @@ public sealed class OutboxProcessorKeyedFailingPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -818,13 +819,13 @@ public sealed class OutboxProcessorKeyedCancellationPostmanGrain(
     ManualTimeProvider timeProvider)
     : Grain, IOutboxProcessorKeyedCancellationPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -833,7 +834,7 @@ public sealed class OutboxProcessorKeyedCancellationPostmanGrain(
             TimeProvider = timeProvider,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(OutboxProcessorTestPostmanNames.Delay);
+        .AddPostman<OutboxProcessorTestEvent>(OutboxProcessorTestPostmanNames.Delay);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -877,7 +878,7 @@ public sealed class OutboxProcessorKeyedCancellationPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -886,13 +887,13 @@ public sealed class OutboxProcessorKeyedTimeoutPostmanGrain(
     ManualTimeProvider timeProvider)
     : Grain, IOutboxProcessorKeyedTimeoutPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -901,7 +902,7 @@ public sealed class OutboxProcessorKeyedTimeoutPostmanGrain(
             TimeProvider = timeProvider,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(OutboxProcessorTestPostmanNames.Delay);
+        .AddPostman<OutboxProcessorTestEvent>(OutboxProcessorTestPostmanNames.Delay);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -944,7 +945,7 @@ public sealed class OutboxProcessorKeyedTimeoutPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -953,14 +954,14 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
     ManualTimeProvider timeProvider)
     : Grain, IOutboxProcessorTimeoutRetryGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
     private int attempts;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
@@ -969,7 +970,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
             TimeProvider = timeProvider,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(FirstAttemptBlocksAsync);
+        .AddPostman<OutboxProcessorTestEvent>(FirstAttemptBlocksAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -994,12 +995,12 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private async Task FirstAttemptBlocksAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
         CancellationToken cancellationToken)
     {
         if (++attempts == 1)
         {
-            var gate = OutboxProcessorPostmanGate.For(envelope.Message.Value);
+            var gate = OutboxProcessorPostmanGate.For(envelope.Value);
             gate.Started.TrySetResult();
             await gate.AllowCompletion.Task.WaitAsync(cancellationToken);
         }
@@ -1012,7 +1013,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -1022,7 +1023,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -1030,21 +1031,21 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
     [PersistentState("state", "Default")] IPersistentState<OutboxProcessorSourceState> state)
     : Grain, IOutboxProcessorConcurrentPostmanGrain, IOutboxGrain
 {
-    private OutboxProcessor<OutboxMessageEnvelope<OutboxProcessorTestEvent>>? processor;
+    private OutboxProcessor<OutboxProcessorTestEvent>? processor;
     private int activePostmen;
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         EnsureOutbox();
 
-        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
             PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(PostWithGateAndTrackConcurrencyAsync);
+        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAndTrackConcurrencyAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -1071,7 +1072,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private async Task PostWithGateAndTrackConcurrencyAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        OutboxProcessorTestEvent envelope,
         CancellationToken cancellationToken)
     {
         activePostmen++;
@@ -1079,7 +1080,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
 
         try
         {
-            var gate = OutboxProcessorPostmanGate.For(envelope.Message.Value);
+            var gate = OutboxProcessorPostmanGate.For(envelope.Value);
             gate.Started.TrySetResult();
             await gate.AllowCompletion.Task.WaitAsync(cancellationToken);
         }
@@ -1096,7 +1097,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var item in items)
         {
-            outbox = outbox.Remove(item.Token);
+            outbox = outbox.Remove(item.Id);
         }
 
         state.State.Outbox = outbox;
@@ -1111,7 +1112,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
         var outbox = EnsureOutbox();
         foreach (var failure in failures)
         {
-            outbox = outbox.Remove(failure.Item.Token);
+            outbox = outbox.Remove(failure.Item.Id);
             state.State.LastFailureType = failure.Error.GetType().Name;
         }
 
@@ -1122,7 +1123,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
 
     private Outbox<OutboxProcessorTestEvent> EnsureOutbox()
     {
-        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create(GrainContext.GrainId);
+        return state.State.Outbox ??= Outbox<OutboxProcessorTestEvent>.Create();
     }
 }
 
@@ -1130,7 +1131,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     : Grain, IOutboxProcessorOrderedPostmanGrain, IOutboxGrain
 {
     private OutboxProcessor<OutboxProcessorOrderedMessage>? processor;
-    private ImmutableArray<OutboxProcessorOrderedMessage> pending = [];
+    private ImmutableArray<OutboxMessageEnvelope<OutboxProcessorOrderedMessage>> pending = [];
     private ImmutableArray<string> postedValues = [];
     private ImmutableArray<string> failedValues = [];
     private ImmutableArray<string> attemptedValues = [];
@@ -1156,11 +1157,10 @@ public sealed class OutboxProcessorOrderedPostmanGrain
         string primary,
         string secondary)
     {
-        pending =
-        [
-            new OutboxProcessorPrimaryMessage(primary),
-            new OutboxProcessorSecondaryMessage(secondary)
-        ];
+        pending = Outbox<OutboxProcessorOrderedMessage>.Create()
+            .Add(new OutboxProcessorPrimaryMessage(primary))
+            .Add(new OutboxProcessorSecondaryMessage(secondary))
+            .ToImmutableArray();
 
         await processor!.PostAsync();
         return CreateState();
@@ -1171,12 +1171,11 @@ public sealed class OutboxProcessorOrderedPostmanGrain
         string secondary,
         string blockedPrimary)
     {
-        pending =
-        [
-            new OutboxProcessorPrimaryMessage(failingPrimary),
-            new OutboxProcessorSecondaryMessage(secondary),
-            new OutboxProcessorPrimaryMessage(blockedPrimary)
-        ];
+        pending = Outbox<OutboxProcessorOrderedMessage>.Create()
+            .Add(new OutboxProcessorPrimaryMessage(failingPrimary))
+            .Add(new OutboxProcessorSecondaryMessage(secondary))
+            .Add(new OutboxProcessorPrimaryMessage(blockedPrimary))
+            .ToImmutableArray();
 
         await processor!.PostAsync();
         return CreateState();
@@ -1220,25 +1219,25 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     }
 
     private ValueTask AcknowledgePostedAsync(
-        ImmutableArray<OutboxProcessorOrderedMessage> items,
+        ImmutableArray<OutboxMessageEnvelope<OutboxProcessorOrderedMessage>> items,
         CancellationToken cancellationToken)
     {
         foreach (var item in items)
         {
             pending = pending.Remove(item);
-            postedValues = postedValues.Add(item.Value);
+            postedValues = postedValues.Add(item.Message.Value);
         }
 
         return ValueTask.CompletedTask;
     }
 
     private ValueTask ReconcileFailedAsync(
-        ImmutableArray<(OutboxProcessorOrderedMessage Item, Exception Error, int Attempt)> failures,
+        ImmutableArray<(OutboxMessageEnvelope<OutboxProcessorOrderedMessage> Item, Exception Error, int Attempt)> failures,
         CancellationToken cancellationToken)
     {
         foreach (var failure in failures)
         {
-            failedValues = failedValues.Add(failure.Item.Value);
+            failedValues = failedValues.Add(failure.Item.Message.Value);
         }
 
         return ValueTask.CompletedTask;
@@ -1248,39 +1247,39 @@ public sealed class OutboxProcessorOrderedPostmanGrain
         new(
             postedValues,
             failedValues,
-            pending.Select(static item => item.Value).ToImmutableArray(),
+            pending.Select(static item => item.Message.Value).ToImmutableArray(),
             attemptedValues,
             maxConcurrentPostmen);
 }
 
 public sealed class KeyedOutboxProcessorSuccessPostman :
-    IPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+    IPostman<OutboxProcessorTestEvent>
 {
     public ValueTask PostAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> message,
+        OutboxProcessorTestEvent message,
         CancellationToken cancellationToken) =>
         ValueTask.CompletedTask;
 }
 
 public sealed class KeyedOutboxProcessorFailingPostman :
-    IPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+    IPostman<OutboxProcessorTestEvent>
 {
     public ValueTask PostAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> message,
+        OutboxProcessorTestEvent message,
         CancellationToken cancellationToken)
     {
-        throw new InvalidOperationException($"Cannot post {message.Message.Value}.");
+        throw new InvalidOperationException($"Cannot post {message.Value}.");
     }
 }
 
 public sealed class KeyedOutboxProcessorDelayingPostman :
-    IPostman<OutboxMessageEnvelope<OutboxProcessorTestEvent>>
+    IPostman<OutboxProcessorTestEvent>
 {
     public async ValueTask PostAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> message,
+        OutboxProcessorTestEvent message,
         CancellationToken cancellationToken)
     {
-        var gate = OutboxProcessorPostmanGate.For(message.Message.Value);
+        var gate = OutboxProcessorPostmanGate.For(message.Value);
         gate.Started.TrySetResult();
         await gate.AllowCompletion.Task.WaitAsync(cancellationToken);
     }
@@ -1294,8 +1293,8 @@ public sealed class OutboxProcessorSinkGrain(
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        streamManager = this.RegisterStreamManager(state.State.Tracker)
-            .ConfigureExplicitSubscription<OutboxMessageEnvelope<OutboxProcessorTestEvent>>(
+        streamManager = this.RegisterStreamManager(() => state.State.Tracker)
+            .ConfigureExplicitSubscription<DeliveredOutboxEvent>(
                 OutboxProcessorTestProviderNames.Events,
                 OutboxProcessorTestNamespaces.Events,
                 HandleEnvelopeAsync);
@@ -1309,7 +1308,7 @@ public sealed class OutboxProcessorSinkGrain(
     public Task<OutboxProcessorSinkState> GetStateAsync() => Task.FromResult(state.State);
 
     private async ValueTask HandleEnvelopeAsync(
-        OutboxMessageEnvelope<OutboxProcessorTestEvent> envelope,
+        DeliveredOutboxEvent envelope,
         StreamCursor cursor)
     {
         if (!state.State.Tracker.ProcessMessage(envelope.Token, out var next))
@@ -1322,3 +1321,8 @@ public sealed class OutboxProcessorSinkGrain(
         await state.WriteStateAsync();
     }
 }
+
+[GenerateSerializer]
+public sealed record DeliveredOutboxEvent(
+    [property: Id(0)] OutboxProcessorTestEvent Message,
+    [property: Id(1)] OutboxSequenceToken Token);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -495,7 +495,7 @@ public sealed class OutboxProcessorSourceGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxProcessorTestEvent>(async (message, token, cancellationToken) => await PublishEnvelopeAsync(message, token, cancellationToken));
+        .AddPostman<OutboxProcessorTestEvent>(PublishEnvelopeAsync);
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -495,7 +495,7 @@ public sealed class OutboxProcessorSourceGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostmanWithToken<OutboxProcessorTestEvent>(PublishEnvelopeAsync);
+        .AddPostman<OutboxProcessorTestEvent>(async (message, token, cancellationToken) => await PublishEnvelopeAsync(message, token, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -970,7 +970,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
             TimeProvider = timeProvider,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxProcessorTestEvent>(FirstAttemptBlocksAsync);
+        .AddPostman<OutboxProcessorTestEvent>(async (message, _, cancellationToken) => await FirstAttemptBlocksAsync(message, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -1045,7 +1045,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
         })
-        .AddPostman<OutboxProcessorTestEvent>(PostWithGateAndTrackConcurrencyAsync);
+        .AddPostman<OutboxProcessorTestEvent>(async (message, _, cancellationToken) => await PostWithGateAndTrackConcurrencyAsync(message, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }
@@ -1147,8 +1147,8 @@ public sealed class OutboxProcessorOrderedPostmanGrain
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })
-        .AddPostman<OutboxProcessorPrimaryMessage>(PostPrimaryAsync)
-        .AddPostman<OutboxProcessorSecondaryMessage>(PostSecondaryAsync);
+        .AddPostman<OutboxProcessorPrimaryMessage>(async (message, _, cancellationToken) => await PostPrimaryAsync(message, cancellationToken))
+        .AddPostman<OutboxProcessorSecondaryMessage>(async (message, _, cancellationToken) => await PostSecondaryAsync(message, cancellationToken));
 
         await base.OnActivateAsync(cancellationToken);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
@@ -5,6 +5,53 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 public sealed class OutboxTests
 {
     [Fact]
+    public void Mutations_create_distinct_uuidv7_snapshot_revisions()
+    {
+        var initial = Outbox<string>.Create();
+        var appended = initial.Add("first", DateTimeOffset.UnixEpoch);
+        var removed = appended.Remove(appended[0].Id);
+        var batchRemoved = appended.RemoveRange([appended[0].Id]);
+        var cleared = appended.Clear();
+
+        Guid[] revisions = [initial.Revision, appended.Revision, removed.Revision, batchRemoved.Revision, cleared.Revision];
+        Assert.Equal(revisions.Length, revisions.Distinct().Count());
+        Assert.All(revisions, revision => Assert.Equal(7, revision.Version));
+    }
+
+    [Fact]
+    public void Operations_without_changes_preserve_the_snapshot_revision()
+    {
+        var empty = Outbox<string>.Create();
+        var pending = empty.Add("first", DateTimeOffset.UnixEpoch);
+        var foreignId = new OutboxMessageId(99, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(empty.Revision, empty.Clear().Revision);
+        Assert.Equal(empty.Revision, empty.Remove(foreignId).Revision);
+        Assert.Equal(pending.Revision, pending.Remove(foreignId).Revision);
+        Assert.Equal(pending.Revision, pending.RemoveRange([]).Revision);
+        Assert.Equal(pending.Revision, pending.RemoveRange([foreignId]).Revision);
+    }
+
+    [Fact]
+    public void Orleans_serialization_preserves_snapshot_identity_and_message_ids()
+    {
+        var outbox = Outbox<string>.Create().Add("first", DateTimeOffset.UnixEpoch);
+        var services = new ServiceCollection();
+        services.AddSerializer(builder => builder.AddAssembly(typeof(Outbox<>).Assembly));
+        using var serviceProvider = services.BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+
+        var loaded = serializer.Deserialize<Outbox<string>>(serializer.SerializeToArray(outbox));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(outbox.Revision, loaded.Revision);
+        Assert.Equal(outbox, loaded);
+        Assert.Equal(outbox.GetHashCode(), loaded.GetHashCode());
+        Assert.Equal(outbox[0].Id, loaded[0].Id);
+        Assert.Equal("first", loaded[0].Message);
+    }
+
+    [Fact]
     public void Add_after_Orleans_deep_copy_uses_explicit_timestamp()
     {
         var epoch = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
@@ -16,6 +63,7 @@ public sealed class OutboxTests
         var copied = serviceProvider.GetRequiredService<DeepCopier>().Copy(outbox);
 
         Assert.NotNull(copied);
+        Assert.Equal(outbox.Revision, copied.Revision);
         var next = copied.Add("second", later);
 
         Assert.Equal(2, next.Count);
@@ -159,7 +207,7 @@ public sealed class OutboxTests
     }
 
     [Fact]
-    public void Equals_treats_matching_sequence_window_as_same_pending_items()
+    public void Competing_appends_are_distinct_despite_matching_sequence_windows()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var left = Outbox<string>.Create();
@@ -168,11 +216,11 @@ public sealed class OutboxTests
         left = left.Add("left", now).Add("middle-left", now).Add("last", now);
         right = right.Add("right", now).Add("middle-right", now).Add("last", now);
 
-        Assert.Equal(left, right);
+        Assert.NotEqual(left, right);
     }
 
     [Fact]
-    public void Equals_treats_removal_only_divergence_as_same_recovery_fingerprint()
+    public void Competing_removals_are_distinct_despite_matching_endpoints()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var baseline = Outbox<string>.Create()
@@ -186,12 +234,11 @@ public sealed class OutboxTests
 
         Assert.Equal([1L, 2L, 4L], left.Select(item => item.Id.SequenceNumber).ToArray());
         Assert.Equal([1L, 3L, 4L], right.Select(item => item.Id.SequenceNumber).ToArray());
-        Assert.Equal(left, right);
-        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotEqual(left, right);
     }
 
     [Fact]
-    public void Equals_returns_true_when_sequence_epoch_and_envelopes_match()
+    public void Independent_snapshots_are_distinct_even_with_identical_payloads()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var left = Outbox<string>.Create();
@@ -200,8 +247,7 @@ public sealed class OutboxTests
         left = left.Add("first", now).Add("second", now);
         right = right.Add("first", now).Add("second", now);
 
-        Assert.Equal(left, right);
-        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotEqual(left, right);
     }
 
     [Fact]

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
@@ -7,10 +7,9 @@ public sealed class OutboxTests
     [Fact]
     public void Add_after_Orleans_deep_copy_uses_explicit_timestamp()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var epoch = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var later = epoch.AddMinutes(5);
-        var outbox = Outbox<string>.Create(sender).Add("first", epoch);
+        var outbox = Outbox<string>.Create().Add("first", epoch);
         var services = new ServiceCollection();
         services.AddSerializer(builder => builder.AddAssembly(typeof(Outbox<>).Assembly));
         using var serviceProvider = services.BuildServiceProvider();
@@ -22,15 +21,14 @@ public sealed class OutboxTests
         Assert.Equal(2, next.Count);
         Assert.Equal(2, next.LatestSequenceNumber);
         Assert.Equal("second", next[1].Message);
-        Assert.Equal(new OutboxSequenceToken(2, sender, later, epoch), next[1].Token);
+        Assert.Equal(new OutboxMessageId(2, later, epoch), next[1].Id);
     }
 
     [Fact]
-    public void Add_appends_message_with_next_sequence_sender_and_time()
+    public void Add_appends_message_with_next_sequence_and_time()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
 
         var next = outbox.Add("created", now);
 
@@ -39,30 +37,28 @@ public sealed class OutboxTests
         Assert.Equal(1, next.LatestSequenceNumber);
         Assert.Equal(now, next.Epoch);
         Assert.Equal("created", next[0].Message);
-        Assert.Equal(new OutboxSequenceToken(1, sender, now, now), next[0].Token);
+        Assert.Equal(new OutboxMessageId(1, now, now), next[0].Id);
     }
 
     [Fact]
     public void Add_normalizes_supplied_timestamp_to_UTC()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var localNow = new DateTimeOffset(2026, 5, 23, 14, 30, 0, TimeSpan.FromHours(2));
         var utcNow = localNow.ToUniversalTime();
 
-        var next = Outbox<string>.Create(sender).Add("created", localNow);
+        var next = Outbox<string>.Create().Add("created", localNow);
 
         Assert.Equal(utcNow, next.Epoch);
-        Assert.Equal(utcNow, next[0].Token.Timestamp);
-        Assert.Equal(TimeSpan.Zero, next[0].Token.Timestamp.Offset);
+        Assert.Equal(utcNow, next[0].Id.Timestamp);
+        Assert.Equal(TimeSpan.Zero, next[0].Id.Timestamp.Offset);
     }
 
     [Fact]
     public void Add_preserves_epoch_and_increments_sequence_for_later_messages()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var epoch = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var later = epoch.AddMinutes(5);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
 
         var next = outbox.Add("first", epoch);
         next = next.Add("second", later);
@@ -70,19 +66,18 @@ public sealed class OutboxTests
         Assert.Equal(2, next.Count);
         Assert.Equal(2, next.LatestSequenceNumber);
         Assert.Equal(epoch, next.Epoch);
-        Assert.Equal(new OutboxSequenceToken(1, sender, epoch, epoch), next[0].Token);
-        Assert.Equal(new OutboxSequenceToken(2, sender, later, epoch), next[1].Token);
+        Assert.Equal(new OutboxMessageId(1, epoch, epoch), next[0].Id);
+        Assert.Equal(new OutboxMessageId(2, later, epoch), next[1].Id);
     }
 
     [Fact]
     public void Remove_deletes_matching_sequence_and_preserves_sequence_metadata()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now);
 
-        var next = outbox.Remove(outbox[0].Token);
+        var next = outbox.Remove(outbox[0].Id);
 
         Assert.Single(next);
         Assert.Equal("second", next[0].Message);
@@ -91,14 +86,12 @@ public sealed class OutboxTests
     }
 
     [Fact]
-    public void Remove_ignores_token_from_different_sender_with_same_sequence()
+    public void Remove_ignores_token_from_different_epoch_with_same_sequence()
     {
-        var sender = GrainId.Create("test/sender", "one");
-        var otherSender = GrainId.Create("test/sender", "two");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now);
-        var otherToken = new OutboxSequenceToken(1, otherSender, now, now);
+        var otherToken = new OutboxMessageId(1, now, now.AddDays(-1));
 
         var next = outbox.Remove(otherToken);
 
@@ -109,12 +102,11 @@ public sealed class OutboxTests
     [Fact]
     public void Remove_ignores_matching_token_that_is_not_fifo_head()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now);
 
-        var next = outbox.Remove(outbox[1].Token);
+        var next = outbox.Remove(outbox[1].Id);
 
         Assert.Same(outbox, next);
         Assert.Equal(2, next.Count);
@@ -123,13 +115,12 @@ public sealed class OutboxTests
     [Fact]
     public void RemoveRange_deletes_matching_fifo_prefix_and_ignores_missing_tokens()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now).Add("third", now);
-        var missing = new OutboxSequenceToken(99, sender, now, now);
+        var missing = new OutboxMessageId(99, now, now);
 
-        var next = outbox.RemoveRange([outbox[0].Token, outbox[1].Token, missing]);
+        var next = outbox.RemoveRange([outbox[0].Id, outbox[1].Id, missing]);
 
         Assert.Single(next);
         Assert.Equal("third", next[0].Message);
@@ -140,12 +131,11 @@ public sealed class OutboxTests
     [Fact]
     public void RemoveRange_removes_matching_tokens_after_gap_and_preserves_remaining_order()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now).Add("third", now);
 
-        var next = outbox.RemoveRange([outbox[0].Token, outbox[2].Token]);
+        var next = outbox.RemoveRange([outbox[0].Id, outbox[2].Id]);
 
         Assert.Single(next);
         Assert.Equal("second", next[0].Message);
@@ -154,10 +144,9 @@ public sealed class OutboxTests
     [Fact]
     public void Clear_removes_items_and_keeps_sequence_metadata_for_next_add()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var epoch = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var later = epoch.AddMinutes(5);
-        var outbox = Outbox<string>.Create(sender);
+        var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", epoch).Add("second", epoch);
 
         var cleared = outbox.Clear();
@@ -166,16 +155,15 @@ public sealed class OutboxTests
         Assert.Empty(cleared);
         Assert.Equal(2, cleared.LatestSequenceNumber);
         Assert.Equal(epoch, cleared.Epoch);
-        Assert.Equal(new OutboxSequenceToken(3, sender, later, epoch), next[0].Token);
+        Assert.Equal(new OutboxMessageId(3, later, epoch), next[0].Id);
     }
 
     [Fact]
     public void Equals_treats_matching_sequence_window_as_same_pending_items()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var left = Outbox<string>.Create(sender);
-        var right = Outbox<string>.Create(sender);
+        var left = Outbox<string>.Create();
+        var right = Outbox<string>.Create();
 
         left = left.Add("left", now).Add("middle-left", now).Add("last", now);
         right = right.Add("right", now).Add("middle-right", now).Add("last", now);
@@ -186,30 +174,28 @@ public sealed class OutboxTests
     [Fact]
     public void Equals_treats_removal_only_divergence_as_same_recovery_fingerprint()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var baseline = Outbox<string>.Create(sender)
+        var baseline = Outbox<string>.Create()
             .Add("first", now)
             .Add("second", now)
             .Add("third", now)
             .Add("fourth", now);
 
-        var left = baseline.RemoveRange([baseline[2].Token]);
-        var right = baseline.RemoveRange([baseline[1].Token]);
+        var left = baseline.RemoveRange([baseline[2].Id]);
+        var right = baseline.RemoveRange([baseline[1].Id]);
 
-        Assert.Equal([1L, 2L, 4L], left.Select(item => item.Token.SequenceNumber).ToArray());
-        Assert.Equal([1L, 3L, 4L], right.Select(item => item.Token.SequenceNumber).ToArray());
+        Assert.Equal([1L, 2L, 4L], left.Select(item => item.Id.SequenceNumber).ToArray());
+        Assert.Equal([1L, 3L, 4L], right.Select(item => item.Id.SequenceNumber).ToArray());
         Assert.Equal(left, right);
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 
     [Fact]
-    public void Equals_returns_true_when_sender_sequence_epoch_and_envelopes_match()
+    public void Equals_returns_true_when_sequence_epoch_and_envelopes_match()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var left = Outbox<string>.Create(sender);
-        var right = Outbox<string>.Create(sender);
+        var left = Outbox<string>.Create();
+        var right = Outbox<string>.Create();
 
         left = left.Add("first", now).Add("second", now);
         right = right.Add("first", now).Add("second", now);
@@ -221,10 +207,9 @@ public sealed class OutboxTests
     [Fact]
     public void Equals_returns_false_when_sequence_metadata_differs()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var left = Outbox<string>.Create(sender);
-        var right = Outbox<string>.Create(sender);
+        var left = Outbox<string>.Create();
+        var right = Outbox<string>.Create();
 
         left = left.Add("first", now).Add("second", now);
         right = right.Add("first", now).Add("second", now).Add("third", now);
@@ -235,10 +220,9 @@ public sealed class OutboxTests
     [Fact]
     public void Equals_returns_false_when_diverged_tail_items_have_different_timestamps()
     {
-        var sender = GrainId.Create("test/sender", "one");
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
-        var left = Outbox<string>.Create(sender);
-        var right = Outbox<string>.Create(sender);
+        var left = Outbox<string>.Create();
+        var right = Outbox<string>.Create();
 
         // Shared history establishes the same epoch and head token, then two
         // duplicate activations each append their own message at the same

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -41,10 +41,10 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
         await fixture.WaitForAssertionAsync(sink, async () =>
         {
             var deliveries = await sink.GetDeliveriesAsync();
-            Assert.Equal(["grain", "local", "stream"], deliveries.Select(item => item.Value).Order().ToArray());
+            Assert.Equal(["grain", "local", "stream", "stream-two"], deliveries.Select(item => item.Value).Order().ToArray());
             Assert.All(deliveries, item => Assert.Equal(source.GetGrainId(), item.Token.Sender));
             Assert.All(deliveries, item => Assert.Equal(fixture.TimeProvider.GetUtcNow(), item.Token.Timestamp));
-            Assert.Equal([1L, 2L, 3L], deliveries.Select(item => item.Token.SequenceNumber).Order().ToArray());
+            Assert.Equal([1L, 2L, 3L, 4L], deliveries.Select(item => item.Token.SequenceNumber).Order().ToArray());
         }, ct: TestContext.Current.CancellationToken);
         Assert.Equal(0, await source.PendingCountAsync());
     }
@@ -58,7 +58,7 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
         await sink.EnsureActiveAsync();
         await source.PublishAsync(key, failAcknowledgment: true);
         await fixture.WaitForAssertionAsync(sink, async () =>
-            Assert.Equal(3, (await sink.GetDeliveriesAsync()).Length), ct: TestContext.Current.CancellationToken);
+            Assert.Equal(4, (await sink.GetDeliveriesAsync()).Length), ct: TestContext.Current.CancellationToken);
         var first = await sink.GetDeliveriesAsync();
 
         await source.RetryAsync();
@@ -66,7 +66,7 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
         await fixture.WaitForAssertionAsync(sink, async () =>
         {
             var deliveries = await sink.GetDeliveriesAsync();
-            Assert.Equal(6, deliveries.Length);
+            Assert.Equal(8, deliveries.Length);
             Assert.All(first, item => Assert.Equal(2, deliveries.Count(delivery => delivery == item)));
         }, ct: TestContext.Current.CancellationToken);
         Assert.Equal(0, await source.PendingCountAsync());
@@ -76,6 +76,7 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
 [JsonPolymorphic]
 [JsonDerivedType(typeof(LocalPayload), "local")]
 [JsonDerivedType(typeof(StreamPayload), "stream")]
+[JsonDerivedType(typeof(SecondStreamPayload), "stream-two")]
 [JsonDerivedType(typeof(GrainPayload), "grain")]
 public interface IPayloadEvent
 {
@@ -88,6 +89,9 @@ public sealed record LocalPayload([property: Id(0)] Guid Target, [property: Id(1
 
 [GenerateSerializer]
 public sealed record StreamPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
+
+[GenerateSerializer]
+public sealed record SecondStreamPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
 
 [GenerateSerializer]
 public sealed record GrainPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
@@ -127,14 +131,22 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
             AcknowledgePostedAsync = AcknowledgeAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })
-        .AddPostman<LocalPayload>(async (message, token) => await DeliverLocalAsync(message, token))
-        .AddStreamPostman<StreamPayload, PayloadDelivery>(OutboxProcessorTestProviderNames.Events,
-            message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
-            static (message, token) => new(message.Value, token))
+        .AddPostman<LocalPayload>(DeliverLocalAsync)
         .AddGrainPostman<GrainPayload, IPayloadSinkGrain>(
             static (message, grains) => grains.GetGrain<IPayloadSinkGrain>(message.Target),
-            static async (grain, message, token) => await grain.ReceiveAsync(new(message.Value, token)))
+            static (grain, message, token) => grain.ReceiveAsync(new(message.Value, token)));
+
+        processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events)
+            .AddStreamPostman<StreamPayload, PayloadDelivery>(
+                message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
+                static (message, token) => new(message.Value, token))
+            .AddStreamPostman<SecondStreamPayload, PayloadDelivery>(
+                (message, _) => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
+                static (message, token) => new(message.Value, token));
+
+        processor
         .AddPostman<IPayloadEvent>(static async message => await RejectUnexpectedPayloadAsync(message))
+        .AddPostman<IPayloadEvent>(static async (message, _) => await RejectUnexpectedPayloadAsync(message))
         .AddPostman<IPayloadEvent>(static async (message, _, cancellationToken) =>
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -145,9 +157,9 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
     private static ValueTask RejectUnexpectedPayloadAsync(IPayloadEvent message) =>
         ValueTask.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}"));
 
-    private ValueTask DeliverLocalAsync(LocalPayload message, OutboxSequenceToken token) =>
-        new(GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)
-            .ReceiveAsync(new(message.Value, token)));
+    private Task DeliverLocalAsync(LocalPayload message, OutboxSequenceToken token) =>
+        GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)
+            .ReceiveAsync(new(message.Value, token));
 
     public async Task PublishAsync(Guid target, bool failAcknowledgment)
     {
@@ -159,6 +171,7 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
                 .Add(new LocalPayload(target, "local"), now)
                 .Add(new StreamPayload(target, "stream"), now)
                 .Add(new GrainPayload(target, "grain"), now)
+                .Add(new SecondStreamPayload(target, "stream-two"), now)
         });
         try
         {

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -1,0 +1,213 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Egil.Orleans.Testing;
+using TimeProviderExtensions;
+
+namespace Egil.Orleans.Messaging.Tests.Outboxes;
+
+public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
+    : IClassFixture<MessagingTestClusterFixture>
+{
+    [Fact]
+    public void Polymorphic_payloads_round_trip_with_stored_identity()
+    {
+        var target = Guid.NewGuid();
+        var now = fixture.TimeProvider.GetUtcNow();
+        var outbox = Outbox<IPayloadEvent>.Create()
+            .Add(new LocalPayload(target, "local"), now)
+            .Add(new StreamPayload(target, "stream"), now);
+
+        var json = JsonSerializer.Serialize(outbox);
+        var loaded = JsonSerializer.Deserialize<Outbox<IPayloadEvent>>(json);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(outbox[0].Id, loaded[0].Id);
+        Assert.Equal(outbox[0].Message, Assert.IsType<LocalPayload>(loaded[0].Message));
+        Assert.Equal(outbox[1].Message, Assert.IsType<StreamPayload>(loaded[1].Message));
+        Assert.DoesNotContain("Sender", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Constructor_registered_postmen_dispatch_polymorphic_payloads_and_acknowledge_original_items()
+    {
+        var key = Guid.NewGuid();
+        var source = fixture.GrainFactory.GetGrain<IPayloadSourceGrain>(key);
+        var sink = fixture.GrainFactory.GetGrain<IPayloadSinkGrain>(key);
+        await sink.EnsureActiveAsync();
+
+        await source.PublishAsync(key, failAcknowledgment: false);
+
+        await fixture.WaitForAssertionAsync(sink, async () =>
+        {
+            var deliveries = await sink.GetDeliveriesAsync();
+            Assert.Equal(["grain", "local", "stream"], deliveries.Select(item => item.Value).Order().ToArray());
+            Assert.All(deliveries, item => Assert.Equal(source.GetGrainId(), item.Token.Sender));
+            Assert.All(deliveries, item => Assert.Equal(fixture.TimeProvider.GetUtcNow(), item.Token.Timestamp));
+            Assert.Equal([1L, 2L, 3L], deliveries.Select(item => item.Token.SequenceNumber).Order().ToArray());
+        }, ct: TestContext.Current.CancellationToken);
+        Assert.Equal(0, await source.PendingCountAsync());
+    }
+
+    [Fact]
+    public async Task Reactivation_retries_with_the_same_delivery_tokens_after_acknowledgment_failure()
+    {
+        var key = Guid.NewGuid();
+        var source = fixture.GrainFactory.GetGrain<IPayloadSourceGrain>(key);
+        var sink = fixture.GrainFactory.GetGrain<IPayloadSinkGrain>(key);
+        await sink.EnsureActiveAsync();
+        await source.PublishAsync(key, failAcknowledgment: true);
+        await fixture.WaitForAssertionAsync(sink, async () =>
+            Assert.Equal(3, (await sink.GetDeliveriesAsync()).Length), ct: TestContext.Current.CancellationToken);
+        var first = await sink.GetDeliveriesAsync();
+
+        await source.RetryAsync();
+
+        await fixture.WaitForAssertionAsync(sink, async () =>
+        {
+            var deliveries = await sink.GetDeliveriesAsync();
+            Assert.Equal(6, deliveries.Length);
+            Assert.All(first, item => Assert.Equal(2, deliveries.Count(delivery => delivery == item)));
+        }, ct: TestContext.Current.CancellationToken);
+        Assert.Equal(0, await source.PendingCountAsync());
+    }
+}
+
+[JsonPolymorphic]
+[JsonDerivedType(typeof(LocalPayload), "local")]
+[JsonDerivedType(typeof(StreamPayload), "stream")]
+[JsonDerivedType(typeof(GrainPayload), "grain")]
+public interface IPayloadEvent
+{
+    Guid Target { get; }
+    string Value { get; }
+}
+
+[GenerateSerializer]
+public sealed record LocalPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
+
+[GenerateSerializer]
+public sealed record StreamPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
+
+[GenerateSerializer]
+public sealed record GrainPayload([property: Id(0)] Guid Target, [property: Id(1)] string Value) : IPayloadEvent;
+
+[GenerateSerializer]
+public sealed record PayloadDelivery([property: Id(0)] string Value, [property: Id(1)] OutboxSequenceToken Token);
+
+[GenerateSerializer]
+public sealed record PayloadSourceState
+{
+    [Id(0)] public Outbox<IPayloadEvent> Outbox { get; init; } = Outbox<IPayloadEvent>.Create();
+}
+
+public interface IPayloadSourceGrain : IGrainWithGuidKey
+{
+    Task PublishAsync(Guid target, bool failAcknowledgment);
+    Task RetryAsync();
+    Task<int> PendingCountAsync();
+}
+
+public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrain
+{
+    private readonly IStateManager<PayloadSourceState> manager;
+    private readonly OutboxProcessor<IPayloadEvent> processor;
+    private readonly ManualTimeProvider time;
+    private bool failAcknowledgment;
+
+    public PayloadSourceGrain(
+        [PersistentState("payload", "Payload")] IPersistentState<PayloadSourceState> storage,
+        ManualTimeProvider time)
+    {
+        this.time = time;
+        manager = this.RegisterStateManager("Payload", storage);
+        processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IPayloadEvent>
+        {
+            PendingItems = () => manager.State.Outbox.ToImmutableArray(),
+            AcknowledgePostedAsync = AcknowledgeAsync,
+            RetryDelay = TimeSpan.FromMinutes(10)
+        })
+        .AddPostman<LocalPayload>((message, token, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)
+                .ReceiveAsync(new(message.Value, token));
+        })
+        .AddStreamPostman<StreamPayload, PayloadDelivery>(OutboxProcessorTestProviderNames.Events,
+            message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
+            static (message, token) => new(message.Value, token))
+        .AddGrainPostman<GrainPayload, IPayloadSinkGrain>(
+            static (message, grains) => grains.GetGrain<IPayloadSinkGrain>(message.Target),
+            static (grain, message, token) => grain.ReceiveAsync(new(message.Value, token)))
+        .AddPostman<IPayloadEvent>(static _ => ValueTask.FromException(new InvalidOperationException("A specific payload handler should win.")));
+    }
+
+    public async Task PublishAsync(Guid target, bool failAcknowledgment)
+    {
+        this.failAcknowledgment = failAcknowledgment;
+        var now = time.GetUtcNow();
+        await manager.WriteAsync(manager.State with
+        {
+            Outbox = manager.State.Outbox
+                .Add(new LocalPayload(target, "local"), now)
+                .Add(new StreamPayload(target, "stream"), now)
+                .Add(new GrainPayload(target, "grain"), now)
+        });
+        try
+        {
+            await processor.PostAsync();
+        }
+        catch (InvalidOperationException) when (failAcknowledgment)
+        {
+            DeactivateOnIdle();
+        }
+    }
+
+    public Task RetryAsync() => processor.PostAsync().AsTask();
+
+    public Task<int> PendingCountAsync() => Task.FromResult(manager.State.Outbox.Count);
+
+    private async ValueTask AcknowledgeAsync(ImmutableArray<OutboxMessageEnvelope<IPayloadEvent>> items, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (failAcknowledgment)
+        {
+            throw new InvalidOperationException("The delivery landed but acknowledgment could not persist.");
+        }
+
+        await manager.WriteAsync(manager.State with { Outbox = manager.State.Outbox.RemoveRange(items.Select(item => item.Id)) });
+    }
+}
+
+public interface IPayloadSinkGrain : IGrainWithGuidKey
+{
+    Task EnsureActiveAsync();
+    Task ReceiveAsync(PayloadDelivery delivery);
+    Task<ImmutableArray<PayloadDelivery>> GetDeliveriesAsync();
+}
+
+public sealed class PayloadSinkGrain : Grain, IPayloadSinkGrain
+{
+    private readonly StreamManager streams;
+    private ImmutableArray<PayloadDelivery> deliveries = [];
+
+    public PayloadSinkGrain()
+    {
+        streams = this.RegisterStreamManager()
+            .ConfigureExplicitSubscription<PayloadDelivery>(OutboxProcessorTestProviderNames.Events,
+                "payload-postmen", (delivery, _) => new ValueTask(ReceiveAsync(delivery)));
+    }
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken) =>
+        streams.EnsureExplicitSubscriptionsAsync(cancellationToken);
+
+    public Task EnsureActiveAsync() => Task.CompletedTask;
+
+    public Task ReceiveAsync(PayloadDelivery delivery)
+    {
+        deliveries = deliveries.Add(delivery);
+        return Task.CompletedTask;
+    }
+
+    public Task<ImmutableArray<PayloadDelivery>> GetDeliveriesAsync() => Task.FromResult(deliveries);
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -127,16 +127,23 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
             AcknowledgePostedAsync = AcknowledgeAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })
-        .AddPostmanWithToken<LocalPayload>(DeliverLocalAsync)
+        .AddPostman<LocalPayload>(async (message, token) => await DeliverLocalAsync(message, token))
         .AddStreamPostman<StreamPayload, PayloadDelivery>(OutboxProcessorTestProviderNames.Events,
             message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
             static (message, token) => new(message.Value, token))
         .AddGrainPostman<GrainPayload, IPayloadSinkGrain>(
             static (message, grains) => grains.GetGrain<IPayloadSinkGrain>(message.Target),
-            static (grain, message, token) => grain.ReceiveAsync(new(message.Value, token)))
-        .AddPostman<IPayloadEvent>(static (message, _) => Task.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}")))
-        .AddPostman<IPayloadEvent>(static (message, _, cancellationToken) => ValueTask.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}, cancellation: {cancellationToken.IsCancellationRequested}")));
+            static async (grain, message, token) => await grain.ReceiveAsync(new(message.Value, token)))
+        .AddPostman<IPayloadEvent>(static async message => await RejectUnexpectedPayloadAsync(message))
+        .AddPostman<IPayloadEvent>(static async (message, _, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await RejectUnexpectedPayloadAsync(message);
+        });
     }
+
+    private static ValueTask RejectUnexpectedPayloadAsync(IPayloadEvent message) =>
+        ValueTask.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}"));
 
     private ValueTask DeliverLocalAsync(LocalPayload message, OutboxSequenceToken token) =>
         new(GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -127,20 +127,20 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
             AcknowledgePostedAsync = AcknowledgeAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })
-        .AddPostman<LocalPayload>((message, token, cancellationToken) =>
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)
-                .ReceiveAsync(new(message.Value, token));
-        })
+        .AddPostmanWithToken<LocalPayload>(DeliverLocalAsync)
         .AddStreamPostman<StreamPayload, PayloadDelivery>(OutboxProcessorTestProviderNames.Events,
             message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
             static (message, token) => new(message.Value, token))
         .AddGrainPostman<GrainPayload, IPayloadSinkGrain>(
             static (message, grains) => grains.GetGrain<IPayloadSinkGrain>(message.Target),
             static (grain, message, token) => grain.ReceiveAsync(new(message.Value, token)))
-        .AddPostman<IPayloadEvent>(static _ => ValueTask.FromException(new InvalidOperationException("A specific payload handler should win.")));
+        .AddPostman<IPayloadEvent>(static (message, _) => Task.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}")))
+        .AddPostman<IPayloadEvent>(static (message, _, cancellationToken) => ValueTask.FromException(new InvalidOperationException($"Unexpected payload: {message.Value}, cancellation: {cancellationToken.IsCancellationRequested}")));
     }
+
+    private ValueTask DeliverLocalAsync(LocalPayload message, OutboxSequenceToken token) =>
+        new(GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target)
+            .ReceiveAsync(new(message.Value, token)));
 
     public async Task PublishAsync(Guid target, bool failAcknowledgment)
     {

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
@@ -1,0 +1,59 @@
+namespace Egil.Orleans.Messaging.Tests.State;
+
+public sealed class OutboxRecoveryProofTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task Competing_append_must_not_be_confirmed_as_the_attempted_write(int competingTimestampOffsetTicks)
+    {
+        var timestamp = new DateTimeOffset(2026, 9, 11, 12, 0, 0, TimeSpan.Zero);
+        var initial = Outbox<string>.Create().Add("already pending", timestamp);
+        var attempted = initial.Add("attempted message", timestamp.AddSeconds(1));
+        var competing = initial.Add("competing message", timestamp.AddSeconds(1).AddTicks(competingTimestampOffsetTicks));
+        var storage = new AmbiguousOutboxStorage(initial, competing);
+        var manager = new DefaultStateManager<Outbox<string>>(storage, Outbox<string>.Create);
+
+        var error = await Record.ExceptionAsync(() => manager.WriteAsync(attempted));
+
+        Assert.DoesNotContain(manager.State, item => item.Message == "attempted message");
+        Assert.IsType<TimeoutException>(error);
+    }
+
+    [Fact]
+    public async Task Saved_snapshot_with_lost_response_is_confirmed_after_deserialization()
+    {
+        var initial = Outbox<string>.Create();
+        var attempted = initial.Add("saved message", DateTimeOffset.UnixEpoch);
+        var durable = System.Text.Json.JsonSerializer.Deserialize<Outbox<string>>(
+            System.Text.Json.JsonSerializer.Serialize(attempted))!;
+        var storage = new AmbiguousOutboxStorage(initial, durable);
+        var manager = new DefaultStateManager<Outbox<string>>(storage, Outbox<string>.Create);
+
+        await manager.WriteAsync(attempted);
+
+        Assert.Equal("saved message", Assert.Single(manager.State).Message);
+        Assert.Equal(attempted, manager.State);
+    }
+
+    private sealed class AmbiguousOutboxStorage(Outbox<string> initial, Outbox<string> durable) : IPersistentState<Outbox<string>>
+    {
+        public Outbox<string> State { get; set; } = initial;
+        public string Etag { get; set; } = "initial";
+        public bool RecordExists => true;
+
+        public Task ReadStateAsync()
+        {
+            State = durable;
+            Etag = "competing";
+            return Task.CompletedTask;
+        }
+
+        // An unknown-outcome failure permits a competing write to be visible on recovery.
+        public Task WriteStateAsync() => Task.FromException(new TimeoutException("Unknown write outcome"));
+        public Task ClearStateAsync() => throw new NotSupportedException();
+        public Task ReadStateAsync(CancellationToken cancellationToken) => ReadStateAsync();
+        public Task WriteStateAsync(CancellationToken cancellationToken) => WriteStateAsync();
+        public Task ClearStateAsync(CancellationToken cancellationToken) => ClearStateAsync();
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
@@ -1,0 +1,124 @@
+using TimeProviderExtensions;
+
+namespace Egil.Orleans.Messaging.Tests.State;
+
+public sealed class StateManagerActivationTests(MessagingTestClusterFixture fixture)
+    : IClassFixture<MessagingTestClusterFixture>
+{
+    [Fact]
+    public async Task Runtime_clock_configuration_reaches_the_tracker_replaced_by_a_read()
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStateManagerActivationGrain>(Guid.NewGuid());
+        await grain.SaveAndDeactivateAsync("saved");
+
+        Assert.True(await grain.UsesConfiguredClockAfterReadAsync());
+    }
+
+    [Fact]
+    public async Task Constructor_registration_defers_defaults_until_state_is_loaded()
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStateManagerActivationGrain>(Guid.NewGuid());
+
+        var state = await grain.InspectAsync();
+
+        Assert.True(state.ConstructorReadRejected);
+        Assert.Equal("default", state.Value);
+        Assert.Equal("default", state.ActivationValue);
+        Assert.Equal(1, state.FactoryCalls);
+        Assert.Equal(1, state.ConfigureCalls);
+        Assert.False(state.RecordExists);
+    }
+
+    [Fact]
+    public async Task Constructor_registered_manager_uses_persisted_state_on_reactivation()
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStateManagerActivationGrain>(Guid.NewGuid());
+        await grain.SaveAndDeactivateAsync("saved");
+
+        var state = await grain.InspectAsync();
+
+        Assert.Equal("saved", state.Value);
+        Assert.Equal("saved", state.ActivationValue);
+        Assert.Equal(0, state.FactoryCalls);
+        Assert.Equal(1, state.ConfigureCalls);
+        Assert.True(state.RecordExists);
+    }
+}
+
+public interface IStateManagerActivationGrain : IGrainWithGuidKey
+{
+    Task<ActivationStateObservation> InspectAsync();
+    Task SaveAndDeactivateAsync(string value);
+    Task<bool> UsesConfiguredClockAfterReadAsync();
+}
+
+[GenerateSerializer]
+public sealed record ActivationStateObservation(
+    [property: Id(0)] string Value,
+    [property: Id(1)] string ActivationValue,
+    [property: Id(2)] bool RecordExists,
+    [property: Id(3)] int FactoryCalls,
+    [property: Id(4)] int ConfigureCalls,
+    [property: Id(5)] bool ConstructorReadRejected);
+
+[GenerateSerializer]
+public sealed record ActivationManagedState
+{
+    [Id(0)] public string Value { get; init; } = "provider-default";
+    [Id(1)] public MessageTracker Tracker { get; init; } = new();
+}
+
+public sealed class StateManagerActivationGrain : Grain, IStateManagerActivationGrain
+{
+    private readonly IPersistentState<ActivationManagedState> storage;
+    private readonly IStateManager<ActivationManagedState> manager;
+    private readonly bool constructorReadRejected;
+    private readonly ManualTimeProvider time;
+    private int factoryCalls;
+    private int configureCalls;
+    private string activationValue = "not activated";
+
+    public StateManagerActivationGrain(
+        [PersistentState("state", "Default")] IPersistentState<ActivationManagedState> storage,
+        ManualTimeProvider time)
+    {
+        this.time = time;
+        this.storage = storage;
+        manager = this.RegisterStateManager("Default", storage,
+            () => { factoryCalls++; return new() { Value = "default" }; },
+            state => { configureCalls++; state.Tracker.RegisterTimeProvider(time); });
+        try
+        {
+            _ = manager.State;
+        }
+        catch (InvalidOperationException)
+        {
+            constructorReadRejected = true;
+        }
+    }
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        activationValue = manager.State.Value;
+        return Task.CompletedTask;
+    }
+
+    public Task<ActivationStateObservation> InspectAsync() => Task.FromResult(new ActivationStateObservation(
+        manager.State.Value, activationValue, storage.RecordExists,
+        factoryCalls, configureCalls, constructorReadRejected));
+
+    public async Task<bool> UsesConfiguredClockAfterReadAsync()
+    {
+        await manager.ReadAsync();
+        var now = time.GetUtcNow();
+        var sender = GrainContext.GrainId;
+        manager.State.Tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out var tracked);
+        return tracked.Evict(sender, now.AddSeconds(1)).LatestOutbox(sender) is null;
+    }
+
+    public async Task SaveAndDeactivateAsync(string value)
+    {
+        await manager.WriteAsync(manager.State with { Value = value });
+        DeactivateOnIdle();
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerExtensionsTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerExtensionsTests.cs
@@ -15,7 +15,7 @@ public sealed class StateManagerExtensionsTests
             provider,
             storageName,
             storage,
-            typeof(StateManagerExtensionsTests));
+            typeof(StateManagerExtensionsTests), static () => new TestState("default"));
 
         Assert.NotNull(manager);
         Assert.Equal(new TestState("initial"), manager.State);
@@ -32,7 +32,7 @@ public sealed class StateManagerExtensionsTests
                 provider,
                 "missing",
                 storage,
-                typeof(StateManagerExtensionsTests)));
+                typeof(StateManagerExtensionsTests), static () => new TestState("default")));
 
         Assert.Contains("missing", ex.Message);
         Assert.Contains(typeof(TestState).FullName!, ex.Message);
@@ -45,7 +45,7 @@ public sealed class StateManagerExtensionsTests
         var storage = new FakePersistentState(new TestState("initial"));
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
-            StateManagerExtensions.RegisterStateManager<TestGrainBase, TestState>(null!, "state", storage));
+            StateManagerExtensions.RegisterStateManager<TestGrainBase, TestState>(null!, "state", storage, static () => new TestState("default")));
 
         Assert.Equal("grain", ex.ParamName);
     }
@@ -57,7 +57,7 @@ public sealed class StateManagerExtensionsTests
         var storage = new FakePersistentState(new TestState("initial"));
 
         var ex = Assert.Throws<ArgumentException>(() =>
-            grain.RegisterStateManager(" ", storage));
+            grain.RegisterStateManager(" ", storage, static () => new TestState("default")));
 
         Assert.Equal("storageName", ex.ParamName);
     }
@@ -68,7 +68,7 @@ public sealed class StateManagerExtensionsTests
         var grain = new FakeGrainBase();
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
-            grain.RegisterStateManager<TestGrainBase, TestState>("state", null!));
+            grain.RegisterStateManager<TestGrainBase, TestState>("state", null!, static () => new TestState("default")));
 
         Assert.Equal("storage", ex.ParamName);
     }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerRegistrationExtensionsTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerRegistrationExtensionsTests.cs
@@ -110,16 +110,16 @@ public sealed class StateManagerRegistrationExtensionsTests
 
     private sealed class CustomStateManagerFactory : IStateManagerFactory
     {
-        public IStateManager<TState> Create<TState>(IPersistentState<TState> storage)
+        public IStateManager<TState> Create<TState>(IPersistentState<TState> storage, Func<TState> createInitialState, Action<TState>? configureState = null)
             where TState : class, IEquatable<TState> =>
-            new DefaultStateManager<TState>(storage);
+            new DefaultStateManager<TState>(storage, createInitialState, configureState);
     }
 
     private sealed class TestStateManagerFactory : IStateManagerFactory
     {
-        public IStateManager<TState> Create<TState>(IPersistentState<TState> storage)
+        public IStateManager<TState> Create<TState>(IPersistentState<TState> storage, Func<TState> createInitialState, Action<TState>? configureState = null)
             where TState : class, IEquatable<TState> =>
-            new DefaultStateManager<TState>(storage);
+            new DefaultStateManager<TState>(storage, createInitialState, configureState);
     }
 
     private sealed class FakeSiloBuilder : ISiloBuilder

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
@@ -5,25 +5,26 @@ namespace Egil.Orleans.Messaging.Tests.State;
 public sealed class StateManagerTests
 {
     [Fact]
-    public void State_when_storage_exposes_null_is_null()
+    public void Missing_state_exposes_default_without_writing()
     {
         var storage = new FakePersistentState(null);
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(0, storage.WriteCount);
     }
 
     [Fact]
-    public void State_when_storage_exposes_value_without_record_exposes_value()
+    public void Missing_record_uses_configured_default_instead_of_provider_default()
     {
-        var initial = new TestState("default");
+        var initial = new TestState("provider-default");
         var storage = new FakePersistentState(initial)
         {
             RecordExists = false
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        Assert.Same(initial, manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
         Assert.False(storage.RecordExists);
     }
 
@@ -31,7 +32,7 @@ public sealed class StateManagerTests
     public async Task ReadAsync_refreshes_state_from_storage()
     {
         var storage = new FakePersistentState(new TestState("initial"));
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         storage.State = new TestState("fresh");
 
         await manager.ReadAsync();
@@ -40,7 +41,7 @@ public sealed class StateManagerTests
     }
 
     [Fact]
-    public async Task ReadAsync_when_storage_exposes_null_updates_state_to_null()
+    public async Task ReadAsync_when_record_is_missing_exposes_default()
     {
         var storage = new FakePersistentState(new TestState("initial"))
         {
@@ -50,11 +51,12 @@ public sealed class StateManagerTests
                 state.RecordExists = false;
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         await manager.ReadAsync();
 
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(0, storage.WriteCount);
         Assert.False(storage.RecordExists);
     }
 
@@ -62,7 +64,7 @@ public sealed class StateManagerTests
     public async Task WriteAsync_success_updates_committed_state()
     {
         var storage = new FakePersistentState(new TestState("initial"));
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
         await manager.WriteAsync(next);
@@ -79,7 +81,7 @@ public sealed class StateManagerTests
             WriteException = new TimeoutException("write timeout"),
             OnRead = state => state.State = new TestState("next")
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
         await manager.WriteAsync(next);
@@ -101,7 +103,7 @@ public sealed class StateManagerTests
                 state.Etag = "etag-2";
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next")));
 
@@ -126,7 +128,7 @@ public sealed class StateManagerTests
                 state.Etag = "etag-2";
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
             () => manager.WriteAsync(attempted));
@@ -151,7 +153,7 @@ public sealed class StateManagerTests
                 state.Etag = "etag-2";
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
             () => manager.WriteAsync(attempted));
@@ -170,7 +172,7 @@ public sealed class StateManagerTests
             WriteException = writeException,
             ReadException = new InvalidOperationException("read failed")
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next")));
 
@@ -188,7 +190,7 @@ public sealed class StateManagerTests
             WriteException = writeException,
             ReadException = new InvalidOperationException("read failed")
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
             () => manager.WriteAsync(new TestState("next")));
@@ -203,7 +205,7 @@ public sealed class StateManagerTests
     {
         var original = new VersionedTestState("initial");
         var storage = new FakePersistentVersionedState(original);
-        var manager = new DefaultStateManager<VersionedTestState>(storage);
+        var manager = new DefaultStateManager<VersionedTestState>(storage, static () => new("default"));
         var next = new VersionedTestState("next") { Version = Guid.Empty };
 
         await manager.WriteAsync(next);
@@ -216,11 +218,12 @@ public sealed class StateManagerTests
     public async Task ClearAsync_success_updates_committed_state()
     {
         var storage = new FakePersistentState(new TestState("initial"));
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         await manager.ClearAsync();
 
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(0, storage.WriteCount);
         Assert.False(storage.RecordExists);
     }
 
@@ -228,7 +231,7 @@ public sealed class StateManagerTests
     public async Task WriteAsync_after_clear_can_persist_new_state()
     {
         var storage = new FakePersistentState(new TestState("initial"));
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
         await manager.ClearAsync();
@@ -239,11 +242,11 @@ public sealed class StateManagerTests
     }
 
     [Fact]
-    public async Task WriteAsync_from_cleared_state_when_recovery_read_exposes_null_keeps_null()
+    public async Task WriteAsync_from_cleared_state_when_recovery_read_is_missing_keeps_default()
     {
         var writeException = new TimeoutException("write timeout");
         var storage = new FakePersistentState(new TestState("initial"));
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         await manager.ClearAsync();
         storage.WriteException = writeException;
         storage.OnRead = state =>
@@ -256,7 +259,8 @@ public sealed class StateManagerTests
             () => manager.WriteAsync(new TestState("next")));
 
         Assert.Same(writeException, ex);
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(1, storage.WriteCount);
         Assert.False(storage.RecordExists);
     }
 
@@ -272,11 +276,12 @@ public sealed class StateManagerTests
                 state.RecordExists = false;
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         await manager.ClearAsync();
 
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(0, storage.WriteCount);
         Assert.False(storage.RecordExists);
     }
 
@@ -295,7 +300,7 @@ public sealed class StateManagerTests
                 state.Etag = "etag-2";
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync());
 
@@ -318,12 +323,13 @@ public sealed class StateManagerTests
                 state.RecordExists = false;
             }
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(() => manager.ClearAsync());
 
         Assert.Same(clearException, ex);
-        Assert.Null(manager.State);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.Equal(0, storage.WriteCount);
         Assert.False(storage.RecordExists);
     }
 
@@ -336,12 +342,87 @@ public sealed class StateManagerTests
             ClearException = clearException,
             ReadException = new InvalidOperationException("read failed")
         };
-        var manager = new DefaultStateManager<TestState>(storage);
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync());
 
         Assert.Same(clearException, ex);
         Assert.Equal(new TestState("initial"), manager.State);
+    }
+
+    [Fact]
+    public async Task Missing_record_does_not_confirm_an_ambiguous_write_equal_to_the_default()
+    {
+        var failure = new TimeoutException("lost write");
+        var storage = new FakePersistentState(null)
+        {
+            WriteException = failure,
+            OnRead = loaded => { loaded.State = null!; loaded.RecordExists = false; }
+        };
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
+
+        var error = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new("default")));
+
+        Assert.Same(failure, error);
+        Assert.Equal(new TestState("default"), manager.State);
+        Assert.False(storage.RecordExists);
+    }
+
+    [Fact]
+    public async Task Runtime_configuration_follows_loaded_and_default_instances()
+    {
+        var configured = new List<TestState>();
+        var initial = new TestState("initial");
+        var loaded = new TestState("loaded");
+        var storage = new FakePersistentState(initial) { OnRead = state => state.State = loaded };
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"), configured.Add);
+
+        await manager.ReadAsync();
+        await manager.ClearAsync();
+
+        Assert.Equal([initial, loaded, new TestState("default")], configured);
+        Assert.Same(configured[2], manager.State);
+        Assert.Equal(0, storage.WriteCount);
+    }
+
+    [Fact]
+    public void Null_factory_result_is_rejected()
+    {
+        var storage = new FakePersistentState(null);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            new DefaultStateManager<TestState>(storage, static () => null!));
+
+        Assert.Contains("factory returned null", error.Message);
+    }
+
+    [Fact]
+    public void Existing_null_record_is_not_replaced_with_defaults()
+    {
+        var storage = new FakePersistentState(null) { RecordExists = true };
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            new DefaultStateManager<TestState>(storage, static () => new("default")));
+
+        Assert.Contains("existing state record", error.Message);
+    }
+
+    [Fact]
+    public async Task Readers_keep_the_previous_snapshot_until_the_write_completes()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var previous = new TestState("previous");
+        var next = new TestState("next");
+        var storage = new FakePersistentState(previous) { WriteCompletion = completion.Task };
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
+
+        var write = manager.WriteAsync(next);
+
+        Assert.Same(previous, manager.State);
+        Assert.Same(next, storage.State);
+        completion.SetResult();
+        await write;
+        Assert.Same(next, manager.State);
     }
 
     private sealed record TestState(string Value);
@@ -359,6 +440,8 @@ public sealed class StateManagerTests
         public Exception? ReadException { get; set; }
         public Exception? WriteException { get; set; }
         public Exception? ClearException { get; set; }
+        public Task? WriteCompletion { get; init; }
+        public int WriteCount { get; private set; }
         public Action<FakePersistentState>? OnRead { get; set; }
         public Action<FakePersistentState>? OnWrite { get; set; }
         public Action<FakePersistentState>? OnClear { get; set; }
@@ -380,13 +463,14 @@ public sealed class StateManagerTests
 
         public Task WriteStateAsync()
         {
+            WriteCount++;
             OnWrite?.Invoke(this);
             if (WriteException is not null)
             {
                 throw WriteException;
             }
 
-            return Task.CompletedTask;
+            return WriteCompletion ?? Task.CompletedTask;
         }
 
         public Task ClearStateAsync()

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
@@ -425,6 +425,113 @@ public sealed class StateManagerTests
         Assert.Same(next, manager.State);
     }
 
+    [Theory]
+    [InlineData("read")]
+    [InlineData("write")]
+    [InlineData("clear")]
+    [InlineData("write-recovery")]
+    [InlineData("clear-recovery")]
+    public async Task Configuration_observes_the_adopted_snapshot(string operation)
+    {
+        var storage = new FakePersistentState(new TestState("initial"));
+        DefaultStateManager<TestState>? manager = null;
+        TestState? observedManager = null;
+        TestState? observedStorage = null;
+        TestState? configured = null;
+        manager = new DefaultStateManager<TestState>(storage, static () => new("default"), value =>
+        {
+            configured = value;
+            observedManager = manager?.State;
+            observedStorage = storage.State;
+        });
+        storage.OnRead = loaded => loaded.State = new("loaded");
+        storage.WriteException = operation == "write-recovery" ? new TimeoutException() : null;
+        storage.ClearException = operation == "clear-recovery" ? new TimeoutException() : null;
+
+        _ = await Record.ExceptionAsync(() => operation switch
+        {
+            "read" => manager.ReadAsync(),
+            "write" or "write-recovery" => manager.WriteAsync(new("next")),
+            _ => manager.ClearAsync()
+        });
+
+        Assert.Same(configured, observedManager);
+        Assert.Same(configured, observedStorage);
+        Assert.Same(configured, manager.State);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Configuration_failure_after_successful_storage_is_not_retried_or_hidden(bool clear)
+    {
+        var storage = new FakePersistentState(new TestState("initial"));
+        var failure = new InvalidOperationException("runtime configuration failed");
+        var failNextConfiguration = false;
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"), _ =>
+        {
+            if (failNextConfiguration)
+            {
+                failNextConfiguration = false;
+                throw failure;
+            }
+        });
+        failNextConfiguration = true;
+        var recoveryReads = 0;
+        storage.OnRead = _ => recoveryReads++;
+
+        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+
+        Assert.Same(failure, error);
+        Assert.Equal(clear ? "default" : "next", manager.State.Value);
+        Assert.Equal(0, recoveryReads);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task Invalid_state_after_recovery_read_is_reported_as_validation_failure(bool clear, bool recordExists)
+    {
+        var storage = new FakePersistentState(new TestState("initial"))
+        {
+            WriteException = new TimeoutException("write failed"),
+            ClearException = new TimeoutException("clear failed"),
+            OnRead = loaded => { loaded.State = null!; loaded.RecordExists = recordExists; }
+        };
+        var manager = new DefaultStateManager<TestState>(storage, static () => null!);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+
+        Assert.Contains(recordExists ? "existing state record" : "factory returned null", error.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Configuration_failure_after_recovery_is_reported_and_keeps_loaded_state(bool clear)
+    {
+        var loaded = new TestState("loaded");
+        var storage = new FakePersistentState(new TestState("initial"))
+        {
+            WriteException = new TimeoutException(),
+            ClearException = new TimeoutException(),
+            OnRead = state => state.State = loaded
+        };
+        var failure = new InvalidOperationException("runtime configuration failed");
+        var manager = new DefaultStateManager<TestState>(storage, static () => new("default"), value =>
+        {
+            if (ReferenceEquals(value, loaded)) throw failure;
+        });
+
+        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+
+        Assert.Same(failure, error);
+        Assert.Same(loaded, manager.State);
+        Assert.Same(loaded, storage.State);
+    }
+
     private sealed record TestState(string Value);
 
     private sealed record VersionedTestState(string Value) : VersionedState, IEquatable<VersionedTestState>;

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
@@ -8,11 +8,26 @@ namespace Egil.Orleans.Messaging.Tests.Streams;
 public sealed class StreamManagerResumeTests
 {
     [Fact]
+    public async Task Subscription_uses_tracker_adopted_after_registration()
+    {
+        var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
+        var tracker = CreateTracker("provider-a", "orders", sequenceNumber: 1);
+        var manager = CreateManager(() => tracker, stream);
+        tracker = CreateTracker("provider-a", "orders", sequenceNumber: 9);
+
+        await manager
+            .ConfigureExplicitSubscription<string>("provider-a", "orders", static (_, _) => ValueTask.CompletedTask)
+            .EnsureExplicitSubscriptionsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(new EventSequenceToken(9), stream.SubscribeToken);
+    }
+
+    [Fact]
     public async Task EnsureExplicitSubscriptionsAsync_uses_tracker_resume_token_when_creating_subscription()
     {
         var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
         var tracker = CreateTracker("provider-a", "orders", sequenceNumber: 7);
-        var manager = CreateManager(tracker, stream);
+        var manager = CreateManager(() => tracker, stream);
 
         await manager
             .ConfigureExplicitSubscription<string>("provider-a", "orders", static (_, _) => ValueTask.CompletedTask)
@@ -41,7 +56,7 @@ public sealed class StreamManagerResumeTests
     {
         var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
         var tracker = CreateTracker("provider-a", "orders", sequenceNumber: 7);
-        var manager = CreateManager(tracker, stream);
+        var manager = CreateManager(() => tracker, stream);
 
         await manager
             .ConfigureExplicitSubscription<string>(
@@ -80,7 +95,7 @@ public sealed class StreamManagerResumeTests
         var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
         stream.Handles.Add(handle);
         var tracker = CreateTracker("provider-a", "orders", sequenceNumber: 7);
-        var manager = CreateManager(tracker, stream);
+        var manager = CreateManager(() => tracker, stream);
 
         await manager
             .ConfigureExplicitSubscription<string>("provider-a", "orders", static (_, _) => ValueTask.CompletedTask)
@@ -98,7 +113,7 @@ public sealed class StreamManagerResumeTests
         var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
         stream.Handles.Add(handle);
         var tracker = CreateTracker("provider-a", "orders", sequenceNumber: 7);
-        var manager = CreateManager(tracker, stream);
+        var manager = CreateManager(() => tracker, stream);
 
         await manager
             .ConfigureExplicitSubscription<string>(
@@ -122,7 +137,7 @@ public sealed class StreamManagerResumeTests
             "provider-a",
             streamId,
             new FakeSubscriptionHandle<string>("provider-a", streamId));
-        var manager = CreateManager(tracker, new FakeStream<string>("provider-a", streamId));
+        var manager = CreateManager(() => tracker, new FakeStream<string>("provider-a", streamId));
 
         await ((IStreamManagerComponent)manager
             .ConfigureImplicitSubscription<string>("orders", static (_, _) => ValueTask.CompletedTask))
@@ -141,7 +156,7 @@ public sealed class StreamManagerResumeTests
             "provider-a",
             streamId,
             new FakeSubscriptionHandle<string>("provider-a", streamId));
-        var manager = CreateManager(tracker, new FakeStream<string>("provider-a", streamId));
+        var manager = CreateManager(() => tracker, new FakeStream<string>("provider-a", streamId));
 
         await ((IStreamManagerComponent)manager
             .ConfigureImplicitSubscription<string>(
@@ -172,7 +187,7 @@ public sealed class StreamManagerResumeTests
     }
 
     private static StreamManager CreateManager<TEvent>(
-        MessageTracker? tracker,
+        Func<MessageTracker?>? tracker,
         FakeStream<TEvent> stream)
     {
         var owner = new FakeGrainBase();

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerTests.cs
@@ -233,7 +233,7 @@ public sealed class StreamManagerTestGrain(
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        streamManager = this.RegisterStreamManager(state.State.Tracker)
+        streamManager = this.RegisterStreamManager(() => state.State.Tracker)
             .ConfigureExplicitSubscription<string>(StreamManagerTestProviderNames.Explicit, StreamManagerTestNamespaces.ValueTask, HandleValueTaskAsync)
             .ConfigureExplicitSubscription<string>(StreamManagerTestProviderNames.Explicit, StreamManagerTestNamespaces.Task, HandleTaskAsync)
             .ConfigureExplicitSubscription<string>(StreamManagerTestProviderNames.Explicit, StreamManagerTestNamespaces.Failure, HandleFailureAsync)


### PR DESCRIPTION
Outboxes declared with an interface payload could not register handlers for individual event types, and constructor registration could access state before Orleans hydrated it. This change supports both workflows while keeping acknowledgment tied to the original stored envelopes.

- `AddPostman`, `AddStreamPostman`, and `AddGrainPostman` select payload subtypes. Direct callbacks use `AddPostman` with one, two, or three arguments: payload, optional delivery token, then cancellation. Direct and grain invocation callbacks support both `Task` and `ValueTask`. `OverloadResolutionPriority` prefers `ValueTask` for ordinary async lambdas on C# 13+; older compilers need explicit delegate or lambda return types. `AddGrainPostman` and `AddStreamPostman` remain available with optional token arguments; stream selectors/projections remain synchronous. For example, an `Outbox<IMyEvent>` can dispatch `MyEvent1` and `MyEvent2` to separate postmen.
- `ForStreamProvider(name)` groups chainable `AddStreamPostman` registrations for a configured provider. Grouped and direct registrations share the original processor and first-match ordering, acknowledgment, and retries.
- Stored envelopes contain sender-free `OutboxMessageId` values. Delivery tokens use the owning grain identity, preserving stable tokens on retry and reactivation.
- Each outbox snapshot stores a UUIDv7 `Revision` as an outbox-specific ETag. Mutations change it; no-ops and serialization preserve it. Constant-time equality and hashing use only the revision so recovery rejects competing appends even when their timestamps and sequence metadata match. The redundant first/last comparison is removed; delivery tokens remain unchanged. Code comments explain the recovery failure, revision identity, and serialization requirements. JSON requires a non-empty revision.
- State registration defers creation until hydration. Default factories supply non-null state after missing-record reads and successful clears without persisting a recreatable default. Runtime configuration callbacks run after state replacement, and stream registration resolves the current tracker through an accessor.
- Stream routing and projections independently accept delivery tokens, including token-aware routing of original payloads, through both direct and grouped registration. Removal arguments are named `id`/`ids` to distinguish stored identity from delivery tokens.
- State adoption updates the manager and storage facet before runtime configuration. Callback and validation errors propagate outside storage recovery; configuration failure after a successful write/clear does not trigger a recovery read or silent retry.
- README and API design documentation describe the new APIs and beta migration. This intentionally breaks the previous beta APIs and serialized envelope shape.

The design retains first-match dispatch, sequential delivery within each postman, and original-envelope acknowledgment. A writable State property and covariant envelope interface were unnecessary for the agreed use cases.

Validation completed locally with .NET SDK 10.0.401:

- 284 tests passed, 0 failed or skipped (245 baseline).
- All 18 direct/grain callback combinations compile in a consumer project. Grouped integration coverage delivers two stream payload types alongside direct/grain postmen and retries them after reactivation with stable delivery tokens.
- Release build: 0 warnings and 0 errors.
- Core, Azure Storage, and Event Hubs packages packed successfully.
- Regression coverage includes constructor registration, absent/cleared defaults, tracker replacement, polymorphic payload dispatch, and stable delivery tokens following acknowledgment failure and reactivation.
- Recovery regression tests failed before the revision fix and now pass. They cover rejection of a competing append and confirmation of a saved snapshot after a lost response; additional tests cover revision changes, no-ops, and JSON/Orleans serialization.
- Added regression evidence for 13 state-adoption/configuration/validation cases and four real-grain token-routing combinations, including successful acknowledgment. Documentation compilation infrastructure is deferred.
- Azure adapter tests passed; live Azure services were not exercised.

Closes #179





