### PR TITLE
feat(om)!: support payload-first outbox collections

### DIFF
--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -142,8 +142,7 @@ public sealed record OrderState : VersionedState
 {
     [Id(0)] public string? Name { get; init; }
 
-    [Id(1)] public Outbox<IOrderEvent> Outbox { get; init; } =
-        Outbox<IOrderEvent>.Create();
+    [Id(1)] public Outbox<IOrderEvent> Outbox { get; init; } = [];
 }
 
 public async Task SubmitAsync()
@@ -157,6 +156,34 @@ public async Task SubmitAsync()
     await outboxProcessor.PostInBackgroundAsync();
 }
 ```
+
+`Outbox<T>` implements `IReadOnlyList<T>`: indexing, enumeration, LINQ, and
+collection expressions use payloads. `Envelopes` exposes the same snapshot as an
+`ImmutableArray<OutboxMessageEnvelope<T>>`, including the assigned message IDs,
+without copying. Collection structure is immutable; do not mutate payload objects
+after enqueueing.
+
+```csharp
+Outbox<IOrderEvent> pending = [new OrderSubmitted()];
+var extended = pending.AddRange(new IOrderEvent[] { new OrderCancelled() });
+var queued = extended.Envelopes[0];
+var acknowledged = extended.Remove(queued);
+```
+
+`[]`, `[message]`, and `[.. pending, message]` construct **fresh history** with a
+fresh revision and consecutive IDs starting at one. Spreading copies payloads,
+not IDs, epoch, or the prior sequence high-water mark. Use `Add` / `AddRange` to
+extend existing history, and `Clear` to drain it while preserving that history.
+`AddRange(messages)` uses one system UTC timestamp for the batch; its overload
+`AddRange(messages, utcNow)` accepts an explicit batch timestamp. An empty batch
+returns the same snapshot. Batch inputs are enumerated once and buffered together.
+
+`Remove(envelope)` and `Remove(id)` remove only a matching FIFO head.
+`RemoveRange(envelopes)` and `RemoveRange(ids)` remove matching occurrences
+anywhere, preserving remaining order and sequence history. Use the batch overload
+for processor acknowledgements, which may contain gaps. For an empty removal
+batch, supply a typed collection: bare `RemoveRange([])` is ambiguous between the
+two overloads.
 
 `Add(message)` uses system UTC. When a grain uses an injected clock, sample it
 at the call site and pass the instant with
@@ -176,13 +203,13 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
     state = this.RegisterStateManager("state", storage);
     outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IOrderEvent>
     {
-        PendingItems = () => [.. state.State.Outbox],
+        PendingItems = () => state.State.Outbox,
         AcknowledgePostedAsync = async (items, ct) =>
         {
             ct.ThrowIfCancellationRequested();
             await state.WriteAsync(state.State with
             {
-                Outbox = state.State.Outbox.RemoveRange(items.Select(item => item.Id))
+                Outbox = state.State.Outbox.RemoveRange(items)
             });
         }
     })
@@ -205,7 +232,7 @@ timestamp across retries and reactivation. No sender identity is stored in the o
 `PendingItems`, `AcknowledgePostedAsync`, and `ReconcileFailedAsync` use the original
 stored `OutboxMessageEnvelope<T>` values. Acknowledgment receives exactly the
 successfully delivered items, which need not be a contiguous prefix. Remove them
-by `item.Id` using `RemoveRange`; never remove by position or count. Equal payloads
+by passing the envelopes directly to `RemoveRange`; never remove by position or count. Equal payloads
 can represent different messages and retain distinct stored IDs.
 
 `IOutboxGrain` forwards reminder ticks to the single attached processor.
@@ -319,18 +346,20 @@ synchronous, with optional token arguments.
 Group registrations that use the same configured provider:
 
 ```csharp
-processor.ForStreamProvider("events")
+processor.ForStreamProvider("events", provider => provider
     .AddStreamPostman<OrderSubmitted>(
         message => StreamId.Create("submitted-orders", message.OrderId))
     .AddStreamPostman<OrderCancelled>(
-        message => StreamId.Create("cancelled-orders", message.OrderId));
+        message => StreamId.Create("cancelled-orders", message.OrderId)));
 ```
 
 The group supports the same projections and token-aware selectors as direct
 `AddStreamPostman` calls. Each call registers immediately on the original
 processor, so registration order remains first-match-wins across both forms.
 `ForStreamProvider` selects an existing Orleans provider; it does not install one.
-Continue unrelated registrations through the original `processor` variable.
+The callback overload returns the original processor, so additional postmen can
+be chained after the group. Configuration is synchronous; registrations already
+made remain if the callback throws. The builder-returning overload is also available.
 
 Routing and projection choose their token arguments independently. Both direct
 and grouped registration support token-aware routing with no projection:
@@ -348,6 +377,16 @@ processor.ForStreamProvider("events")
         (message, token) => StreamId.Create("cancelled-by-sender", token.Sender.ToString()),
         message => new CancelledDelivery(message.OrderId));
 ```
+
+### Migrating existing outbox callers
+
+- Indexing and enumeration now return payloads. Use `outbox.Envelopes` where code
+  previously read `.Id` or `.Message` from outbox entries.
+- `PendingItems` now returns a non-null `Outbox<T>` directly. Replace array
+  conversions with `() => state.Outbox`; return `[]` for a fresh empty snapshot,
+  not `default` or `null` (null is rejected with `InvalidOperationException`).
+- Acknowledgement and failure callbacks still receive envelopes. Existing ID-based
+  removal remains supported. The persisted JSON and Orleans field layout is unchanged.
 
 ## Receiver Dedup
 

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -80,10 +80,22 @@ public sealed class OrderGrain : Grain, IOrderGrain
         state = this.RegisterStateManager("state", storage, () => new OrderState());
     }
 
-    public Task RenameAsync(string name) =>
-        state.WriteAsync(state.State with { Name = name });
+    public Task RenameAsync(string name, CancellationToken cancellationToken) =>
+        state.WriteAsync(state.State with { Name = name }, cancellationToken);
 }
 ```
+
+`ReadAsync`, `WriteAsync`, and `ClearAsync` accept an optional `CancellationToken`,
+which is forwarded to storage and any recovery read. Cancellation is cooperative:
+the provider decides whether it can interrupt in-flight work. Existing calls may omit the token; custom
+`IStateManager<T>` implementations must update their method signatures. An already canceled
+token prevents storage access and write-version stamping.
+
+Cancellation after a write or clear starts does not establish whether it persisted.
+If recovery is also canceled, the manager retains its previous visible snapshot
+and rethrows the original operation exception. Re-read with a fresh token before
+another mutation to refresh the state and ETag. A provider-confirmed success is
+adopted even if cancellation was requested concurrently.
 
 The overload without a factory requires `TState : new()`. Constructor registration
 returns immediately, but the provider-specific manager and default state are
@@ -145,15 +157,15 @@ public sealed record OrderState : VersionedState
     [Id(1)] public Outbox<IOrderEvent> Outbox { get; init; } = [];
 }
 
-public async Task SubmitAsync()
+public async Task SubmitAsync(CancellationToken cancellationToken)
 {
     var next = state.State with
     {
         Outbox = state.State.Outbox.Add(new OrderSubmitted())
     };
 
-    await state.WriteAsync(next);
-    await outboxProcessor.PostInBackgroundAsync();
+    await state.WriteAsync(next, cancellationToken);
+    await outboxProcessor.PostInBackgroundAsync(cancellationToken);
 }
 ```
 
@@ -206,11 +218,10 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
         OutboxAccessor = () => state.State.Outbox,
         AcknowledgePostedAsync = async (items, ct) =>
         {
-            ct.ThrowIfCancellationRequested();
             await state.WriteAsync(state.State with
             {
                 Outbox = state.State.Outbox.RemoveRange(items)
-            });
+            }, ct);
         }
     })
     .AddPostman<OrderSubmitted>(async message => await PublishSubmittedAsync(message))

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -405,7 +405,7 @@ processor.ForStreamProvider("events")
 `MessageTracker` accepts a message only when its stream token, stream cursor, or outbox token advances the stored high-water mark:
 
 ```csharp
-if (!state.State.Tracker.ProcessMessage("prices", token, out var tracker))
+if (!state.State.Tracker.TryAcceptMessage("prices", token, out var tracker))
 {
     return;
 }
@@ -435,7 +435,7 @@ streamManager = this.RegisterStreamManager(() => state.State.Tracker)
         "prices",
         async (message, cursor) =>
         {
-            if (!state.State.Tracker.ProcessMessage(cursor, out var tracker))
+            if (!state.State.Tracker.TryAcceptMessage(cursor, out var tracker))
             {
                 return;
             }
@@ -548,6 +548,11 @@ guaranteed; use a System.Text.Json serializer or the Orleans binary serializer.
 This package is messaging infrastructure, not an event-sourcing or CQRS framework. It wraps Orleans state, outbox dispatch, receiver deduplication, and stream subscription management while leaving domain modeling, read models, transport targets, and operational policy to the application.
 
 ## Beta API changes
+
+Replace `MessageTracker.ProcessMessage(...)` with `TryAcceptMessage(...)` for all
+stream and outbox overloads. It returns the acceptance decision and the next
+tracker; it does not execute the message handler or persist the tracker. Tokenless
+stream messages are accepted without advancing tracking state.
 
 The constructor-registration and payload-postman changes tracked in
 [issue #179](https://github.com/egil/framework/issues/179) are breaking changes:

--- a/Egil.Orleans.Messaging/README.md
+++ b/Egil.Orleans.Messaging/README.md
@@ -203,7 +203,7 @@ public OrderGrain([PersistentState("state", "Default")] IPersistentState<OrderSt
     state = this.RegisterStateManager("state", storage);
     outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IOrderEvent>
     {
-        PendingItems = () => state.State.Outbox,
+        OutboxAccessor = () => state.State.Outbox,
         AcknowledgePostedAsync = async (items, ct) =>
         {
             ct.ThrowIfCancellationRequested();
@@ -229,7 +229,8 @@ and cancellation is always third. Capture a grain factory when needed, or use
 `OutboxMessageId` and its owning grain ID, preserving sequence, epoch and append
 timestamp across retries and reactivation. No sender identity is stored in the outbox.
 
-`PendingItems`, `AcknowledgePostedAsync`, and `ReconcileFailedAsync` use the original
+`OutboxAccessor` returns the current `Outbox<T>` snapshot.
+`AcknowledgePostedAsync` and `ReconcileFailedAsync` receive its original
 stored `OutboxMessageEnvelope<T>` values. Acknowledgment receives exactly the
 successfully delivered items, which need not be a contiguous prefix. Remove them
 by passing the envelopes directly to `RemoveRange`; never remove by position or count. Equal payloads
@@ -382,7 +383,7 @@ processor.ForStreamProvider("events")
 
 - Indexing and enumeration now return payloads. Use `outbox.Envelopes` where code
   previously read `.Id` or `.Message` from outbox entries.
-- `PendingItems` now returns a non-null `Outbox<T>` directly. Replace array
+- Rename `PendingItems` to `OutboxAccessor`, which returns a non-null `Outbox<T>` directly. Replace array
   conversions with `() => state.Outbox`; return `[]` for a fresh empty snapshot,
   not `default` or `null` (null is rejected with `InvalidOperationException`).
 - Acknowledgement and failure callbacks still receive envelopes. Existing ID-based
@@ -548,4 +549,7 @@ The constructor-registration and payload-postman changes tracked in
 - Supply state factories for types without a public parameterless constructor. Custom `IStateManagerFactory` implementations receive the initial-state factory and runtime configuration callback.
 - Pass a tracker accessor to `RegisterStreamManager`, for example `() => state.State.Tracker`. It is evaluated when attaching/resuming subscriptions, after hydration, and observes later state replacement.
 
-The stored outbox JSON shape changes. Migration of earlier beta data is not provided.
+The earlier sender-free message-ID and revision changes described above changed
+the stored JSON shape; migration of snapshots predating those changes is not
+provided. The payload-first collection and OutboxAccessor changes preserve that
+existing sender-free, revision-bearing JSON and Orleans layout.

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -403,7 +403,9 @@ outbox.Clear();             // Preserves sequence high-water mark and epoch.
 
 The actual types carry Orleans serialization metadata and JSON support. Each stored
 ID field is required in JSON so malformed data cannot silently acquire default
-sequence metadata. This beta changes the stored shape without a legacy migration.
+sequence metadata. The earlier sender-free ID and revision changes changed the
+stored shape without a legacy migration. Payload-first enumeration and the
+OutboxAccessor rename do not change that persisted representation.
 
 The public collection implements `IReadOnlyList<T>` over payloads. `Envelopes`
 returns the existing immutable envelope array for inspection and acknowledgement.
@@ -1292,14 +1294,14 @@ sequenceDiagram
     participant Reconcile as "Non-interleaving reconciliation turn"
 
     Grain->>Dispatch: "PostInBackgroundAsync schedules dispatch"
-    Dispatch->>Grain: "PendingItems() snapshot"
+    Dispatch->>Grain: "OutboxAccessor() snapshot"
     Dispatch->>Postmen: "Dispatch all pending items concurrently"
     Note over Dispatch,Grain: "Other grain calls may run while postmen await"
     Postmen-->>Dispatch: "Success/failure results"
     Dispatch->>Reconcile: "Enqueue reconciliation"
     Reconcile->>Grain: "AcknowledgePostedAsync / ReconcileFailedAsync"
     Note over Reconcile,Grain: "Must not interleave with normal writes"
-    Reconcile->>Grain: "PendingItems() and retry/reminder update"
+    Reconcile->>Grain: "OutboxAccessor() and retry/reminder update"
 ```
 
 Orleans has two relevant scheduling layers:
@@ -1327,7 +1329,7 @@ The two technically valid ways to get the diagram above are:
    time-based.
 2. Move pending/acknowledge/reconcile callbacks onto an outbox grain interface
    and have the processor call the owning grain through its self-reference.
-   Those methods are then ordinary Orleans grain calls. `PendingItems` should
+   Those methods are then ordinary Orleans grain calls. `OutboxAccessor` should
    not be `[ReadOnly]` if it must wait behind writes; `[ReadOnly]` only
    interleaves with other read-only calls, not arbitrary writes.
 
@@ -1397,8 +1399,9 @@ extension<TGrain>(TGrain grain) where TGrain : IOutboxGrain, IGrainBase
 ```csharp
 public sealed class OutboxProcessorOptions<TOutbox> where TOutbox : notnull
 {
-    /// Snapshot of pending items. Called once per post run from a grain turn.
-    public required Func<Outbox<TOutbox>> PendingItems { get; init; }
+    /// Returns the current immutable outbox snapshot. Evaluated before dispatch
+    /// and again during reconciliation and retry scheduling.
+    public required Func<Outbox<TOutbox>> OutboxAccessor { get; init; }
 
     /// Acknowledges successfully posted items.
     /// Expected to remove those items from the durable outbox state.
@@ -1441,23 +1444,22 @@ processing-timeout behavior, and pass `timeProvider.GetUtcNow()` to
 `Outbox.Add(message, utcNow)` when appending. The processor does not own the
 persisted outbox or re-inject transient services into it.
 
-Naming note: `PendingItems` intentionally names the role of the callback
-rather than an imperative method (`GetPending`). `OutboxAccessor` was
-considered, but it is less precise because the processor does not need
-general outbox access, only a pending-item snapshot.
+Naming note: `OutboxAccessor` describes a callback that reads the current immutable
+outbox snapshot. The processor evaluates it again as reconciliation and retry
+scheduling proceed, because state writes can replace the outbox instance.
 
 `AcknowledgePostedAsync` and `ReconcileFailedAsync` are reconciliation
 callbacks, not passive notifications:
 
 - `AcknowledgePostedAsync` is expected to remove successfully posted items
   from the durable outbox and persist that change. If acknowledged items
-  still appear in `PendingItems` after the callback returns, the processor
+  still appear in `OutboxAccessor` after the callback returns, the processor
   treats them as pending and they may be posted again.
 - `ReconcileFailedAsync` is the grain's policy hook for failed items. The
   grain may leave them in the outbox for retry, remove them, move them to
   dead-letter state, or make any other durable state change. If null, failed
   items are left pending and retried silently.
-- After either callback returns, the processor reads `PendingItems` again
+- After either callback returns, the processor reads `OutboxAccessor` again
   before scheduling retry/reminder work. The latest pending snapshot is the
   source of truth.
 
@@ -1591,9 +1593,9 @@ public async Task ReceiveReminder(string name, TickStatus status)
 - **Callback-based, not DI service.** Grain controls dispatch logic,
   can pass its own state to the postman. DI service adds indirection
   without clear benefit.
-- **`PendingItems`, not `GetPending`.** The option is a callback consumed
-  by the processor, not a method users call. The name describes the data
-  supplied to the processor and avoids implying ad-hoc outbox operations.
+- **`OutboxAccessor`.** The callback reads the current immutable outbox,
+  including after state replacement. It is not a captured, fixed collection
+  of pending items.
 - **First-registered-wins postman matching.** Simple dispatch model.
   The metaphor is a switch statement: the first matching case handles the
   item. Order most-specific first. Unmatched items →

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -580,17 +580,17 @@ public sealed class MessageTracker
 
     public void RegisterTimeProvider(TimeProvider time) => this.time = time;
 
-    public bool ProcessMessage(StreamCursor cursor, out MessageTracker next);
-    public bool ProcessMessage(
+    public bool TryAcceptMessage(StreamCursor cursor, out MessageTracker next);
+    public bool TryAcceptMessage(
         string streamNamespace,
         StreamSequenceToken? token,
         out MessageTracker next);
-    public bool ProcessMessage(
+    public bool TryAcceptMessage(
         string streamProviderName,
         string streamNamespace,
         StreamSequenceToken? token,
         out MessageTracker next);
-    public bool ProcessMessage(OutboxSequenceToken token, out MessageTracker next);
+    public bool TryAcceptMessage(OutboxSequenceToken token, out MessageTracker next);
 
     public StreamCursor? LatestStream(string streamNamespace);
     public StreamCursor? LatestStream(string streamProviderName, string streamNamespace);
@@ -631,7 +631,7 @@ public sealed class MessageTracker
   Stream keys are intentionally not part of `MessageTracker` state because
   the tracker is scoped to one grain activation's durable state.
 
-### `ProcessMessage(StreamCursor)` and stream token semantics
+### `TryAcceptMessage(StreamCursor)` and stream token semantics
 
 Users can pass either a `StreamCursor` or the raw Orleans
 `StreamSequenceToken` plus stream namespace. Provider-qualified overloads are
@@ -651,7 +651,7 @@ It returns `null` both when no stream is tracked and when the tracked cursor
 has a null token; callers that need to distinguish those cases should use
 `LatestStream(...)`.
 
-### `ProcessMessage(OutboxSequenceToken)` semantics
+### `TryAcceptMessage(OutboxSequenceToken)` semantics
 
 | Prior entry | Comparison                                   | Decision | Effect                   |
 | ----------- | -------------------------------------------- | -------- | ------------------------ |
@@ -1818,7 +1818,7 @@ specific behavior:
 - **Outbox drain grain** — exercises `Outbox<T>` Add/Remove/Clear,
   epoch reset, `OutboxProcessor` timer/reminder lifecycle, postman
   dispatch + error callback with attempt count.
-- **Dedup grain** — exercises `MessageTracker.ProcessMessage` for both
+- **Dedup grain** — exercises `MessageTracker.TryAcceptMessage` for both
   stream cursors and outbox tokens, epoch-aware acceptance, eviction.
 - **Interleaved-read grain** — exercises `[AlwaysInterleave]` reads
   seeing only committed state while a write is in-flight.

--- a/Egil.Orleans.Messaging/api-design.md
+++ b/Egil.Orleans.Messaging/api-design.md
@@ -364,9 +364,10 @@ business-state change that produced it.
 (handed off to a postman successfully). It lives as a property on the
 grain's state record for atomic writes.
 
-The collection behaves like `ImmutableArray<OutboxMessageEnvelope<T>>`
-— read-only iteration, indexer, value semantics, mutators return new
-instances — with three additions:
+The collection implements `IReadOnlyList<T>` over payloads, with read-only
+iteration and indexing. Mutations return new snapshots; equality compares their
+persisted revisions rather than payload contents. `Envelopes` exposes the
+immutable array of assigned message IDs and payloads. The outbox also provides:
 
 - A sender-free stored `OutboxMessageId` for each item.
 - A monotonic `LatestSequenceNumber` that persists independently of the
@@ -386,9 +387,15 @@ public sealed record OutboxMessageId(long SequenceNumber, DateTimeOffset Timesta
 public sealed record OutboxMessageEnvelope<T>(OutboxMessageId Id, T Message);
 
 // Public collection operations; mutations return new immutable instances.
+Outbox<T> fresh = [];
 Outbox<T>.Create();
 outbox.Add(message);
 outbox.Add(message, utcNow);
+outbox.AddRange(messages);
+outbox.AddRange(messages, utcNow);
+ImmutableArray<OutboxMessageEnvelope<T>> envelopes = outbox.Envelopes;
+outbox.Remove(envelope);
+outbox.RemoveRange(envelopes);
 outbox.Remove(id);          // Removes only a matching FIFO head.
 outbox.RemoveRange(ids);    // Removes matching IDs anywhere, preserving remaining order.
 outbox.Clear();             // Preserves sequence high-water mark and epoch.
@@ -397,6 +404,13 @@ outbox.Clear();             // Preserves sequence high-water mark and epoch.
 The actual types carry Orleans serialization metadata and JSON support. Each stored
 ID field is required in JSON so malformed data cannot silently acquire default
 sequence metadata. This beta changes the stored shape without a legacy migration.
+
+The public collection implements `IReadOnlyList<T>` over payloads. `Envelopes`
+returns the existing immutable envelope array for inspection and acknowledgement.
+Collection expressions enqueue payloads in fresh history, including spreads;
+`AddRange` extends existing history with one timestamp per batch and one new
+snapshot revision. Empty batches return the original instance. Neither operation
+mutates payload objects or existing snapshots.
 
 ### Epoch semantics
 
@@ -445,7 +459,7 @@ equality, never revision ordering. Message IDs and delivery tokens are unchanged
 ### Why these choices
 
 - **Sealed class, not record.** No `with`, no synthesized copy
-  constructor. Mutation through four method families only, preserving
+  constructor. Mutation through controlled collection operations, preserving
   sequence and epoch invariants.
 - **`Add(T payload)` not `Add(envelope)`.** Outbox owns sequence
   assignment. Callers cannot fabricate sequence numbers.
@@ -1384,7 +1398,7 @@ extension<TGrain>(TGrain grain) where TGrain : IOutboxGrain, IGrainBase
 public sealed class OutboxProcessorOptions<TOutbox> where TOutbox : notnull
 {
     /// Snapshot of pending items. Called once per post run from a grain turn.
-    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>> PendingItems { get; init; }
+    public required Func<Outbox<TOutbox>> PendingItems { get; init; }
 
     /// Acknowledges successfully posted items.
     /// Expected to remove those items from the durable outbox state.
@@ -1450,7 +1464,7 @@ callbacks, not passive notifications:
 ### `OutboxProcessor<TOutbox>`
 
 `TOutbox` is the base payload type. All handler families operate on payloads;
-stored envelopes are confined to pending snapshots and reconciliation callbacks.
+stored envelopes are available through `Outbox<T>.Envelopes` and reconciliation callbacks.
 `AddPostman` callbacks take `(message)`, `(message, token)`, or
 `(message, token, cancellationToken)`, with both `Task` and `ValueTask` overloads.
 Argument count selects the parameter shape. `OverloadResolutionPriority(1)` on
@@ -1467,7 +1481,9 @@ provide the same combinations.
 Grain invocations take `(grain, message)`, `(grain, message, token)`, or
 `(grain, message, token, cancellationToken)` with the same Task/ValueTask overload
 priority.
-`ForStreamProvider(name)` returns an `OutboxStreamProviderBuilder<TOutbox>` with
+`ForStreamProvider(name, configure)` invokes synchronous configuration and returns the
+original processor. Registrations are immediate and preserve first-match order,
+including if the callback subsequently throws. `ForStreamProvider(name)` returns an `OutboxStreamProviderBuilder<TOutbox>` with
 chainable `AddStreamPostman` overloads matching the direct registrations, except
 that the provider name is supplied once. Registration forwards immediately to the
 original processor; there is no separate dispatch registry, acknowledgment state,
@@ -1518,6 +1534,8 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         Func<TSub, TEvent> project)
         where TSub : TOutbox;
     public OutboxStreamProviderBuilder<TOutbox> ForStreamProvider(string streamProviderName);
+    public OutboxProcessor<TOutbox> ForStreamProvider(
+        string streamProviderName, Action<OutboxStreamProviderBuilder<TOutbox>> configure);
     [OverloadResolutionPriority(1)]
     public OutboxProcessor<TOutbox> AddGrainPostman<TSub, TGrain>(
         Func<TSub, IGrainFactory, TGrain> resolveGrain,

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.State.AzureStorage/AzureStorage/AzureStorageStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging.State.AzureStorage/AzureStorage/AzureStorageStateManager.cs
@@ -76,7 +76,9 @@ internal static class AzureStorageFailureClassifier
             foreach (var inner in aggregateException.Flatten().InnerExceptions)
             {
                 var innerKind = TryClassify(inner);
-                if (innerKind is StorageFailureKind.UnknownOutcome)
+                // An unclassified inner failure (for example a transport timeout) is
+                // also uncertain. A rejected retry cannot prove an earlier attempt failed.
+                if (innerKind is null or StorageFailureKind.UnknownOutcome)
                 {
                     return StorageFailureKind.UnknownOutcome;
                 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.CollectionBuilder.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.CollectionBuilder.cs
@@ -1,0 +1,31 @@
+using System.Collections.Immutable;
+
+namespace Egil.Orleans.Messaging.Outboxes;
+
+/// <summary>Constructs fresh outboxes from payload collection expressions.</summary>
+public static class Outbox
+{
+    /// <summary>Enqueues the supplied payloads in a fresh outbox, assigning consecutive message IDs.</summary>
+    /// <remarks>
+    /// Collection expressions create new history, even when spreading an existing outbox.
+    /// Use AddRange to extend existing history and Clear to drain it without resetting it.
+    /// All payloads in this construction share one system UTC timestamp.
+    /// </remarks>
+    public static Outbox<T> Create<T>(ReadOnlySpan<T> messages)
+    {
+        if (messages.IsEmpty)
+        {
+            return Outbox<T>.Create();
+        }
+
+        var now = TimeProvider.System.GetUtcNow();
+        var builder = ImmutableArray.CreateBuilder<OutboxMessageEnvelope<T>>(messages.Length);
+        foreach (var message in messages)
+        {
+            var id = new OutboxMessageId(builder.Count + 1L, now, now);
+            builder.Add(new(id, message));
+        }
+
+        return new(messages.Length, builder.MoveToImmutable(), now, Guid.CreateVersion7());
+    }
+}

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/Outbox.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace Egil.Orleans.Messaging.Outboxes;
@@ -14,12 +15,12 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// <para>
 /// <b>Immutable-collection semantics:</b> Behaves like
 /// <see cref="ImmutableArray{T}"/> — read-only iteration, indexer access,
-/// mutators (<see cref="Add(T)"/>, <see cref="Remove"/>, <see cref="RemoveRange"/>,
+/// mutators (<see cref="Add(T)"/>, <see cref="Remove(OutboxMessageId)"/>, <see cref="RemoveRange(IEnumerable{OutboxMessageId})"/>,
 /// <see cref="Clear"/>) return <em>new</em> instances. The original is never
 /// modified. Assign the return value back to the state property and write.
 /// </para>
 /// <para>
-/// <b>Sequence ownership:</b> Only <see cref="Add(T)"/> assigns sequence numbers.
+/// <b>Sequence ownership:</b> <see cref="Add(T)"/>, <see cref="AddRange(IEnumerable{T})"/>, and collection expressions assign sequence numbers.
 /// Callers supply the payload; the outbox stamps <see cref="OutboxMessageId"/>
 /// with a monotonically increasing <see cref="LatestSequenceNumber"/> and the
 /// current <see cref="Epoch"/>. This is a hard invariant — there is no public
@@ -71,7 +72,8 @@ namespace Egil.Orleans.Messaging.Outboxes;
 [GenerateSerializer]
 [Alias("egil.orleans.messaging.Outbox`1")]
 [JsonConverter(typeof(OutboxJsonConverterFactory))]
-public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquatable<Outbox<T>>
+[CollectionBuilder(typeof(Outbox), nameof(Outbox.Create))]
+public sealed class Outbox<T> : IReadOnlyList<T>, IEquatable<Outbox<T>>
 {
     [Id(1)] private readonly long latestSequenceNumber;
     [Id(2)] private readonly ImmutableArray<OutboxMessageEnvelope<T>> items;
@@ -149,12 +151,26 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
     /// </summary>
     public bool IsEmpty => items.IsDefaultOrEmpty;
 
-    /// <summary>Gets the envelope at the specified index.</summary>
-    public OutboxMessageEnvelope<T> this[int index] => items[index];
+    /// <summary>Gets the payload at the specified index.</summary>
+    public T this[int index] => items[index].Message;
+
+    /// <summary>Gets the immutable snapshot of payloads and their assigned message IDs.</summary>
+    /// <remarks>
+    /// Acknowledgement callbacks return entries from this view. Pass them to
+    /// <see cref="RemoveRange(IEnumerable{OutboxMessageEnvelope{T}})"/> to remove
+    /// specific queued occurrences, even when payloads are equal. The array is
+    /// shared without copying; payload objects must not be mutated after enqueueing.
+    /// </remarks>
+    public ImmutableArray<OutboxMessageEnvelope<T>> Envelopes => items;
 
     /// <inheritdoc/>
-    public IEnumerator<OutboxMessageEnvelope<T>> GetEnumerator()
-        => ((IEnumerable<OutboxMessageEnvelope<T>>)items).GetEnumerator();
+    public IEnumerator<T> GetEnumerator()
+    {
+        foreach (var item in items)
+        {
+            yield return item.Message;
+        }
+    }
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -211,6 +227,60 @@ public sealed class Outbox<T> : IReadOnlyList<OutboxMessageEnvelope<T>>, IEquata
             items.Add(new OutboxMessageEnvelope<T>(token, message)),
             epoch,
             Guid.CreateVersion7());
+    }
+
+    /// <summary>Appends payloads in enumeration order using one system UTC timestamp for the batch.</summary>
+    /// <remarks>
+    /// Preserves existing IDs and sequence history. An empty batch returns this
+    /// snapshot unchanged. Inputs are enumerated once and the backing array is built once.
+    /// </remarks>
+    public Outbox<T> AddRange(IEnumerable<T> messages) =>
+        AddRange(messages, TimeProvider.System.GetUtcNow());
+
+    /// <summary>Appends payloads with consecutive IDs using the supplied timestamp for the batch.</summary>
+    /// <remarks>Normalizes the timestamp to UTC. The first nonempty batch establishes the epoch.</remarks>
+    public Outbox<T> AddRange(IEnumerable<T> messages, DateTimeOffset utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        using var enumerator = messages.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            return this;
+        }
+
+        utcNow = utcNow.ToUniversalTime();
+        var batchEpoch = epoch ?? utcNow;
+        var sequenceNumber = latestSequenceNumber;
+        var count = messages is IReadOnlyCollection<T> collection
+            ? collection.Count
+            : messages.TryGetNonEnumeratedCount(out var knownCount) ? knownCount : 0;
+        var capacity = checked(items.Length + count);
+        var builder = ImmutableArray.CreateBuilder<OutboxMessageEnvelope<T>>(capacity);
+        builder.AddRange(items);
+        do
+        {
+            var id = new OutboxMessageId(++sequenceNumber, utcNow, batchEpoch);
+            builder.Add(new(id, enumerator.Current));
+        }
+        while (enumerator.MoveNext());
+
+        return new(sequenceNumber, builder.DrainToImmutable(), batchEpoch, Guid.CreateVersion7());
+    }
+
+    /// <summary>Removes the supplied queued occurrence if it is the FIFO head.</summary>
+    /// <remarks>Matches the message ID, not payload equality; a non-head item leaves the snapshot unchanged.</remarks>
+    public Outbox<T> Remove(OutboxMessageEnvelope<T> item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return Remove(item.Id);
+    }
+
+    /// <summary>Removes the supplied queued occurrences by ID, preserving the order of remaining items.</summary>
+    /// <remarks>Supports noncontiguous acknowledgement batches. Missing IDs are ignored.</remarks>
+    public Outbox<T> RemoveRange(IEnumerable<OutboxMessageEnvelope<T>> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return RemoveRange(items.Select(item => item.Id));
     }
 
     /// <summary>

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxJsonConverterFactory.cs
@@ -144,7 +144,7 @@ internal sealed class OutboxJsonConverterFactory : JsonConverterFactory
 
             writer.WritePropertyName("Items");
             writer.WriteStartArray();
-            foreach (var item in value)
+            foreach (var item in value.Envelopes)
             {
                 envelopeConverter.Write(writer, item, options);
             }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.Postmen.cs
@@ -89,6 +89,20 @@ public sealed partial class OutboxProcessor<TOutbox>
         return new(this, streamProviderName);
     }
 
+    /// <summary>Configures stream postmen for a provider and returns this processor for further registrations.</summary>
+    /// <remarks>
+    /// Configuration runs synchronously. Registrations take effect immediately in callback order;
+    /// if configuration throws, registrations already made remain on this processor.
+    /// </remarks>
+    public OutboxProcessor<TOutbox> ForStreamProvider(
+        string streamProviderName, Action<OutboxStreamProviderBuilder<TOutbox>> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
+        ArgumentNullException.ThrowIfNull(configure);
+        configure(ForStreamProvider(streamProviderName));
+        return this;
+    }
+
     /// <summary>
     /// Registers a keyed <see cref="IPostman{TMessage}"/> service that handles
     /// items of type <typeparamref name="TSub"/>.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
@@ -14,7 +14,7 @@ namespace Egil.Orleans.Messaging.Outboxes;
 /// <remarks>
 /// Matching remains first-match-wins across registered postmen. During a post
 /// run, each postman receives its matching items sequentially in the order
-/// returned by <see cref="OutboxProcessorOptions{TOutbox}.PendingItems"/>. A
+/// returned by <see cref="OutboxProcessorOptions{TOutbox}.OutboxAccessor"/>. A
 /// failure stops that postman's sequence so later matching items remain
 /// pending until the owning grain removes or reconciles the failed item.
 /// Different postmen are dispatched concurrently.
@@ -330,7 +330,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     }
 
     private ImmutableArray<OutboxMessageEnvelope<TOutbox>> GetPendingItems() =>
-        (options.PendingItems() ?? throw new InvalidOperationException("PendingItems must return a non-null outbox snapshot.")).Envelopes;
+        (options.OutboxAccessor() ?? throw new InvalidOperationException("OutboxAccessor must return a non-null outbox snapshot.")).Envelopes;
 
     private async Task<OutboxReconciliationBatch<OutboxMessageEnvelope<TOutbox>>> ProcessPendingItemsAsync(
         CancellationToken cancellationToken)

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 
 namespace Egil.Orleans.Messaging.Outboxes;
@@ -134,7 +135,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     public async ValueTask PostInBackgroundAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (options.PendingItems().IsDefaultOrEmpty)
+        if (GetPendingItems().IsDefaultOrEmpty)
         {
             await DisableRetryAsync();
             return;
@@ -328,11 +329,14 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         }
     }
 
+    private ImmutableArray<OutboxMessageEnvelope<TOutbox>> GetPendingItems() =>
+        (options.PendingItems() ?? throw new InvalidOperationException("PendingItems must return a non-null outbox snapshot.")).Envelopes;
+
     private async Task<OutboxReconciliationBatch<OutboxMessageEnvelope<TOutbox>>> ProcessPendingItemsAsync(
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var pending = options.PendingItems();
+        var pending = GetPendingItems();
         MessagingTelemetry.RecordOutboxDepth(grainType, pending.IsDefault ? 0 : pending.Length);
 
         if (pending.IsDefaultOrEmpty)
@@ -359,7 +363,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
 
     private async Task ReconcileRetryStateAsync()
     {
-        var pending = options.PendingItems();
+        var pending = GetPendingItems();
         MessagingTelemetry.RecordOutboxDepth(grainType, pending.IsDefault ? 0 : pending.Length);
 
         // Items the grain removed without a successful post (dead-lettered or
@@ -385,7 +389,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
         }
 
         drainRequested = false;
-        if (options.PendingItems().IsDefaultOrEmpty)
+        if (GetPendingItems().IsDefaultOrEmpty)
         {
             await DisableRetryAsync();
             return;
@@ -398,7 +402,7 @@ public sealed partial class OutboxProcessor<TOutbox> : IOutboxComponent
     {
         try
         {
-            if (options.PendingItems().IsDefaultOrEmpty)
+            if (GetPendingItems().IsDefaultOrEmpty)
             {
                 return;
             }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
@@ -38,7 +38,7 @@ public static class OutboxProcessorExtensions
         /// {
         ///     outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions&lt;IMyEvent&gt;
         ///     {
-        ///         PendingItems = () => stateManager.State.Outbox.ToImmutableArray(),
+        ///         PendingItems = () => stateManager.State.Outbox,
         ///         AcknowledgePostedAsync = async (items, ct) =>
         ///         {
         ///             // remove exactly the delivered items (match items or their

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorExtensions.cs
@@ -38,7 +38,7 @@ public static class OutboxProcessorExtensions
         /// {
         ///     outboxProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions&lt;IMyEvent&gt;
         ///     {
-        ///         PendingItems = () => stateManager.State.Outbox,
+        ///         OutboxAccessor = () => stateManager.State.Outbox,
         ///         AcknowledgePostedAsync = async (items, ct) =>
         ///         {
         ///             // remove exactly the delivered items (match items or their

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
@@ -15,10 +15,10 @@ public sealed class OutboxProcessorOptions<TOutbox>
     where TOutbox : notnull
 {
     /// <summary>
-    /// Non-null immutable outbox snapshot. Called once before each post run and again
-    /// after reconciliation to decide whether retry work remains.
+    /// Returns the current non-null immutable outbox snapshot. Evaluated before dispatch
+    /// and again during reconciliation and retry scheduling.
     /// </summary>
-    public required Func<Outbox<TOutbox>> PendingItems { get; init; }
+    public required Func<Outbox<TOutbox>> OutboxAccessor { get; init; }
 
     /// <summary>
     /// Called with items that were successfully dispatched by their postmen.
@@ -28,7 +28,7 @@ public sealed class OutboxProcessorOptions<TOutbox>
     /// <remarks>
     /// The batch contains exactly the items that posted successfully and is
     /// <em>not necessarily a contiguous prefix</em> of the
-    /// <see cref="PendingItems"/> snapshot: different postmen dispatch their
+    /// <see cref="OutboxAccessor"/> snapshot: different postmen dispatch their
     /// groups concurrently, and an item without a matching postman fails in
     /// place while later items can still succeed. Remove the received items
     /// by their <see cref="OutboxMessageEnvelope{T}.Id"/>,
@@ -85,7 +85,7 @@ public sealed class OutboxProcessorOptions<TOutbox>
     /// <see cref="AcknowledgePostedAsync"/> and
     /// <see cref="ReconcileFailedAsync"/> use
     /// <see cref="InterleaveReconciliationCallbacks"/>. Snapshot reads from
-    /// <see cref="PendingItems"/> can also happen after a background delivery
+    /// <see cref="OutboxAccessor"/> can also happen after a background delivery
     /// pass to decide whether retry work remains.
     /// </remarks>
     public bool Interleave { get; init; } = true;

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Outboxes/OutboxProcessorOptions.cs
@@ -15,10 +15,10 @@ public sealed class OutboxProcessorOptions<TOutbox>
     where TOutbox : notnull
 {
     /// <summary>
-    /// Snapshot of pending items. Called once before each post run and again
+    /// Non-null immutable outbox snapshot. Called once before each post run and again
     /// after reconciliation to decide whether retry work remains.
     /// </summary>
-    public required Func<ImmutableArray<OutboxMessageEnvelope<TOutbox>>> PendingItems { get; init; }
+    public required Func<Outbox<TOutbox>> PendingItems { get; init; }
 
     /// <summary>
     /// Called with items that were successfully dispatched by their postmen.

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/ActivationStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/ActivationStateManager.cs
@@ -25,9 +25,9 @@ internal sealed class ActivationStateManager<T> : IStateManager<T>
 
     public T State => Manager.State;
 
-    public Task ReadAsync() => Manager.ReadAsync();
+    public Task ReadAsync(CancellationToken cancellationToken = default) => Manager.ReadAsync(cancellationToken);
 
-    public Task WriteAsync(T newState) => Manager.WriteAsync(newState);
+    public Task WriteAsync(T newState, CancellationToken cancellationToken = default) => Manager.WriteAsync(newState, cancellationToken);
 
-    public Task ClearAsync() => Manager.ClearAsync();
+    public Task ClearAsync(CancellationToken cancellationToken = default) => Manager.ClearAsync(cancellationToken);
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/IStateManager.cs
@@ -17,6 +17,16 @@ namespace Egil.Orleans.Messaging.State;
 /// rather than extension methods on <see cref="IPersistentState{TState}"/>.
 /// </para>
 /// <para>
+/// <b>Cancellation:</b> Operations forward the token to storage, including recovery
+/// reads. Cancellation is cooperative and depends on provider support. An already
+/// canceled token prevents storage access and write-version stamping. Once a write
+/// or clear starts, cancellation does not prove that it failed to persist. If recovery
+/// is canceled, the previous visible snapshot is retained and the original operation
+/// exception is rethrown. Call <see cref="ReadAsync"/> with a fresh token before the
+/// next mutation to refresh state and ETag. A provider-confirmed success is adopted
+/// even if cancellation was requested concurrently.
+/// </para>
+/// <para>
 /// <b>Usage:</b> Inject <see cref="IPersistentState{TState}"/> as normal via
 /// <c>[PersistentState]</c>, then register the manager in the grain constructor:
 /// <code>
@@ -99,7 +109,8 @@ public interface IStateManager<T>
     /// needs to force a re-read mid-activation (e.g., after a known external
     /// mutation or to recover from a double-failure scenario).
     /// </remarks>
-    Task ReadAsync();
+    /// <param name="cancellationToken">The cancellation token for the storage operation.</param>
+    Task ReadAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Atomically writes <paramref name="newState"/> to durable storage.
@@ -129,7 +140,8 @@ public interface IStateManager<T>
     /// </para>
     /// </remarks>
     /// <param name="newState">The new state value to persist.</param>
-    Task WriteAsync(T newState);
+    /// <param name="cancellationToken">The cancellation token for the storage operation and recovery read.</param>
+    Task WriteAsync(T newState, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Clears the persisted state. On success, <see cref="State"/> reflects
@@ -158,5 +170,6 @@ public interface IStateManager<T>
     /// A null result is rejected with an InvalidOperationException for diagnosis.
     /// </para>
     /// </remarks>
-    Task ClearAsync();
+    /// <param name="cancellationToken">The cancellation token for the storage operation and recovery read.</param>
+    Task ClearAsync(CancellationToken cancellationToken = default);
 }

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/State/StateManager.cs
@@ -104,16 +104,18 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     }
 
     /// <inheritdoc/>
-    public async Task ReadAsync()
+    public async Task ReadAsync(CancellationToken cancellationToken = default)
     {
-        await storage.ReadStateAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        await storage.ReadStateAsync(cancellationToken);
         Adopt(ResolveLoadedState());
     }
 
     /// <inheritdoc/>
-    public async Task WriteAsync(T newState)
+    public async Task WriteAsync(T newState, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(newState);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var previousState = state;
 
@@ -126,7 +128,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
 
         try
         {
-            await storage.WriteStateAsync();
+            await storage.WriteStateAsync(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -139,7 +141,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
                 throw;
             }
 
-            if (!await TryReadForRecoveryAsync(previousState))
+            if (!await TryReadForRecoveryAsync(previousState, cancellationToken))
             {
                 throw;
             }
@@ -165,12 +167,13 @@ public abstract class StateManagerBase<T> : IStateManager<T>
     }
 
     /// <inheritdoc/>
-    public async Task ClearAsync()
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var previousState = state;
         try
         {
-            await storage.ClearStateAsync();
+            await storage.ClearStateAsync(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -180,7 +183,7 @@ public abstract class StateManagerBase<T> : IStateManager<T>
                 throw;
             }
 
-            if (!await TryReadForRecoveryAsync(previousState))
+            if (!await TryReadForRecoveryAsync(previousState, cancellationToken))
             {
                 throw;
             }
@@ -206,11 +209,14 @@ public abstract class StateManagerBase<T> : IStateManager<T>
         Adopt(CreateInitialState());
     }
 
-    private async Task<bool> TryReadForRecoveryAsync(T previousState)
+    private async Task<bool> TryReadForRecoveryAsync(T previousState, CancellationToken cancellationToken)
     {
         try
         {
-            await storage.ReadStateAsync();
+            // Cancellation cannot prove whether the mutation landed. If recovery
+            // is canceled too, retain the previous fence and the original failure.
+            cancellationToken.ThrowIfCancellationRequested();
+            await storage.ReadStateAsync(cancellationToken);
             return true;
         }
         catch

--- a/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Tracking/MessageTracker.cs
+++ b/Egil.Orleans.Messaging/src/Egil.Orleans.Messaging/Tracking/MessageTracker.cs
@@ -27,7 +27,7 @@ namespace Egil.Orleans.Messaging.Tracking;
 /// prevents <c>with { ... }</c> expressions that could bypass invariants.
 /// </para>
 /// <para>
-/// <b>ProcessMessage semantics (streams):</b>
+/// <b>TryAcceptMessage semantics (streams):</b>
 /// <list type="bullet">
 /// <item><c>cursor.Token is null</c> → Accept, no tracking update.</item>
 /// <item>No prior entry → Accept, insert <c>(LastPosition = cursor, Received = now)</c>.</item>
@@ -36,7 +36,7 @@ namespace Egil.Orleans.Messaging.Tracking;
 /// </list>
 /// </para>
 /// <para>
-/// <b>ProcessMessage semantics (outbox):</b>
+/// <b>TryAcceptMessage semantics (outbox):</b>
 /// <list type="bullet">
 /// <item>No prior entry → Accept, insert.</item>
 /// <item><c>token.Epoch &gt; stored.Epoch</c> → Accept (sender reset), replace entry.</item>
@@ -109,10 +109,11 @@ public sealed class MessageTracker : IEquatable<MessageTracker>
     /// <param name="cursor">The stream cursor to evaluate.</param>
     /// <param name="next">
     /// When accepted, a new <see cref="MessageTracker"/> with the updated
-    /// position. When rejected, equals <c>this</c>.
+    /// position. Tokenless messages are accepted without advancing the position
+    /// and return <c>this</c>. Rejected messages also return <c>this</c>.
     /// </param>
-    /// <returns><c>true</c> if accepted (new message); <c>false</c> if duplicate.</returns>
-    public bool ProcessMessage(StreamCursor cursor, out MessageTracker next)
+    /// <returns><c>true</c> if accepted, including tokenless messages; <c>false</c> if duplicate or stale.</returns>
+    public bool TryAcceptMessage(StreamCursor cursor, out MessageTracker next)
     {
         var now = time.GetUtcNow();
         if (cursor.Token is null)
@@ -150,17 +151,18 @@ public sealed class MessageTracker : IEquatable<MessageTracker>
     /// <param name="token">The stream sequence token to evaluate.</param>
     /// <param name="next">
     /// When accepted, a new <see cref="MessageTracker"/> with the updated
-    /// position. When rejected, equals <c>this</c>.
+    /// position. Tokenless messages are accepted without advancing the position
+    /// and return <c>this</c>. Rejected messages also return <c>this</c>.
     /// </param>
-    /// <returns><c>true</c> if accepted (new message); <c>false</c> if duplicate.</returns>
-    public bool ProcessMessage(
+    /// <returns><c>true</c> if accepted, including tokenless messages; <c>false</c> if duplicate or stale.</returns>
+    public bool TryAcceptMessage(
         string streamNamespace,
         StreamSequenceToken? token,
         out MessageTracker next)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(streamNamespace);
 
-        return ProcessMessage(new StreamCursor(streamNamespace, token), out next);
+        return TryAcceptMessage(new StreamCursor(streamNamespace, token), out next);
     }
 
     /// <summary>
@@ -173,10 +175,11 @@ public sealed class MessageTracker : IEquatable<MessageTracker>
     /// <param name="token">The stream sequence token to evaluate.</param>
     /// <param name="next">
     /// When accepted, a new <see cref="MessageTracker"/> with the updated
-    /// position. When rejected, equals <c>this</c>.
+    /// position. Tokenless messages are accepted without advancing the position
+    /// and return <c>this</c>. Rejected messages also return <c>this</c>.
     /// </param>
-    /// <returns><c>true</c> if accepted (new message); <c>false</c> if duplicate.</returns>
-    public bool ProcessMessage(
+    /// <returns><c>true</c> if accepted, including tokenless messages; <c>false</c> if duplicate or stale.</returns>
+    public bool TryAcceptMessage(
         string streamProviderName,
         string streamNamespace,
         StreamSequenceToken? token,
@@ -185,7 +188,7 @@ public sealed class MessageTracker : IEquatable<MessageTracker>
         ArgumentException.ThrowIfNullOrWhiteSpace(streamProviderName);
         ArgumentException.ThrowIfNullOrWhiteSpace(streamNamespace);
 
-        return ProcessMessage(new StreamCursor(streamNamespace, token, streamProviderName), out next);
+        return TryAcceptMessage(new StreamCursor(streamNamespace, token, streamProviderName), out next);
     }
 
     /// <summary>
@@ -199,7 +202,7 @@ public sealed class MessageTracker : IEquatable<MessageTracker>
     /// position. When rejected, equals <c>this</c>.
     /// </param>
     /// <returns><c>true</c> if accepted; <c>false</c> if duplicate or stale.</returns>
-    public bool ProcessMessage(OutboxSequenceToken token, out MessageTracker next)
+    public bool TryAcceptMessage(OutboxSequenceToken token, out MessageTracker next)
     {
         var now = time.GetUtcNow();
 

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
@@ -250,6 +250,61 @@ public sealed class AzureStorageStateManagerTests
         Assert.Equal(new TestState("default"), manager.State);
     }
 
+    [Theory]
+    [InlineData(408)]
+    [InlineData(429)]
+    public async Task Timeout_and_throttling_responses_require_proof_of_the_write_outcome(int status)
+    {
+        var attempted = new TestState("next");
+        var storage = new FakePersistentState(new TestState("initial"))
+        {
+            WriteException = new RequestFailedException(status, "The write outcome is not established."),
+            OnRead = state => state.State = attempted
+        };
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
+
+        await manager.WriteAsync(attempted);
+
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Same(attempted, manager.State);
+    }
+
+    [Fact]
+    public async Task Unclassified_aggregate_failure_requires_read_back_instead_of_assuming_rejection()
+    {
+        var attempted = new TestState("next");
+        var storage = new FakePersistentState(new TestState("initial"))
+        {
+            WriteException = new AggregateException(new InvalidOperationException("provider failure"), new TimeoutException()),
+            OnRead = state => state.State = attempted
+        };
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
+
+        await manager.WriteAsync(attempted);
+
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Same(attempted, manager.State);
+    }
+
+    [Fact]
+    public async Task Aggregate_timeout_cannot_be_masked_by_a_rejected_attempt()
+    {
+        var attempted = new TestState("next");
+        var storage = new FakePersistentState(new TestState("initial"))
+        {
+            WriteException = new AggregateException(
+                new RequestFailedException(412, "A retry was rejected."),
+                new TimeoutException("An earlier attempt may have persisted.")),
+            OnRead = state => state.State = attempted
+        };
+        var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
+
+        await manager.WriteAsync(attempted);
+
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Same(attempted, manager.State);
+    }
+
     private sealed record TestState(string Value);
 
     private sealed class FakePersistentState(TestState state) : IPersistentState<TestState>

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.State.AzureStorage.Tests/AzureStorage/AzureStorageStateManagerTests.cs
@@ -17,7 +17,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -38,7 +38,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -60,7 +60,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -82,7 +82,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -99,7 +99,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(new TestState("next"));
+        await manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Equal(new TestState("next"), manager.State);
@@ -119,7 +119,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(new TestState("next"));
+        await manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Equal(new TestState("next"), manager.State);
@@ -139,7 +139,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(new TestState("next"));
+        await manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Equal(new TestState("next"), manager.State);
@@ -155,7 +155,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(new TestState("next"));
+        await manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Equal(new TestState("next"), manager.State);
@@ -177,7 +177,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<AggregateException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -204,7 +204,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(new TestState("next"));
+        await manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Equal(new TestState("next"), manager.State);
@@ -221,7 +221,7 @@ public sealed class AzureStorageStateManagerTests
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
         var actual = await Assert.ThrowsAsync<RequestFailedException>(
-            () => manager.ClearAsync());
+            () => manager.ClearAsync(TestContext.Current.CancellationToken));
 
         Assert.Same(exception, actual);
         Assert.Equal(0, storage.ReadCount);
@@ -243,7 +243,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.ClearAsync();
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.False(storage.RecordExists);
@@ -263,7 +263,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(attempted);
+        await manager.WriteAsync(attempted, TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Same(attempted, manager.State);
@@ -280,7 +280,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(attempted);
+        await manager.WriteAsync(attempted, TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Same(attempted, manager.State);
@@ -299,7 +299,7 @@ public sealed class AzureStorageStateManagerTests
         };
         var manager = new AzureStorageStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.WriteAsync(attempted);
+        await manager.WriteAsync(attempted, TestContext.Current.CancellationToken);
 
         Assert.Equal(1, storage.ReadCount);
         Assert.Same(attempted, manager.State);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Streams.EventHubs.Tests/EventHubs/EnrichedEventHubSequenceTokenJsonConverterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Streams.EventHubs.Tests/EventHubs/EnrichedEventHubSequenceTokenJsonConverterTests.cs
@@ -76,7 +76,7 @@ public sealed class EnrichedEventHubSequenceTokenJsonConverterTests
             new EnrichedEventHubSequenceTokenJsonConverter());
         var token = CreateToken();
         var tracker = new MessageTracker();
-        tracker.ProcessMessage(new StreamCursor("orders", token), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", token), out tracker);
 
         var json = JsonSerializer.Serialize(tracker);
         var roundTripped = JsonSerializer.Deserialize<MessageTracker>(json);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxCollectionTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxCollectionTests.cs
@@ -6,6 +6,41 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 public sealed class OutboxCollectionTests
 {
     [Fact]
+    public void Appending_an_outbox_to_itself_reenqueues_payloads_without_changing_original_ids()
+    {
+        Outbox<string> original = ["same", "other"];
+        var originalEnvelopes = original.Envelopes;
+
+        var appended = original.AddRange(original, DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(["same", "other", "same", "other"], appended.ToArray());
+        Assert.Equal(originalEnvelopes, appended.Envelopes.Take(2));
+        Assert.Equal([1L, 2L, 3L, 4L], appended.Envelopes.Select(item => item.Id.SequenceNumber));
+        Assert.Equal(2, original.Count);
+    }
+
+    [Fact]
+    public void Batch_input_failure_leaves_the_original_snapshot_and_history_usable()
+    {
+        Outbox<string> original = ["original"];
+        var revision = original.Revision;
+
+        Assert.Throws<InvalidOperationException>(() => original.AddRange(FailingBatch()));
+        var next = original.Add("next");
+
+        Assert.Equal(revision, original.Revision);
+        Assert.Equal(["original"], original.ToArray());
+        Assert.Equal(["original", "next"], next.ToArray());
+        Assert.Equal(2, next.LatestSequenceNumber);
+    }
+
+    private static IEnumerable<string> FailingBatch()
+    {
+        yield return "partial";
+        throw new InvalidOperationException("Input could not be fully read.");
+    }
+
+    [Fact]
     public void Collection_expressions_enqueue_payloads_with_fresh_history()
     {
         Outbox<string> empty = [];

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxCollectionTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxCollectionTests.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace Egil.Orleans.Messaging.Tests.Outboxes;
+
+public sealed class OutboxCollectionTests
+{
+    [Fact]
+    public void Collection_expressions_enqueue_payloads_with_fresh_history()
+    {
+        Outbox<string> empty = [];
+        Outbox<string> single = ["first"];
+        Outbox<string> source = ["first", "second"];
+        var drained = source.Clear();
+
+        Outbox<string> copied = [.. source, "third"];
+        Outbox<string> restarted = [.. drained, "new"];
+
+        Assert.Empty(empty);
+        Assert.Null(empty.Epoch);
+        Assert.Equal(0, empty.LatestSequenceNumber);
+        Assert.Equal(7, empty.Revision.Version);
+        Assert.Equal("first", Assert.Single(single));
+        Assert.Equal(["first", "second", "third"], copied.ToArray());
+        Assert.Equal([1L, 2L, 3L], copied.Envelopes.Select(item => item.Id.SequenceNumber));
+        Assert.NotEqual(source.Revision, copied.Revision);
+        Assert.Equal(1, restarted.LatestSequenceNumber);
+        Assert.Equal(2, drained.LatestSequenceNumber);
+    }
+
+    [Fact]
+    public void Payload_views_and_envelope_snapshot_stay_consistent_after_append()
+    {
+        Outbox<string> original = ["first", "second"];
+        var envelopes = original.Envelopes;
+        IReadOnlyList<string> list = original;
+        IEnumerable untyped = original;
+
+        var appended = original.AddRange(["third", "fourth"]);
+
+        Assert.Equal("second", list[1]);
+        Assert.Equal(["first", "second"], untyped.Cast<string>());
+        Assert.Equal(["first", "second"], original.Select(item => item));
+        Assert.Equal(["first", "second"], envelopes.Select(item => item.Message));
+        Assert.Equal(["first", "second", "third", "fourth"], appended.ToArray());
+        Assert.Equal(envelopes[0], appended.Envelopes[0]);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Batch_append_preserves_history_and_assigns_consecutive_ids(bool lazy)
+    {
+        var epoch = DateTimeOffset.UnixEpoch;
+        var later = epoch.AddHours(1).ToOffset(TimeSpan.FromHours(2));
+        var original = Outbox<string>.Create().Add("old", epoch).Clear();
+        IEnumerable<string> messages = lazy ? YieldMessages() : new[] { "first", "second" };
+
+        var appended = original.AddRange(messages, later);
+
+        Assert.Empty(original);
+        Assert.Equal(1, original.LatestSequenceNumber);
+        Assert.Equal(epoch, appended.Epoch);
+        Assert.Equal(3, appended.LatestSequenceNumber);
+        Assert.Equal(["first", "second"], appended.ToArray());
+        Assert.Equal(new OutboxMessageId(2, later.ToUniversalTime(), epoch), appended.Envelopes[0].Id);
+        Assert.Equal(new OutboxMessageId(3, later.ToUniversalTime(), epoch), appended.Envelopes[1].Id);
+        Assert.NotEqual(original.Revision, appended.Revision);
+        Assert.Equal(7, appended.Revision.Version);
+    }
+
+    [Fact]
+    public void Empty_batch_preserves_snapshot_and_first_batch_establishes_epoch()
+    {
+        Outbox<string> empty = [];
+        var now = DateTimeOffset.UnixEpoch;
+
+        var appended = empty.AddRange(["first", "second"], now);
+
+        Assert.Same(empty, empty.AddRange([]));
+        Assert.Same(appended, appended.AddRange(Enumerable.Empty<string>().Where(_ => true)));
+        Assert.Equal(now, appended.Epoch);
+        Assert.Equal(new OutboxMessageId(1, now, now), appended.Envelopes[0].Id);
+        Assert.Equal(new OutboxMessageId(2, now, now), appended.Envelopes[1].Id);
+    }
+
+    [Fact]
+    public void Envelope_acknowledgement_distinguishes_equal_payloads_and_preserves_gaps()
+    {
+        Outbox<string> original = ["same", "same", "third"];
+        var envelopes = original.Envelopes;
+
+        var headRemoved = original.Remove(envelopes[0]);
+        var batchRemoved = original.RemoveRange(new[] { envelopes[1], envelopes[2] });
+
+        Assert.Same(original, original.Remove(envelopes[1]));
+        Assert.Equal(envelopes[1], headRemoved.Envelopes[0]);
+        Assert.Equal(envelopes[0], Assert.Single(batchRemoved.Envelopes));
+        Assert.Equal(original.LatestSequenceNumber, batchRemoved.LatestSequenceNumber);
+        Assert.Equal(original.Epoch, batchRemoved.Epoch);
+        Assert.NotEqual(original.Revision, batchRemoved.Revision);
+        Assert.Same(original, original.RemoveRange(ImmutableArray<OutboxMessageEnvelope<string>>.Empty));
+        Assert.Same(batchRemoved, batchRemoved.RemoveRange(new[] { envelopes[1] }));
+    }
+
+    private static IEnumerable<string> YieldMessages()
+    {
+        yield return "first";
+        yield return "second";
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
@@ -5,6 +5,30 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 public sealed class OutboxJsonConverterFactoryTests
 {
     [Theory]
+    [InlineData("null")]
+    [InlineData("{}")]
+    public void Invalid_items_cannot_become_an_empty_outbox(string items)
+    {
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(Outbox<string>.Create()))!.AsObject();
+        json["Items"] = System.Text.Json.Nodes.JsonNode.Parse(items);
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json.ToJsonString()));
+
+        Assert.Contains("Items", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Missing_sequence_history_is_rejected()
+    {
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(Outbox<string>.Create()))!.AsObject();
+        json.Remove("LatestSequenceNumber");
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Outbox<string>>(json.ToJsonString()));
+
+        Assert.Contains("LatestSequenceNumber", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
     [InlineData("first", "second")]
     public void JsonSerializer_round_trips_outbox_with_string_messages(string first, string second)
     {

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxJsonConverterFactoryTests.cs
@@ -18,8 +18,8 @@ public sealed class OutboxJsonConverterFactoryTests
         Assert.NotNull(roundTripped);
         Assert.Equal(outbox, roundTripped);
         Assert.Equal(outbox.Revision, roundTripped.Revision);
-        Assert.Equal(first, roundTripped[0].Message);
-        Assert.Equal(second, roundTripped[1].Message);
+        Assert.Equal(first, roundTripped[0]);
+        Assert.Equal(second, roundTripped[1]);
     }
 
     [Fact]
@@ -51,10 +51,10 @@ public sealed class OutboxJsonConverterFactoryTests
         Assert.NotNull(roundTripped);
         Assert.Equal(outbox, roundTripped);
         Assert.Equal(outbox.Revision, roundTripped.Revision);
-        Assert.Equal("order-17", roundTripped[0].Message.OrderId);
-        Assert.Equal(42, roundTripped[0].Message.Quantity);
-        Assert.Equal("north", roundTripped[0].Message.Route.Name);
-        Assert.True(roundTripped[0].Message.Route.IsExpress);
+        Assert.Equal("order-17", roundTripped[0].OrderId);
+        Assert.Equal(42, roundTripped[0].Quantity);
+        Assert.Equal("north", roundTripped[0].Route.Name);
+        Assert.True(roundTripped[0].Route.IsExpress);
     }
 
     [Fact]

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxMessageEnvelopeJsonConverterFactoryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxMessageEnvelopeJsonConverterFactoryTests.cs
@@ -6,6 +6,32 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 public sealed class OutboxMessageEnvelopeJsonConverterFactoryTests
 {
     [Fact]
+    public void Persisted_envelope_must_distinguish_missing_payload_from_explicit_null()
+    {
+        const string missingProperty = "Message";
+        var envelope = new OutboxMessageEnvelope<string>(new(1, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch), "payload");
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(envelope))!.AsObject();
+        json.Remove(missingProperty);
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OutboxMessageEnvelope<string>>(json.ToJsonString()));
+
+        Assert.Contains(missingProperty, error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Explicit_null_payload_round_trips_and_unknown_nested_metadata_is_ignored()
+    {
+        var id = new OutboxMessageId(1, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+        var envelope = new OutboxMessageEnvelope<string?>(id, null);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(envelope))!.AsObject();
+        json["FutureMetadata"] = System.Text.Json.Nodes.JsonNode.Parse("""{"nested":[1,{"Id":"unrelated"}]}""");
+
+        var loaded = JsonSerializer.Deserialize<OutboxMessageEnvelope<string?>>(json.ToJsonString());
+
+        Assert.Equal(envelope, loaded);
+    }
+
+    [Fact]
     public void OutboxMessageEnvelope_is_decorated_with_converter_factory()
     {
         var attribute = typeof(OutboxMessageEnvelope<string>)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -169,7 +169,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+        PendingItems = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -263,7 +263,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+        PendingItems = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -371,7 +371,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+        PendingItems = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -169,7 +169,7 @@ public sealed class OutboxProcessorStreamPostmanGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox ?? [],
+        OutboxAccessor = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -263,7 +263,7 @@ public sealed class OutboxProcessorProjectedStreamPostmanGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox ?? [],
+        OutboxAccessor = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -371,7 +371,7 @@ public sealed class OutboxProcessorGrainPostmanSourceGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox ?? [],
+        OutboxAccessor = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxPostmanHelperTests.cs
@@ -330,7 +330,7 @@ public sealed class OutboxProcessorProjectedSinkGrain(
         OutboxProcessorTestEvent message,
         StreamCursor cursor)
     {
-        if (!state.State.Tracker.ProcessMessage(cursor.StreamNamespace, cursor.Token, out var next))
+        if (!state.State.Tracker.TryAcceptMessage(cursor.StreamNamespace, cursor.Token, out var next))
         {
             return;
         }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
@@ -139,7 +139,7 @@ public sealed class OutboxProcessorCoverageTests(MessagingTestClusterFixture fix
 
         var error = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.PostNullOutboxAsync());
 
-        Assert.Contains("PendingItems must return a non-null outbox snapshot", error.Message, StringComparison.Ordinal);
+        Assert.Contains("OutboxAccessor must return a non-null outbox snapshot", error.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -543,7 +543,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox ?? [],
+        OutboxAccessor = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -584,7 +584,7 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -661,7 +661,7 @@ public sealed class OutboxProcessorRetryPendingGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
@@ -741,7 +741,7 @@ public sealed class OutboxProcessorReminderCoverageGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
@@ -825,7 +825,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
 
         var processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => returnEmpty ? [] : pending,
+            OutboxAccessor = () => returnEmpty ? [] : pending,
             AcknowledgePostedAsync = (items, _) =>
             {
                 state.State.AcknowledgedCount += items.Length;
@@ -909,7 +909,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
     {
         var firstProcessor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () =>
+            OutboxAccessor = () =>
             {
                 state.State.FirstProcessorReminderCount++;
                 return [];
@@ -923,7 +923,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
         {
             _ = this.RegisterOutboxProcessor(new OutboxProcessorOptions<string>
             {
-                PendingItems = static () => [],
+                OutboxAccessor = static () => [],
                 AcknowledgePostedAsync = static (_, _) => ValueTask.CompletedTask
             });
         }
@@ -939,11 +939,11 @@ public sealed class OutboxProcessorValidationCoverageGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions(
-        Func<Outbox<OutboxProcessorTestEvent>> pendingItems,
+        Func<Outbox<OutboxProcessorTestEvent>> outboxAccessor,
         TimeSpan? processingTimeout = null,
         TimeSpan? retryDelay = null) => new()
         {
-            PendingItems = pendingItems,
+            OutboxAccessor = outboxAccessor,
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             ProcessingTimeout = processingTimeout ?? TimeSpan.FromSeconds(20),
@@ -978,7 +978,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
     {
         processor ??= this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100),

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorCoverageTests.cs
@@ -133,11 +133,21 @@ public sealed class OutboxProcessorCoverageTests(MessagingTestClusterFixture fix
     }
 
     [Fact]
-    public async Task PostAsync_with_default_pending_snapshot_disables_retry()
+    public async Task Null_outbox_snapshot_is_rejected_with_a_clear_error()
     {
         var grain = fixture.GrainFactory.GetGrain<IOutboxProcessorValidationCoverageGrain>(Guid.NewGuid());
 
-        var state = await grain.PostDefaultPendingAsync();
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.PostNullOutboxAsync());
+
+        Assert.Contains("PendingItems must return a non-null outbox snapshot", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PostAsync_with_empty_outbox_snapshot_disables_retry()
+    {
+        var grain = fixture.GrainFactory.GetGrain<IOutboxProcessorValidationCoverageGrain>(Guid.NewGuid());
+
+        var state = await grain.PostEmptyOutboxAsync();
 
         Assert.Equal(0, state.AcknowledgedCount);
         Assert.Equal(0, state.FailedCount);
@@ -145,11 +155,11 @@ public sealed class OutboxProcessorCoverageTests(MessagingTestClusterFixture fix
     }
 
     [Fact]
-    public async Task PostAsync_with_default_pending_snapshot_after_acknowledgement_disables_retry()
+    public async Task PostAsync_with_empty_outbox_snapshot_after_acknowledgement_disables_retry()
     {
         var grain = fixture.GrainFactory.GetGrain<IOutboxProcessorValidationCoverageGrain>(Guid.NewGuid());
 
-        var state = await grain.PostPendingThenDefaultAfterAcknowledgeAsync();
+        var state = await grain.PostPendingThenEmptyAfterAcknowledgeAsync();
 
         Assert.Equal(1, state.AcknowledgedCount);
         Assert.Null(state.Outbox);
@@ -414,9 +424,11 @@ public interface IOutboxProcessorValidationCoverageGrain : IGrainWithGuidKey
 {
     Task<OutboxProcessorSourceState> PostEmptyPendingInBackgroundAsync();
 
-    Task<OutboxProcessorSourceState> PostDefaultPendingAsync();
+    Task PostNullOutboxAsync();
 
-    Task<OutboxProcessorSourceState> PostPendingThenDefaultAfterAcknowledgeAsync();
+    Task<OutboxProcessorSourceState> PostEmptyOutboxAsync();
+
+    Task<OutboxProcessorSourceState> PostPendingThenEmptyAfterAcknowledgeAsync();
 
     Task<string?> PostInBackgroundWithCanceledTokenAsync();
 
@@ -531,7 +543,7 @@ public sealed class OutboxProcessorReentrantPostGrain(
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions() => new()
     {
-        PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+        PendingItems = () => state.State.Outbox ?? [],
         AcknowledgePostedAsync = AcknowledgePostedAsync,
         ReconcileFailedAsync = ReconcileFailedAsync,
         RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -572,7 +584,7 @@ public sealed class OutboxProcessorConcurrentManualPostGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -649,7 +661,7 @@ public sealed class OutboxProcessorRetryPendingGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
@@ -729,7 +741,7 @@ public sealed class OutboxProcessorReminderCoverageGrain(
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(2)
@@ -791,28 +803,33 @@ public sealed class OutboxProcessorValidationCoverageGrain(
         return state.State;
     }
 
-    public async Task<OutboxProcessorSourceState> PostDefaultPendingAsync()
+    public async Task PostNullOutboxAsync()
     {
-        var processor = this.RegisterOutboxProcessor(CreateOptions(static () => default));
+        var processor = this.RegisterOutboxProcessor(CreateOptions(static () => null!));
+        await processor.PostAsync();
+    }
+
+    public async Task<OutboxProcessorSourceState> PostEmptyOutboxAsync()
+    {
+        var processor = this.RegisterOutboxProcessor(CreateOptions(static () => []));
         await processor.PostAsync();
         return state.State;
     }
 
-    public async Task<OutboxProcessorSourceState> PostPendingThenDefaultAfterAcknowledgeAsync()
+    public async Task<OutboxProcessorSourceState> PostPendingThenEmptyAfterAcknowledgeAsync()
     {
         var pending = Outbox<OutboxProcessorTestEvent>
             .Create()
-            .Add(new OutboxProcessorTestEvent("default-after-ack"))
-            .ToImmutableArray();
-        var returnDefault = false;
+            .Add(new OutboxProcessorTestEvent("empty-after-ack"));
+        var returnEmpty = false;
 
         var processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => returnDefault ? default : pending,
+            PendingItems = () => returnEmpty ? [] : pending,
             AcknowledgePostedAsync = (items, _) =>
             {
                 state.State.AcknowledgedCount += items.Length;
-                returnDefault = true;
+                returnEmpty = true;
                 return ValueTask.CompletedTask;
             },
             ReconcileFailedAsync = ReconcileFailedAsync,
@@ -922,7 +939,7 @@ public sealed class OutboxProcessorValidationCoverageGrain(
     public Task<OutboxProcessorSourceState> GetStateAsync() => Task.FromResult(state.State);
 
     private OutboxProcessorOptions<OutboxProcessorTestEvent> CreateOptions(
-        Func<ImmutableArray<OutboxMessageEnvelope<OutboxProcessorTestEvent>>> pendingItems,
+        Func<Outbox<OutboxProcessorTestEvent>> pendingItems,
         TimeSpan? processingTimeout = null,
         TimeSpan? retryDelay = null) => new()
         {
@@ -961,7 +978,7 @@ public sealed class OutboxProcessorReconciliationSchedulingGrain(
     {
         processor ??= this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100),

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -1309,7 +1309,7 @@ public sealed class OutboxProcessorSinkGrain(
         DeliveredOutboxEvent envelope,
         StreamCursor cursor)
     {
-        if (!state.State.Tracker.ProcessMessage(envelope.Token, out var next))
+        if (!state.State.Tracker.TryAcceptMessage(envelope.Token, out var next))
         {
             return;
         }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -490,7 +490,7 @@ public sealed class OutboxProcessorSourceGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -576,7 +576,7 @@ public sealed class OutboxProcessorNoPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -634,7 +634,7 @@ public sealed class OutboxProcessorFailingPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -698,7 +698,7 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -767,7 +767,7 @@ public sealed class OutboxProcessorKeyedFailingPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -827,7 +827,7 @@ public sealed class OutboxProcessorKeyedCancellationPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             ProcessingTimeout = TimeSpan.FromHours(2),
@@ -895,7 +895,7 @@ public sealed class OutboxProcessorKeyedTimeoutPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             ProcessingTimeout = TimeSpan.FromHours(1),
@@ -963,7 +963,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = (_, _) => ValueTask.CompletedTask,
             ProcessingTimeout = TimeSpan.FromHours(1),
@@ -1040,7 +1040,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox?.ToImmutableArray() ?? [],
+            PendingItems = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -1131,7 +1131,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     : Grain, IOutboxProcessorOrderedPostmanGrain, IOutboxGrain
 {
     private OutboxProcessor<OutboxProcessorOrderedMessage>? processor;
-    private ImmutableArray<OutboxMessageEnvelope<OutboxProcessorOrderedMessage>> pending = [];
+    private Outbox<OutboxProcessorOrderedMessage> pending = [];
     private ImmutableArray<string> postedValues = [];
     private ImmutableArray<string> failedValues = [];
     private ImmutableArray<string> attemptedValues = [];
@@ -1159,8 +1159,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     {
         pending = Outbox<OutboxProcessorOrderedMessage>.Create()
             .Add(new OutboxProcessorPrimaryMessage(primary))
-            .Add(new OutboxProcessorSecondaryMessage(secondary))
-            .ToImmutableArray();
+            .Add(new OutboxProcessorSecondaryMessage(secondary));
 
         await processor!.PostAsync();
         return CreateState();
@@ -1174,8 +1173,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
         pending = Outbox<OutboxProcessorOrderedMessage>.Create()
             .Add(new OutboxProcessorPrimaryMessage(failingPrimary))
             .Add(new OutboxProcessorSecondaryMessage(secondary))
-            .Add(new OutboxProcessorPrimaryMessage(blockedPrimary))
-            .ToImmutableArray();
+            .Add(new OutboxProcessorPrimaryMessage(blockedPrimary));
 
         await processor!.PostAsync();
         return CreateState();
@@ -1224,7 +1222,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     {
         foreach (var item in items)
         {
-            pending = pending.Remove(item);
+            pending = pending.RemoveRange(new[] { item });
             postedValues = postedValues.Add(item.Message.Value);
         }
 
@@ -1247,7 +1245,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
         new(
             postedValues,
             failedValues,
-            pending.Select(static item => item.Message.Value).ToImmutableArray(),
+            pending.Select(static item => item.Value).ToImmutableArray(),
             attemptedValues,
             maxConcurrentPostmen);
 }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxProcessorTests.cs
@@ -490,7 +490,7 @@ public sealed class OutboxProcessorSourceGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -576,7 +576,7 @@ public sealed class OutboxProcessorNoPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -634,7 +634,7 @@ public sealed class OutboxProcessorFailingPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -698,7 +698,7 @@ public sealed class OutboxProcessorKeyedPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -767,7 +767,7 @@ public sealed class OutboxProcessorKeyedFailingPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -827,7 +827,7 @@ public sealed class OutboxProcessorKeyedCancellationPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             ProcessingTimeout = TimeSpan.FromHours(2),
@@ -895,7 +895,7 @@ public sealed class OutboxProcessorKeyedTimeoutPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             ProcessingTimeout = TimeSpan.FromHours(1),
@@ -963,7 +963,7 @@ public sealed class OutboxProcessorTimeoutRetryGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = (_, _) => ValueTask.CompletedTask,
             ProcessingTimeout = TimeSpan.FromHours(1),
@@ -1040,7 +1040,7 @@ public sealed class OutboxProcessorConcurrentPostmanGrain(
 
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorTestEvent>
         {
-            PendingItems = () => state.State.Outbox ?? [],
+            OutboxAccessor = () => state.State.Outbox ?? [],
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMilliseconds(100)
@@ -1142,7 +1142,7 @@ public sealed class OutboxProcessorOrderedPostmanGrain
     {
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<OutboxProcessorOrderedMessage>
         {
-            PendingItems = () => pending,
+            OutboxAccessor = () => pending,
             AcknowledgePostedAsync = AcknowledgePostedAsync,
             ReconcileFailedAsync = ReconcileFailedAsync,
             RetryDelay = TimeSpan.FromMinutes(10)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxSequenceTokenJsonConverterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxSequenceTokenJsonConverterTests.cs
@@ -5,6 +5,33 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 
 public sealed class OutboxSequenceTokenJsonConverterTests
 {
+    [Theory]
+    [InlineData("SequenceNumber")]
+    [InlineData("Timestamp")]
+    [InlineData("Epoch")]
+    public void Delivery_identity_cannot_be_reconstructed_with_missing_fields(string missingProperty)
+    {
+        var token = new OutboxSequenceToken(0, GrainId.Create("test/sender", "one"), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(token))!.AsObject();
+        json.Remove(missingProperty);
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OutboxSequenceToken>(json.ToJsonString()));
+
+        Assert.Contains(missingProperty, error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Null_sender_cannot_be_used_as_a_delivery_identity()
+    {
+        var token = new OutboxSequenceToken(1, GrainId.Create("test/sender", "one"), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(token))!.AsObject();
+        json["Sender"] = null;
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OutboxSequenceToken>(json.ToJsonString()));
+
+        Assert.Contains("Sender", error.Message, StringComparison.Ordinal);
+    }
+
     public static TheoryData<string> InvalidKnownPropertyJson => new()
     {
         { """{"SequenceNumber":"7"}""" },

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxSequenceTokenJsonConverterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxSequenceTokenJsonConverterTests.cs
@@ -5,6 +5,32 @@ namespace Egil.Orleans.Messaging.Tests.Outboxes;
 
 public sealed class OutboxSequenceTokenJsonConverterTests
 {
+    [Fact]
+    public void Additional_sender_metadata_preserves_delivery_identity()
+    {
+        var token = new OutboxSequenceToken(7, GrainId.Create("test/sender", "one"), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(token))!;
+        json["Sender"]!["FutureMetadata"] = System.Text.Json.Nodes.JsonNode.Parse("""{"nested":[1,2]}""");
+
+        var restored = JsonSerializer.Deserialize<OutboxSequenceToken>(json.ToJsonString());
+
+        Assert.Equal(token, restored);
+    }
+
+    [Theory]
+    [InlineData("Type")]
+    [InlineData("Key")]
+    public void Incomplete_sender_identity_is_rejected(string field)
+    {
+        var token = new OutboxSequenceToken(7, GrainId.Create("test/sender", "one"), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+        var json = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(token))!;
+        json["Sender"]!.AsObject().Remove(field);
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OutboxSequenceToken>(json.ToJsonString()));
+
+        Assert.Contains(field, error.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("SequenceNumber")]
     [InlineData("Timestamp")]

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/OutboxTests.cs
@@ -9,8 +9,8 @@ public sealed class OutboxTests
     {
         var initial = Outbox<string>.Create();
         var appended = initial.Add("first", DateTimeOffset.UnixEpoch);
-        var removed = appended.Remove(appended[0].Id);
-        var batchRemoved = appended.RemoveRange([appended[0].Id]);
+        var removed = appended.Remove(appended.Envelopes[0].Id);
+        var batchRemoved = appended.RemoveRange([appended.Envelopes[0].Id]);
         var cleared = appended.Clear();
 
         Guid[] revisions = [initial.Revision, appended.Revision, removed.Revision, batchRemoved.Revision, cleared.Revision];
@@ -28,7 +28,7 @@ public sealed class OutboxTests
         Assert.Equal(empty.Revision, empty.Clear().Revision);
         Assert.Equal(empty.Revision, empty.Remove(foreignId).Revision);
         Assert.Equal(pending.Revision, pending.Remove(foreignId).Revision);
-        Assert.Equal(pending.Revision, pending.RemoveRange([]).Revision);
+        Assert.Equal(pending.Revision, pending.RemoveRange(Array.Empty<OutboxMessageId>()).Revision);
         Assert.Equal(pending.Revision, pending.RemoveRange([foreignId]).Revision);
     }
 
@@ -47,8 +47,8 @@ public sealed class OutboxTests
         Assert.Equal(outbox.Revision, loaded.Revision);
         Assert.Equal(outbox, loaded);
         Assert.Equal(outbox.GetHashCode(), loaded.GetHashCode());
-        Assert.Equal(outbox[0].Id, loaded[0].Id);
-        Assert.Equal("first", loaded[0].Message);
+        Assert.Equal(outbox.Envelopes[0].Id, loaded.Envelopes[0].Id);
+        Assert.Equal("first", loaded[0]);
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public sealed class OutboxTests
 
         Assert.Equal(2, next.Count);
         Assert.Equal(2, next.LatestSequenceNumber);
-        Assert.Equal("second", next[1].Message);
-        Assert.Equal(new OutboxMessageId(2, later, epoch), next[1].Id);
+        Assert.Equal("second", next[1]);
+        Assert.Equal(new OutboxMessageId(2, later, epoch), next.Envelopes[1].Id);
     }
 
     [Fact]
@@ -84,8 +84,8 @@ public sealed class OutboxTests
         Assert.Single(next);
         Assert.Equal(1, next.LatestSequenceNumber);
         Assert.Equal(now, next.Epoch);
-        Assert.Equal("created", next[0].Message);
-        Assert.Equal(new OutboxMessageId(1, now, now), next[0].Id);
+        Assert.Equal("created", next[0]);
+        Assert.Equal(new OutboxMessageId(1, now, now), next.Envelopes[0].Id);
     }
 
     [Fact]
@@ -97,8 +97,8 @@ public sealed class OutboxTests
         var next = Outbox<string>.Create().Add("created", localNow);
 
         Assert.Equal(utcNow, next.Epoch);
-        Assert.Equal(utcNow, next[0].Id.Timestamp);
-        Assert.Equal(TimeSpan.Zero, next[0].Id.Timestamp.Offset);
+        Assert.Equal(utcNow, next.Envelopes[0].Id.Timestamp);
+        Assert.Equal(TimeSpan.Zero, next.Envelopes[0].Id.Timestamp.Offset);
     }
 
     [Fact]
@@ -114,8 +114,8 @@ public sealed class OutboxTests
         Assert.Equal(2, next.Count);
         Assert.Equal(2, next.LatestSequenceNumber);
         Assert.Equal(epoch, next.Epoch);
-        Assert.Equal(new OutboxMessageId(1, epoch, epoch), next[0].Id);
-        Assert.Equal(new OutboxMessageId(2, later, epoch), next[1].Id);
+        Assert.Equal(new OutboxMessageId(1, epoch, epoch), next.Envelopes[0].Id);
+        Assert.Equal(new OutboxMessageId(2, later, epoch), next.Envelopes[1].Id);
     }
 
     [Fact]
@@ -125,10 +125,10 @@ public sealed class OutboxTests
         var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now);
 
-        var next = outbox.Remove(outbox[0].Id);
+        var next = outbox.Remove(outbox.Envelopes[0].Id);
 
         Assert.Single(next);
-        Assert.Equal("second", next[0].Message);
+        Assert.Equal("second", next[0]);
         Assert.Equal(2, next.LatestSequenceNumber);
         Assert.Equal(now, next.Epoch);
     }
@@ -154,7 +154,7 @@ public sealed class OutboxTests
         var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now);
 
-        var next = outbox.Remove(outbox[1].Id);
+        var next = outbox.Remove(outbox.Envelopes[1].Id);
 
         Assert.Same(outbox, next);
         Assert.Equal(2, next.Count);
@@ -168,10 +168,10 @@ public sealed class OutboxTests
         outbox = outbox.Add("first", now).Add("second", now).Add("third", now);
         var missing = new OutboxMessageId(99, now, now);
 
-        var next = outbox.RemoveRange([outbox[0].Id, outbox[1].Id, missing]);
+        var next = outbox.RemoveRange([outbox.Envelopes[0].Id, outbox.Envelopes[1].Id, missing]);
 
         Assert.Single(next);
-        Assert.Equal("third", next[0].Message);
+        Assert.Equal("third", next[0]);
         Assert.Equal(3, next.LatestSequenceNumber);
         Assert.Equal(now, next.Epoch);
     }
@@ -183,10 +183,10 @@ public sealed class OutboxTests
         var outbox = Outbox<string>.Create();
         outbox = outbox.Add("first", now).Add("second", now).Add("third", now);
 
-        var next = outbox.RemoveRange([outbox[0].Id, outbox[2].Id]);
+        var next = outbox.RemoveRange([outbox.Envelopes[0].Id, outbox.Envelopes[2].Id]);
 
         Assert.Single(next);
-        Assert.Equal("second", next[0].Message);
+        Assert.Equal("second", next[0]);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public sealed class OutboxTests
         Assert.Empty(cleared);
         Assert.Equal(2, cleared.LatestSequenceNumber);
         Assert.Equal(epoch, cleared.Epoch);
-        Assert.Equal(new OutboxMessageId(3, later, epoch), next[0].Id);
+        Assert.Equal(new OutboxMessageId(3, later, epoch), next.Envelopes[0].Id);
     }
 
     [Fact]
@@ -229,11 +229,11 @@ public sealed class OutboxTests
             .Add("third", now)
             .Add("fourth", now);
 
-        var left = baseline.RemoveRange([baseline[2].Id]);
-        var right = baseline.RemoveRange([baseline[1].Id]);
+        var left = baseline.RemoveRange([baseline.Envelopes[2].Id]);
+        var right = baseline.RemoveRange([baseline.Envelopes[1].Id]);
 
-        Assert.Equal([1L, 2L, 4L], left.Select(item => item.Id.SequenceNumber).ToArray());
-        Assert.Equal([1L, 3L, 4L], right.Select(item => item.Id.SequenceNumber).ToArray());
+        Assert.Equal([1L, 2L, 4L], left.Envelopes.Select(item => item.Id.SequenceNumber).ToArray());
+        Assert.Equal([1L, 3L, 4L], right.Envelopes.Select(item => item.Id.SequenceNumber).ToArray());
         Assert.NotEqual(left, right);
     }
 

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -22,9 +22,9 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
         var loaded = JsonSerializer.Deserialize<Outbox<IPayloadEvent>>(json);
 
         Assert.NotNull(loaded);
-        Assert.Equal(outbox[0].Id, loaded[0].Id);
-        Assert.Equal(outbox[0].Message, Assert.IsType<LocalPayload>(loaded[0].Message));
-        Assert.Equal(outbox[1].Message, Assert.IsType<StreamPayload>(loaded[1].Message));
+        Assert.Equal(outbox.Envelopes[0].Id, loaded.Envelopes[0].Id);
+        Assert.Equal(outbox[0], Assert.IsType<LocalPayload>(loaded[0]));
+        Assert.Equal(outbox[1], Assert.IsType<StreamPayload>(loaded[1]));
         Assert.DoesNotContain("Sender", json, StringComparison.Ordinal);
     }
 
@@ -127,7 +127,7 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
         manager = this.RegisterStateManager("Payload", storage);
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IPayloadEvent>
         {
-            PendingItems = () => manager.State.Outbox.ToImmutableArray(),
+            PendingItems = () => manager.State.Outbox,
             AcknowledgePostedAsync = AcknowledgeAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })
@@ -136,15 +136,13 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
             static (message, grains) => grains.GetGrain<IPayloadSinkGrain>(message.Target),
             static (grain, message, token) => grain.ReceiveAsync(new(message.Value, token)));
 
-        processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events)
+        processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events, provider => provider
             .AddStreamPostman<StreamPayload, PayloadDelivery>(
                 message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
                 static (message, token) => new(message.Value, token))
             .AddStreamPostman<SecondStreamPayload, PayloadDelivery>(
                 (message, _) => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
-                static (message, token) => new(message.Value, token));
-
-        processor
+                static (message, token) => new(message.Value, token)))
         .AddPostman<IPayloadEvent>(static async message => await RejectUnexpectedPayloadAsync(message))
         .AddPostman<IPayloadEvent>(static async (message, _) => await RejectUnexpectedPayloadAsync(message))
         .AddPostman<IPayloadEvent>(static async (message, _, cancellationToken) =>
@@ -195,7 +193,7 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
             throw new InvalidOperationException("The delivery landed but acknowledgment could not persist.");
         }
 
-        await manager.WriteAsync(manager.State with { Outbox = manager.State.Outbox.RemoveRange(items.Select(item => item.Id)) });
+        await manager.WriteAsync(manager.State with { Outbox = manager.State.Outbox.RemoveRange(items) });
     }
 }
 

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -10,6 +10,26 @@ public sealed class PayloadPostmanTests(MessagingTestClusterFixture fixture)
     : IClassFixture<MessagingTestClusterFixture>
 {
     [Fact]
+    public async Task Provider_configuration_failure_keeps_earlier_registrations_ahead_of_later_handlers()
+    {
+        var key = Guid.NewGuid();
+        var source = fixture.GrainFactory.GetGrain<IPartialProviderConfigurationGrain>(key);
+        var sink = fixture.GrainFactory.GetGrain<IPayloadSinkGrain>(key);
+        await sink.EnsureActiveAsync();
+
+        var result = await source.PublishAsync(key);
+
+        Assert.Equal("configuration failed", result.Error);
+        Assert.Equal(0, result.Pending);
+        Assert.Equal(0, result.FallbackCalls);
+        await fixture.WaitForAssertionAsync(sink, async () =>
+        {
+            var deliveries = await sink.GetDeliveriesAsync();
+            Assert.Equal("registered-before-failure", Assert.Single(deliveries).Value);
+        }, ct: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public void Polymorphic_payloads_round_trip_with_stored_identity()
     {
         var target = Guid.NewGuid();
@@ -228,4 +248,50 @@ public sealed class PayloadSinkGrain : Grain, IPayloadSinkGrain
     }
 
     public Task<ImmutableArray<PayloadDelivery>> GetDeliveriesAsync() => Task.FromResult(deliveries);
+}
+
+public interface IPartialProviderConfigurationGrain : IGrainWithGuidKey
+{
+    Task<(string? Error, int Pending, int FallbackCalls)> PublishAsync(Guid target);
+}
+
+public sealed class PartialProviderConfigurationGrain : Grain, IPartialProviderConfigurationGrain, IOutboxGrain
+{
+    public async Task<(string? Error, int Pending, int FallbackCalls)> PublishAsync(Guid target)
+    {
+        Outbox<IPayloadEvent> outbox = [new StreamPayload(target, "registered-before-failure")];
+        var fallbackCalls = 0;
+        string? error = null;
+        var processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IPayloadEvent>
+        {
+            OutboxAccessor = () => outbox,
+            AcknowledgePostedAsync = (items, _) =>
+            {
+                outbox = outbox.RemoveRange(items);
+                return ValueTask.CompletedTask;
+            }
+        });
+        try
+        {
+            processor.ForStreamProvider(OutboxProcessorTestProviderNames.Events, provider =>
+            {
+                provider.AddStreamPostman<StreamPayload, PayloadDelivery>(
+                    message => StreamManager.CreateStreamId("payload-postmen", GrainFactory.GetGrain<IPayloadSinkGrain>(message.Target).GetGrainId()),
+                    static (message, token) => new(message.Value, token));
+                throw new InvalidOperationException("configuration failed");
+            });
+        }
+        catch (InvalidOperationException exception)
+        {
+            error = exception.Message;
+        }
+
+        processor.AddPostman<IPayloadEvent>(_ =>
+        {
+            fallbackCalls++;
+            return ValueTask.CompletedTask;
+        });
+        await processor.PostAsync();
+        return (error, outbox.Count, fallbackCalls);
+    }
 }

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Outboxes/PayloadPostmanTests.cs
@@ -127,7 +127,7 @@ public sealed class PayloadSourceGrain : Grain, IPayloadSourceGrain, IOutboxGrai
         manager = this.RegisterStateManager("Payload", storage);
         processor = this.RegisterOutboxProcessor(new OutboxProcessorOptions<IPayloadEvent>
         {
-            PendingItems = () => manager.State.Outbox,
+            OutboxAccessor = () => manager.State.Outbox,
             AcknowledgePostedAsync = AcknowledgeAsync,
             RetryDelay = TimeSpan.FromMinutes(10)
         })

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
@@ -14,7 +14,7 @@ public sealed class OutboxRecoveryProofTests
         var storage = new AmbiguousOutboxStorage(initial, competing);
         var manager = new DefaultStateManager<Outbox<string>>(storage, Outbox<string>.Create);
 
-        var error = await Record.ExceptionAsync(() => manager.WriteAsync(attempted));
+        var error = await Record.ExceptionAsync(() => manager.WriteAsync(attempted, TestContext.Current.CancellationToken));
 
         Assert.DoesNotContain(manager.State, item => item == "attempted message");
         Assert.IsType<TimeoutException>(error);
@@ -30,7 +30,7 @@ public sealed class OutboxRecoveryProofTests
         var storage = new AmbiguousOutboxStorage(initial, durable);
         var manager = new DefaultStateManager<Outbox<string>>(storage, Outbox<string>.Create);
 
-        await manager.WriteAsync(attempted);
+        await manager.WriteAsync(attempted, TestContext.Current.CancellationToken);
 
         Assert.Equal("saved message", Assert.Single(manager.State));
         Assert.Equal(attempted, manager.State);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/OutboxRecoveryProofTests.cs
@@ -16,7 +16,7 @@ public sealed class OutboxRecoveryProofTests
 
         var error = await Record.ExceptionAsync(() => manager.WriteAsync(attempted));
 
-        Assert.DoesNotContain(manager.State, item => item.Message == "attempted message");
+        Assert.DoesNotContain(manager.State, item => item == "attempted message");
         Assert.IsType<TimeoutException>(error);
     }
 
@@ -32,7 +32,7 @@ public sealed class OutboxRecoveryProofTests
 
         await manager.WriteAsync(attempted);
 
-        Assert.Equal("saved message", Assert.Single(manager.State).Message);
+        Assert.Equal("saved message", Assert.Single(manager.State));
         Assert.Equal(attempted, manager.State);
     }
 

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
@@ -128,7 +128,7 @@ public sealed class StateManagerActivationGrain : Grain, IStateManagerActivation
         await manager.ReadAsync();
         var now = time.GetUtcNow();
         var sender = GrainContext.GrainId;
-        manager.State.Tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out var tracked);
+        manager.State.Tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out var tracked);
         return tracked.Evict(sender, now.AddSeconds(1)).LatestOutbox(sender) is null;
     }
 

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerActivationTests.cs
@@ -5,6 +5,21 @@ namespace Egil.Orleans.Messaging.Tests.State;
 public sealed class StateManagerActivationTests(MessagingTestClusterFixture fixture)
     : IClassFixture<MessagingTestClusterFixture>
 {
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task Constructor_registered_manager_forwards_cancellation(int operation)
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStateManagerActivationGrain>(Guid.NewGuid());
+
+        Assert.True(await grain.CancelOperationAsync(operation));
+
+        var state = await grain.InspectAsync();
+        Assert.Equal("default", state.Value);
+        Assert.False(state.RecordExists);
+    }
+
     [Fact]
     public async Task Runtime_clock_configuration_reaches_the_tracker_replaced_by_a_read()
     {
@@ -47,6 +62,7 @@ public sealed class StateManagerActivationTests(MessagingTestClusterFixture fixt
 
 public interface IStateManagerActivationGrain : IGrainWithGuidKey
 {
+    Task<bool> CancelOperationAsync(int operation);
     Task<ActivationStateObservation> InspectAsync();
     Task SaveAndDeactivateAsync(string value);
     Task<bool> UsesConfiguredClockAfterReadAsync();
@@ -114,6 +130,27 @@ public sealed class StateManagerActivationGrain : Grain, IStateManagerActivation
         var sender = GrainContext.GrainId;
         manager.State.Tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out var tracked);
         return tracked.Evict(sender, now.AddSeconds(1)).LatestOutbox(sender) is null;
+    }
+
+    public async Task<bool> CancelOperationAsync(int operation)
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        try
+        {
+            await (operation switch
+            {
+                0 => manager.ReadAsync(cancellation.Token),
+                1 => manager.WriteAsync(manager.State with { Value = "canceled" }, cancellation.Token),
+                2 => manager.ClearAsync(cancellation.Token),
+                _ => throw new ArgumentOutOfRangeException(nameof(operation))
+            });
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
     }
 
     public async Task SaveAndDeactivateAsync(string value)

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerCancellationTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerCancellationTests.cs
@@ -1,0 +1,167 @@
+namespace Egil.Orleans.Messaging.Tests.State;
+
+public sealed class StateManagerCancellationTests
+{
+    [Theory]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task Confirmed_success_is_adopted_when_cancellation_arrives_after_persistence(StorageOperation operation)
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var storage = new CancellableStorage(operation) { CancelAfterPersisting = cancellation };
+        storage.Release.TrySetResult();
+        IStateManager<Snapshot> manager = new DefaultStateManager<Snapshot>(storage, static () => new("default"));
+
+        await Invoke(manager, operation, cancellation.Token);
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal(new Snapshot(operation == StorageOperation.Write ? "next" : "default"), manager.State);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task Cancellation_before_start_leaves_snapshot_and_storage_untouched(StorageOperation operation)
+    {
+        using var storage = new CancellableStorage(operation);
+        IStateManager<Snapshot> manager = new DefaultStateManager<Snapshot>(storage, static () => new("default"));
+        var previous = manager.State;
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        storage.Release.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Invoke(manager, operation, cancellation.Token));
+
+        Assert.Equal(0, storage.Calls);
+        Assert.Same(previous, manager.State);
+        Assert.Same(previous, storage.State);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task Cancellation_interrupts_storage_without_publishing_uncommitted_state(StorageOperation operation)
+    {
+        using var storage = new CancellableStorage(operation);
+        IStateManager<Snapshot> manager = new DefaultStateManager<Snapshot>(storage, static () => new("default"));
+        var previous = manager.State;
+        using var cancellation = new CancellationTokenSource();
+        var pending = Invoke(manager, operation, cancellation.Token);
+        await storage.Started.Task.WaitAsync(TestContext.Current.CancellationToken);
+        Assert.Same(previous, manager.State);
+
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            pending.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+        Assert.Same(previous, manager.State);
+        Assert.Same(previous, storage.State);
+        Assert.Equal(1, storage.Calls);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task Cancellation_interrupts_recovery_and_a_fresh_read_restores_durable_state(StorageOperation operation)
+    {
+        using var storage = new CancellableStorage(StorageOperation.Read) { LoseResponse = true };
+        IStateManager<Snapshot> manager = new DefaultStateManager<Snapshot>(storage, static () => new("default"));
+        var previous = manager.State;
+        using var cancellation = new CancellationTokenSource();
+        var pending = Invoke(manager, operation, cancellation.Token);
+        await storage.Started.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        await cancellation.CancelAsync();
+        var error = await Assert.ThrowsAsync<IOException>(() =>
+            pending.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+
+        Assert.Same(storage.LostResponse, error);
+        Assert.Same(previous, manager.State);
+        storage.Release.TrySetResult();
+        await manager.ReadAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(new Snapshot(operation == StorageOperation.Write ? "next" : "default"), manager.State);
+    }
+
+    private static Task Invoke(IStateManager<Snapshot> manager, StorageOperation operation, CancellationToken cancellationToken) => operation switch
+    {
+        StorageOperation.Read => manager.ReadAsync(cancellationToken),
+        StorageOperation.Write => manager.WriteAsync(new Snapshot("next"), cancellationToken),
+        StorageOperation.Clear => manager.ClearAsync(cancellationToken),
+        _ => throw new ArgumentOutOfRangeException(nameof(operation))
+    };
+
+    public enum StorageOperation
+    {
+        Read,
+        Write,
+        Clear
+    }
+
+    private sealed record Snapshot(string Value);
+
+    private sealed class CancellableStorage(StorageOperation blockedOperation) : IPersistentState<Snapshot>, IDisposable
+    {
+        private Snapshot? persisted = new("previous");
+        public Snapshot State { get; set; } = new("previous");
+        public string Etag => "etag";
+        public bool RecordExists => persisted is not null;
+        public int Calls { get; private set; }
+        public bool LoseResponse { get; init; }
+        public CancellationTokenSource? CancelAfterPersisting { get; init; }
+        public IOException LostResponse { get; } = new("Storage response was lost.");
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReadStateAsync() => ReadStateAsync(CancellationToken.None);
+        public Task WriteStateAsync() => WriteStateAsync(CancellationToken.None);
+        public Task ClearStateAsync() => ClearStateAsync(CancellationToken.None);
+
+        public async Task ReadStateAsync(CancellationToken cancellationToken)
+        {
+            await BeforeOperationAsync(StorageOperation.Read, cancellationToken);
+            State = persisted!;
+        }
+
+        public async Task WriteStateAsync(CancellationToken cancellationToken)
+        {
+            await BeforeOperationAsync(StorageOperation.Write, cancellationToken);
+            persisted = State;
+            if (CancelAfterPersisting is not null)
+            {
+                await CancelAfterPersisting.CancelAsync();
+            }
+            if (LoseResponse)
+            {
+                throw LostResponse;
+            }
+        }
+
+        public async Task ClearStateAsync(CancellationToken cancellationToken)
+        {
+            await BeforeOperationAsync(StorageOperation.Clear, cancellationToken);
+            persisted = null;
+            if (CancelAfterPersisting is not null)
+            {
+                await CancelAfterPersisting.CancelAsync();
+            }
+            if (LoseResponse)
+            {
+                throw LostResponse;
+            }
+        }
+
+        private async Task BeforeOperationAsync(StorageOperation operation, CancellationToken cancellationToken)
+        {
+            Calls++;
+            if (operation == blockedOperation)
+            {
+                Started.TrySetResult();
+                await Release.Task.WaitAsync(cancellationToken);
+            }
+        }
+
+        public void Dispose() => Release.TrySetResult();
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/State/StateManagerTests.cs
@@ -35,7 +35,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         storage.State = new TestState("fresh");
 
-        await manager.ReadAsync();
+        await manager.ReadAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new TestState("fresh"), manager.State);
     }
@@ -53,7 +53,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.ReadAsync();
+        await manager.ReadAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new TestState("default"), manager.State);
         Assert.Equal(0, storage.WriteCount);
@@ -67,7 +67,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
-        await manager.WriteAsync(next);
+        await manager.WriteAsync(next, TestContext.Current.CancellationToken);
 
         Assert.Equal(next, manager.State);
         Assert.Equal(next, storage.State);
@@ -84,7 +84,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
-        await manager.WriteAsync(next);
+        await manager.WriteAsync(next, TestContext.Current.CancellationToken);
 
         Assert.Equal(next, manager.State);
     }
@@ -105,7 +105,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next")));
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Equal(persisted, manager.State);
@@ -131,7 +131,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => manager.WriteAsync(attempted));
+            () => manager.WriteAsync(attempted, TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Equal(persisted, manager.State);
@@ -156,7 +156,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => manager.WriteAsync(attempted));
+            () => manager.WriteAsync(attempted, TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Equal(new TestState("next"), manager.State);
@@ -174,7 +174,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next")));
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Equal(new TestState("initial"), manager.State);
@@ -193,7 +193,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
         var ex = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Same(initial, manager.State);
@@ -208,7 +208,7 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<VersionedTestState>(storage, static () => new("default"));
         var next = new VersionedTestState("next") { Version = Guid.Empty };
 
-        await manager.WriteAsync(next);
+        await manager.WriteAsync(next, TestContext.Current.CancellationToken);
 
         Assert.NotEqual(Guid.Empty, next.Version);
         Assert.Equal(next.Version, manager.State!.Version);
@@ -220,7 +220,7 @@ public sealed class StateManagerTests
         var storage = new FakePersistentState(new TestState("initial"));
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.ClearAsync();
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new TestState("default"), manager.State);
         Assert.Equal(0, storage.WriteCount);
@@ -234,8 +234,8 @@ public sealed class StateManagerTests
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
         var next = new TestState("next");
 
-        await manager.ClearAsync();
-        await manager.WriteAsync(next);
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
+        await manager.WriteAsync(next, TestContext.Current.CancellationToken);
 
         Assert.Equal(next, manager.State);
         Assert.Equal(next, storage.State);
@@ -247,7 +247,7 @@ public sealed class StateManagerTests
         var writeException = new TimeoutException("write timeout");
         var storage = new FakePersistentState(new TestState("initial"));
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
-        await manager.ClearAsync();
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
         storage.WriteException = writeException;
         storage.OnRead = state =>
         {
@@ -256,7 +256,7 @@ public sealed class StateManagerTests
         };
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(
-            () => manager.WriteAsync(new TestState("next")));
+            () => manager.WriteAsync(new TestState("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(writeException, ex);
         Assert.Equal(new TestState("default"), manager.State);
@@ -278,7 +278,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        await manager.ClearAsync();
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new TestState("default"), manager.State);
         Assert.Equal(0, storage.WriteCount);
@@ -302,7 +302,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync());
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync(TestContext.Current.CancellationToken));
 
         Assert.Same(clearException, ex);
         Assert.Same(persisted, manager.State);
@@ -325,7 +325,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var ex = await Assert.ThrowsAsync<InconsistentStateException>(() => manager.ClearAsync());
+        var ex = await Assert.ThrowsAsync<InconsistentStateException>(() => manager.ClearAsync(TestContext.Current.CancellationToken));
 
         Assert.Same(clearException, ex);
         Assert.Equal(new TestState("default"), manager.State);
@@ -344,7 +344,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync());
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => manager.ClearAsync(TestContext.Current.CancellationToken));
 
         Assert.Same(clearException, ex);
         Assert.Equal(new TestState("initial"), manager.State);
@@ -361,7 +361,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var error = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new("default")));
+        var error = await Assert.ThrowsAsync<TimeoutException>(() => manager.WriteAsync(new("default"), TestContext.Current.CancellationToken));
 
         Assert.Same(failure, error);
         Assert.Equal(new TestState("default"), manager.State);
@@ -377,8 +377,8 @@ public sealed class StateManagerTests
         var storage = new FakePersistentState(initial) { OnRead = state => state.State = loaded };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"), configured.Add);
 
-        await manager.ReadAsync();
-        await manager.ClearAsync();
+        await manager.ReadAsync(TestContext.Current.CancellationToken);
+        await manager.ClearAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal([initial, loaded, new TestState("default")], configured);
         Assert.Same(configured[2], manager.State);
@@ -416,7 +416,7 @@ public sealed class StateManagerTests
         var storage = new FakePersistentState(previous) { WriteCompletion = completion.Task };
         var manager = new DefaultStateManager<TestState>(storage, static () => new("default"));
 
-        var write = manager.WriteAsync(next);
+        var write = manager.WriteAsync(next, TestContext.Current.CancellationToken);
 
         Assert.Same(previous, manager.State);
         Assert.Same(next, storage.State);
@@ -450,9 +450,9 @@ public sealed class StateManagerTests
 
         _ = await Record.ExceptionAsync(() => operation switch
         {
-            "read" => manager.ReadAsync(),
-            "write" or "write-recovery" => manager.WriteAsync(new("next")),
-            _ => manager.ClearAsync()
+            "read" => manager.ReadAsync(TestContext.Current.CancellationToken),
+            "write" or "write-recovery" => manager.WriteAsync(new("next"), TestContext.Current.CancellationToken),
+            _ => manager.ClearAsync(TestContext.Current.CancellationToken)
         });
 
         Assert.Same(configured, observedManager);
@@ -480,7 +480,7 @@ public sealed class StateManagerTests
         var recoveryReads = 0;
         storage.OnRead = _ => recoveryReads++;
 
-        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync(TestContext.Current.CancellationToken) : manager.WriteAsync(new("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(failure, error);
         Assert.Equal(clear ? "default" : "next", manager.State.Value);
@@ -502,7 +502,7 @@ public sealed class StateManagerTests
         };
         var manager = new DefaultStateManager<TestState>(storage, static () => null!);
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => clear ? manager.ClearAsync(TestContext.Current.CancellationToken) : manager.WriteAsync(new("next"), TestContext.Current.CancellationToken));
 
         Assert.Contains(recordExists ? "existing state record" : "factory returned null", error.Message);
     }
@@ -525,7 +525,7 @@ public sealed class StateManagerTests
             if (ReferenceEquals(value, loaded)) throw failure;
         });
 
-        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync() : manager.WriteAsync(new("next")));
+        var error = await Record.ExceptionAsync(() => clear ? manager.ClearAsync(TestContext.Current.CancellationToken) : manager.WriteAsync(new("next"), TestContext.Current.CancellationToken));
 
         Assert.Same(failure, error);
         Assert.Same(loaded, manager.State);

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamCursorJsonConverterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamCursorJsonConverterTests.cs
@@ -7,6 +7,44 @@ namespace Egil.Orleans.Messaging.Tests.Streams;
 
 public sealed class StreamCursorJsonConverterTests
 {
+    [Theory]
+    [InlineData("event-sequence", "1.5")]
+    [InlineData("event-sequence", "2147483648")]
+    [InlineData("event-sequence", "\"1\"")]
+    [InlineData("event-sequence-v2", "1.5")]
+    [InlineData("event-sequence-v2", "2147483648")]
+    [InlineData("event-sequence-v2", "\"1\"")]
+    public void Invalid_event_index_cannot_change_stream_position(string kind, string index)
+    {
+        var json = $$"""{"StreamNamespace":"orders","Token":{"Kind":"{{kind}}","Payload":{"SequenceNumber":7,"EventIndex":{{index}} } } }""";
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StreamCursor>(json));
+
+        Assert.Contains("EventIndex", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Legacy_null_provider_preserves_stream_position()
+    {
+        var json = """{"StreamNamespace":"orders","ProviderName":null,"Token":{"Kind":"event-sequence","Payload":{"SequenceNumber":7,"EventIndex":2}}}""";
+
+        var cursor = JsonSerializer.Deserialize<StreamCursor>(json);
+
+        Assert.Equal(new StreamCursor("orders", new EventSequenceToken(7, 2)), cursor);
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("{}")]
+    public void Invalid_provider_metadata_is_rejected(string provider)
+    {
+        var json = $$"""{"StreamNamespace":"orders","ProviderName":{{provider}},"Token":null}""";
+
+        var error = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StreamCursor>(json));
+
+        Assert.Contains("ProviderName", error.Message, StringComparison.Ordinal);
+    }
+
     public static TheoryData<string, string> InvalidCursorJson => new()
     {
         { """{"Token":null}""", "StreamNamespace" },

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerBehaviorTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerBehaviorTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Orleans.Providers.Streams.Common;
+
+namespace Egil.Orleans.Messaging.Tests.Streams;
+
+public sealed class StreamManagerBehaviorTests(MessagingTestClusterFixture fixture) : IClassFixture<MessagingTestClusterFixture>
+{
+    [Theory]
+    [InlineData(SubscriptionKind.Implicit)]
+    [InlineData(SubscriptionKind.Convention)]
+    [InlineData(SubscriptionKind.ExplicitId)]
+    public async Task Rejected_duplicate_keeps_original_subscription_handler(SubscriptionKind subscriptionKind)
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStreamManagerBehaviorGrain>(Guid.NewGuid());
+
+        var result = await grain.DuplicateAsync(subscriptionKind);
+
+        Assert.True(result.Rejected);
+        Assert.Equal(["original"], result.Delivered);
+    }
+
+    [Theory]
+    [InlineData("00-11111111111111111111111111111111-2222222222222222-01", true)]
+    [InlineData("invalid-traceparent", false)]
+    public async Task Consumer_tracing_links_valid_context_and_records_handler_failure(string traceParent, bool expectedLink)
+    {
+        var streamNamespace = Guid.NewGuid().ToString("N");
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "egil.orleans.messaging",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (Equals(activity.GetTagItem("messaging.destination.name"), streamNamespace))
+                {
+                    activities.Enqueue(activity);
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+        var grain = fixture.GrainFactory.GetGrain<IStreamManagerBehaviorGrain>(Guid.NewGuid());
+
+        var result = await grain.DeliverAsync(streamNamespace, false, traceParent);
+
+        Assert.Equal(["after-failure"], result.Delivered);
+        Assert.Equal(2, activities.Count);
+        var failed = Assert.Single(activities, activity => activity.Status == ActivityStatusCode.Error);
+        Assert.Equal("Delivery failed.", failed.StatusDescription);
+        Assert.All(activities, activity =>
+        {
+            Assert.Equal(ActivityKind.Consumer, activity.Kind);
+            Assert.Equal(expectedLink ? 1 : 0, activity.Links.Count());
+        });
+        if (expectedLink)
+        {
+            var link = Assert.Single(failed.Links);
+            Assert.Equal("11111111111111111111111111111111", link.Context.TraceId.ToString());
+            Assert.Equal("2222222222222222", link.Context.SpanId.ToString());
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Custom_error_callback_does_not_prevent_subsequent_delivery(bool callbackThrows)
+    {
+        var grain = fixture.GrainFactory.GetGrain<IStreamManagerBehaviorGrain>(Guid.NewGuid());
+        var streamNamespace = Guid.NewGuid().ToString("N");
+
+        var result = await grain.DeliverAsync(streamNamespace, callbackThrows, null);
+
+        Assert.Equal(["after-failure"], result.Delivered);
+        Assert.Equal(1, result.Errors);
+        Assert.True(result.OriginalError);
+        Assert.Equal(streamNamespace, result.ErrorNamespace);
+    }
+}
+
+public interface IStreamManagerBehaviorGrain : IGrainWithGuidKey
+{
+    Task<(bool Rejected, string[] Delivered)> DuplicateAsync(SubscriptionKind subscriptionKind);
+    Task<(string[] Delivered, int Errors, bool OriginalError, string? ErrorNamespace)> DeliverAsync(string streamNamespace, bool callbackThrows, string? traceParent);
+}
+
+public sealed class StreamManagerBehaviorGrain : Grain, IStreamManagerBehaviorGrain
+{
+    public async Task<(bool Rejected, string[] Delivered)> DuplicateAsync(SubscriptionKind subscriptionKind)
+    {
+        var streamId = StreamId.Create("orders", "one");
+        var stream = new StreamManagerResumeTests.FakeStream<string>("provider-a", streamId);
+        var manager = StreamManagerResumeTests.CreateManager(null, stream, this);
+        List<string> delivered = [];
+        void Configure(Func<string, StreamCursor, ValueTask> handler)
+        {
+            switch (subscriptionKind)
+            {
+                case SubscriptionKind.Implicit:
+                    manager.ConfigureImplicitSubscription("orders", handler);
+                    break;
+                case SubscriptionKind.Convention:
+                    manager.ConfigureExplicitSubscription("provider-a", "orders", handler);
+                    break;
+                default:
+                    manager.ConfigureExplicitSubscription("provider-a", streamId, handler);
+                    break;
+            }
+        }
+        Configure((message, _) =>
+        {
+            delivered.Add(message);
+            return ValueTask.CompletedTask;
+        });
+        var rejected = false;
+        try
+        {
+            Configure((_, _) => throw new InvalidOperationException("Replacement handler must not run."));
+        }
+        catch (InvalidOperationException)
+        {
+            rejected = true;
+        }
+
+        if (subscriptionKind == SubscriptionKind.Implicit)
+        {
+            var handle = new StreamManagerResumeTests.FakeSubscriptionHandle<string>("provider-a", streamId);
+            await ((IStreamManagerComponent)manager).OnSubscribedAsync(
+                new StreamManagerResumeTests.FakeStreamSubscriptionHandleFactory("provider-a", streamId, handle));
+            await handle.DeliverAsync("original");
+        }
+        else
+        {
+            await manager.EnsureExplicitSubscriptionsAsync();
+            await stream.OnNextAsync("original");
+        }
+        return (rejected, delivered.ToArray());
+    }
+
+    public async Task<(string[] Delivered, int Errors, bool OriginalError, string? ErrorNamespace)> DeliverAsync(
+        string streamNamespace, bool callbackThrows, string? traceParent)
+    {
+        var stream = new StreamManagerResumeTests.FakeStream<string>("provider-a", StreamId.Create(streamNamespace, "one"));
+        var manager = StreamManagerResumeTests.CreateManager(null, stream, this);
+        List<string> delivered = [];
+        var failure = new InvalidOperationException("Delivery failed.");
+        var errors = 0;
+        var originalError = false;
+        string? errorNamespace = null;
+        manager.ConfigureExplicitSubscription<string>("provider-a", streamNamespace,
+            (message, _) =>
+            {
+                if (message == "fail")
+                {
+                    throw failure;
+                }
+                delivered.Add(message);
+                return ValueTask.CompletedTask;
+            },
+            (name, error) =>
+            {
+                errors++;
+                errorNamespace = name;
+                originalError = ReferenceEquals(error, failure);
+                if (callbackThrows)
+                {
+                    throw new InvalidOperationException("Error callback failed.");
+                }
+            });
+        await manager.EnsureExplicitSubscriptionsAsync();
+        await stream.OnNextAsync("fail", new DiagnosticToken(traceParent));
+        await stream.OnNextAsync("after-failure", new DiagnosticToken(traceParent));
+        return (delivered.ToArray(), errors, originalError, errorNamespace);
+    }
+}
+
+internal sealed class DiagnosticToken(string? traceParent, DateTimeOffset? enqueuedTime = null) : EventSequenceToken(1), IStreamSequenceTokenMetadata
+{
+    public bool TryGetTraceParent([NotNullWhen(true)] out string? value)
+    {
+        value = traceParent;
+        return value is not null;
+    }
+
+    public bool TryGetEnqueuedTime(out DateTimeOffset value)
+    {
+        value = enqueuedTime.GetValueOrDefault();
+        return enqueuedTime.HasValue;
+    }
+
+    public bool TryGetProviderName([NotNullWhen(true)] out string? value)
+    {
+        value = "provider-a";
+        return true;
+    }
+}
+
+public enum SubscriptionKind
+{
+    Implicit,
+    Convention,
+    ExplicitId
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
@@ -31,10 +31,10 @@ public sealed class StreamManagerResumeTests
     public async Task Legacy_position_resumes_subscription_unless_provider_has_its_own_position(bool hasProviderPosition, long expectedSequence)
     {
         var tracker = new MessageTracker();
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
         if (hasProviderPosition)
         {
-            tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-a"), out tracker);
+            tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-a"), out tracker);
         }
         var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
         var manager = CreateManager(() => tracker, stream);
@@ -244,7 +244,7 @@ public sealed class StreamManagerResumeTests
         long sequenceNumber)
     {
         var tracker = new MessageTracker();
-        tracker.ProcessMessage(
+        tracker.TryAcceptMessage(
             new StreamCursor(
                 streamNamespace,
                 new EventSequenceToken(sequenceNumber),

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerResumeTests.cs
@@ -7,6 +7,44 @@ namespace Egil.Orleans.Messaging.Tests.Streams;
 
 public sealed class StreamManagerResumeTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Distinct_explicit_subscription_sources_can_be_configured(bool explicitId)
+    {
+        var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
+        var manager = CreateManager(null, stream);
+        Func<string, string, StreamManager> configure = explicitId
+            ? (provider, name) => manager.ConfigureExplicitSubscription<string>(provider, StreamId.Create(name, "one"), static (_, _) => ValueTask.CompletedTask)
+            : (provider, name) => manager.ConfigureExplicitSubscription<string>(provider, name, static (_, _) => ValueTask.CompletedTask);
+        configure("provider-a", "orders");
+
+        configure("provider-b", "orders");
+        var configured = configure("provider-a", "other");
+
+        Assert.Same(manager, configured);
+    }
+
+    [Theory]
+    [InlineData(false, 7)]
+    [InlineData(true, 9)]
+    public async Task Legacy_position_resumes_subscription_unless_provider_has_its_own_position(bool hasProviderPosition, long expectedSequence)
+    {
+        var tracker = new MessageTracker();
+        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        if (hasProviderPosition)
+        {
+            tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-a"), out tracker);
+        }
+        var stream = new FakeStream<string>("provider-a", StreamId.Create("orders", "one"));
+        var manager = CreateManager(() => tracker, stream);
+
+        await manager.ConfigureExplicitSubscription<string>("provider-a", "orders", static (_, _) => ValueTask.CompletedTask)
+            .EnsureExplicitSubscriptionsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(new EventSequenceToken(expectedSequence), stream.SubscribeToken);
+    }
+
     [Fact]
     public async Task Subscription_uses_tracker_adopted_after_registration()
     {
@@ -186,11 +224,12 @@ public sealed class StreamManagerResumeTests
         Assert.Contains("provider-a", exception.Message);
     }
 
-    private static StreamManager CreateManager<TEvent>(
+    internal static StreamManager CreateManager<TEvent>(
         Func<MessageTracker?>? tracker,
-        FakeStream<TEvent> stream)
+        FakeStream<TEvent> stream,
+        IGrainBase? owner = null)
     {
-        var owner = new FakeGrainBase();
+        owner ??= new FakeGrainBase();
         return StreamManager.Create(
             owner,
             tracker,
@@ -233,11 +272,13 @@ public sealed class StreamManagerResumeTests
         }
     }
 
-    private sealed class FakeStream<T>(
+    internal sealed class FakeStream<T>(
         string providerName,
         StreamId streamId) : IAsyncStream<T>
     {
         public List<StreamSubscriptionHandle<T>> Handles { get; } = [];
+
+        private IAsyncObserver<T>? observer;
 
         public int SubscribeCount { get; private set; }
 
@@ -264,6 +305,7 @@ public sealed class StreamManagerResumeTests
             StreamSequenceToken? token,
             string? filterData = null)
         {
+            this.observer = observer;
             SubscribeCount++;
             SubscribeToken = token;
             var handle = new FakeSubscriptionHandle<T>(providerName, streamId);
@@ -272,7 +314,8 @@ public sealed class StreamManagerResumeTests
             return Task.FromResult<StreamSubscriptionHandle<T>>(handle);
         }
 
-        public Task OnNextAsync(T item, StreamSequenceToken? token = null) => Task.CompletedTask;
+        public Task OnNextAsync(T item, StreamSequenceToken? token = null) =>
+            (observer ?? throw new InvalidOperationException("No subscriber attached.")).OnNextAsync(item, token);
 
         public Task OnNextBatchAsync(IEnumerable<T> batch, StreamSequenceToken? token = null) => Task.CompletedTask;
 
@@ -316,10 +359,15 @@ public sealed class StreamManagerResumeTests
         }
     }
 
-    private sealed class FakeSubscriptionHandle<T>(
+    internal sealed class FakeSubscriptionHandle<T>(
         string providerName,
         StreamId streamId) : StreamSubscriptionHandle<T>
     {
+        private IAsyncObserver<T>? observer;
+
+        public Task DeliverAsync(T item) =>
+            (observer ?? throw new InvalidOperationException("No subscriber attached.")).OnNextAsync(item);
+
         public int ResumeCount { get; private set; }
 
         public StreamSequenceToken? ResumeToken { get; private set; }
@@ -336,6 +384,7 @@ public sealed class StreamManagerResumeTests
             IAsyncObserver<T> observer,
             StreamSequenceToken? token)
         {
+            this.observer = observer;
             ResumeCount++;
             ResumeToken = token;
             return Task.FromResult<StreamSubscriptionHandle<T>>(this);
@@ -354,7 +403,7 @@ public sealed class StreamManagerResumeTests
             other?.HandleId == HandleId;
     }
 
-    private sealed class FakeStreamSubscriptionHandleFactory(
+    internal sealed class FakeStreamSubscriptionHandleFactory(
         string providerName,
         StreamId streamId,
         FakeSubscriptionHandle<string> stringHandle) : IStreamSubscriptionHandleFactory

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamManagerTests.cs
@@ -318,7 +318,7 @@ public sealed class StreamManagerTestGrain(
 
     private void TrackStreamCursor(StreamCursor cursor)
     {
-        if (state.State.Tracker.ProcessMessage(cursor, out var next))
+        if (state.State.Tracker.TryAcceptMessage(cursor, out var next))
         {
             state.State.Tracker = next;
         }
@@ -360,7 +360,7 @@ public sealed class ImplicitStreamManagerTestGrain(
 
     private async ValueTask HandleImplicitAsync(string item, StreamCursor cursor)
     {
-        state.State.Tracker.ProcessMessage(cursor, out var tracker);
+        state.State.Tracker.TryAcceptMessage(cursor, out var tracker);
         state.State.Tracker = tracker;
         state.State.Value = item;
         state.State.DeliveryCount++;

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamSequenceTokenRegistrationTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Streams/StreamSequenceTokenRegistrationTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Orleans.Providers.Streams.Common;
+
+namespace Egil.Orleans.Messaging.Tests.Streams;
+
+public sealed class StreamSequenceTokenRegistrationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Conflicting_descriptor_preserves_original_decoder(bool differentTokenType)
+    {
+        var descriptor = Guid.NewGuid().ToString("N");
+        StreamSequenceTokenJsonConverters.Register(descriptor, new TokenConverter());
+        Action conflictingRegistration = differentTokenType
+            ? () => StreamSequenceTokenJsonConverters.Register(descriptor, new V2Converter())
+            : () => StreamSequenceTokenJsonConverters.Register(descriptor, new OtherConverter());
+
+        Assert.Throws<InvalidOperationException>(conflictingRegistration);
+        var restored = JsonSerializer.Deserialize<StreamCursor>(
+            $$"""{"StreamNamespace":"orders","Token":{"Kind":"{{descriptor}}","Payload":7} }""");
+
+        Assert.Equal(new EventSequenceToken(7), restored!.Token);
+    }
+
+    private class TokenConverter : JsonConverter<EventSequenceToken>
+    {
+        public override EventSequenceToken Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(reader.GetInt64());
+        public override void Write(Utf8JsonWriter writer, EventSequenceToken value, JsonSerializerOptions options) => writer.WriteNumberValue(value.SequenceNumber);
+    }
+
+    private sealed class OtherConverter : TokenConverter;
+
+    private sealed class V2Converter : JsonConverter<EventSequenceTokenV2>
+    {
+        public override EventSequenceTokenV2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(reader.GetInt64());
+        public override void Write(Utf8JsonWriter writer, EventSequenceTokenV2 value, JsonSerializerOptions options) => writer.WriteNumberValue(value.SequenceNumber);
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerJsonConverterTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerJsonConverterTests.cs
@@ -28,7 +28,7 @@ public sealed class MessageTrackerJsonConverterTests
         var streamId = StreamId.Create("orders", token.GetType().Name);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", token), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", token), out tracker);
 
         var json = JsonSerializer.Serialize(tracker);
         var roundTripped = JsonSerializer.Deserialize<MessageTracker>(json);
@@ -47,7 +47,7 @@ public sealed class MessageTrackerJsonConverterTests
         var sender = GrainId.Create("test/sender", "one");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new OutboxSequenceToken(sequenceNumber, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(sequenceNumber, sender, now, now), out tracker);
 
         var json = JsonSerializer.Serialize(tracker);
         var roundTripped = JsonSerializer.Deserialize<MessageTracker>(json);
@@ -66,7 +66,7 @@ public sealed class MessageTrackerJsonConverterTests
         var streamId = StreamId.Create("orders", "unsupported");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", new UnsupportedSequenceToken(1, 0)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new UnsupportedSequenceToken(1, 0)), out tracker);
 
         Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(tracker));
     }
@@ -183,10 +183,10 @@ public sealed class MessageTrackerJsonConverterTests
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(
+        tracker.TryAcceptMessage(
             new StreamCursor("orders", new EventSequenceToken(7, 1), "provider-a"),
             out tracker);
-        tracker.ProcessMessage(
+        tracker.TryAcceptMessage(
             new OutboxSequenceToken(
                 42,
                 GrainId.Create("test/sender", "one"),

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTelemetryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTelemetryTests.cs
@@ -42,8 +42,8 @@ public sealed class MessageTrackerTelemetryTests
         var future = clock.GetUtcNow().AddMinutes(5);
 
         var accepted = streamMessage
-            ? tracker.ProcessMessage(new StreamCursor(source, new DiagnosticToken(null, future)), out _)
-            : tracker.ProcessMessage(new OutboxSequenceToken(1, GrainId.Create(source, "one"), future, future), out _);
+            ? tracker.TryAcceptMessage(new StreamCursor(source, new DiagnosticToken(null, future)), out _)
+            : tracker.TryAcceptMessage(new OutboxSequenceToken(1, GrainId.Create(source, "one"), future, future), out _);
 
         Assert.True(accepted);
         Assert.Equal(0d, Assert.Single(measurements));

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTelemetryTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTelemetryTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.Metrics;
+using Egil.Orleans.Messaging.Tests.Streams;
+using TimeProviderExtensions;
+
+namespace Egil.Orleans.Messaging.Tests.Tracking;
+
+public sealed class MessageTrackerTelemetryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Sender_clock_skew_never_exports_negative_receive_lag(bool streamMessage)
+    {
+        var source = Guid.NewGuid().ToString("N");
+        var clock = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var tracker = new MessageTracker();
+        tracker.RegisterTimeProvider(clock);
+        var metricName = streamMessage ? "stream.message.receive.lag" : "outbox.message.receive.lag";
+        var sourceTag = streamMessage ? "stream.namespace" : "sender.grain.type";
+        List<double> measurements = [];
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == "egil.orleans.messaging" && instrument.Name == metricName)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, value, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == sourceTag && Equals(tag.Value, source))
+                {
+                    measurements.Add(value);
+                }
+            }
+        });
+        listener.Start();
+        var future = clock.GetUtcNow().AddMinutes(5);
+
+        var accepted = streamMessage
+            ? tracker.ProcessMessage(new StreamCursor(source, new DiagnosticToken(null, future)), out _)
+            : tracker.ProcessMessage(new OutboxSequenceToken(1, GrainId.Create(source, "one"), future, future), out _);
+
+        Assert.True(accepted);
+        Assert.Equal(0d, Assert.Single(measurements));
+    }
+}

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTests.cs
@@ -6,6 +6,63 @@ namespace Egil.Orleans.Messaging.Tests.Tracking;
 public sealed class MessageTrackerTests
 {
     [Fact]
+    public void Eviction_removes_only_expired_sources_and_preserves_recent_deduplication()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var time = new ManualTimeProvider(now);
+        var oldSender = GrainId.Create("sender", "old");
+        var recentSender = GrainId.Create("sender", "recent");
+        var oldToken = new OutboxSequenceToken(1, oldSender, now, now);
+        var recentToken = new OutboxSequenceToken(1, recentSender, now, now);
+        var tracker = new MessageTracker();
+        tracker.RegisterTimeProvider(time);
+        tracker.ProcessMessage(oldToken, out tracker);
+        tracker.ProcessMessage("old", new EventSequenceToken(1), out tracker);
+        time.Advance(TimeSpan.FromMinutes(1));
+        tracker.ProcessMessage(recentToken, out tracker);
+        tracker.ProcessMessage("recent", new EventSequenceToken(2), out tracker);
+
+        var evicted = tracker.Evict(now);
+
+        Assert.True(evicted.ProcessMessage(oldToken, out _));
+        Assert.False(evicted.ProcessMessage(recentToken, out _));
+        Assert.True(evicted.ProcessMessage("old", new EventSequenceToken(1), out _));
+        Assert.False(evicted.ProcessMessage("recent", new EventSequenceToken(2), out _));
+        Assert.False(tracker.ProcessMessage(oldToken, out _));
+        var prunedAgain = evicted.Evict(now).EvictStreams(now).EvictOutboxes(now).Evict(oldSender, now);
+        Assert.False(prunedAgain.ProcessMessage(recentToken, out _));
+        Assert.False(prunedAgain.ProcessMessage("recent", new EventSequenceToken(2), out _));
+    }
+
+    [Fact]
+    public void Duplicate_delivery_does_not_extend_the_deduplication_retention_window()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var time = new ManualTimeProvider(now);
+        var token = new OutboxSequenceToken(1, GrainId.Create("sender", "one"), now, now);
+        var tracker = new MessageTracker();
+        tracker.RegisterTimeProvider(time);
+        tracker.ProcessMessage(token, out tracker);
+        time.Advance(TimeSpan.FromHours(1));
+
+        Assert.False(tracker.ProcessMessage(token, out var duplicate));
+        var evicted = duplicate.Evict(now);
+
+        Assert.True(evicted.ProcessMessage(token, out _));
+    }
+
+    [Fact]
+    public void Provider_lookup_does_not_reuse_another_providers_position()
+    {
+        var tracker = new MessageTracker();
+        tracker.ProcessMessage("provider-a", "orders", new EventSequenceToken(9), out tracker);
+
+        Assert.Null(tracker.LatestStream("provider-b", "orders"));
+        Assert.True(tracker.ProcessMessage("provider-b", "orders", new EventSequenceToken(1), out var next));
+        Assert.False(next.ProcessMessage("provider-a", "orders", new EventSequenceToken(9), out _));
+    }
+
+    [Fact]
     public void ProcessMessage_accepts_first_stream_cursor_and_tracks_latest_position()
     {
         var streamId = StreamId.Create("orders", "one");

--- a/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTests.cs
+++ b/Egil.Orleans.Messaging/test/Egil.Orleans.Messaging.Tests/Tracking/MessageTrackerTests.cs
@@ -16,22 +16,22 @@ public sealed class MessageTrackerTests
         var recentToken = new OutboxSequenceToken(1, recentSender, now, now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(oldToken, out tracker);
-        tracker.ProcessMessage("old", new EventSequenceToken(1), out tracker);
+        tracker.TryAcceptMessage(oldToken, out tracker);
+        tracker.TryAcceptMessage("old", new EventSequenceToken(1), out tracker);
         time.Advance(TimeSpan.FromMinutes(1));
-        tracker.ProcessMessage(recentToken, out tracker);
-        tracker.ProcessMessage("recent", new EventSequenceToken(2), out tracker);
+        tracker.TryAcceptMessage(recentToken, out tracker);
+        tracker.TryAcceptMessage("recent", new EventSequenceToken(2), out tracker);
 
         var evicted = tracker.Evict(now);
 
-        Assert.True(evicted.ProcessMessage(oldToken, out _));
-        Assert.False(evicted.ProcessMessage(recentToken, out _));
-        Assert.True(evicted.ProcessMessage("old", new EventSequenceToken(1), out _));
-        Assert.False(evicted.ProcessMessage("recent", new EventSequenceToken(2), out _));
-        Assert.False(tracker.ProcessMessage(oldToken, out _));
+        Assert.True(evicted.TryAcceptMessage(oldToken, out _));
+        Assert.False(evicted.TryAcceptMessage(recentToken, out _));
+        Assert.True(evicted.TryAcceptMessage("old", new EventSequenceToken(1), out _));
+        Assert.False(evicted.TryAcceptMessage("recent", new EventSequenceToken(2), out _));
+        Assert.False(tracker.TryAcceptMessage(oldToken, out _));
         var prunedAgain = evicted.Evict(now).EvictStreams(now).EvictOutboxes(now).Evict(oldSender, now);
-        Assert.False(prunedAgain.ProcessMessage(recentToken, out _));
-        Assert.False(prunedAgain.ProcessMessage("recent", new EventSequenceToken(2), out _));
+        Assert.False(prunedAgain.TryAcceptMessage(recentToken, out _));
+        Assert.False(prunedAgain.TryAcceptMessage("recent", new EventSequenceToken(2), out _));
     }
 
     [Fact]
@@ -42,28 +42,28 @@ public sealed class MessageTrackerTests
         var token = new OutboxSequenceToken(1, GrainId.Create("sender", "one"), now, now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(token, out tracker);
+        tracker.TryAcceptMessage(token, out tracker);
         time.Advance(TimeSpan.FromHours(1));
 
-        Assert.False(tracker.ProcessMessage(token, out var duplicate));
+        Assert.False(tracker.TryAcceptMessage(token, out var duplicate));
         var evicted = duplicate.Evict(now);
 
-        Assert.True(evicted.ProcessMessage(token, out _));
+        Assert.True(evicted.TryAcceptMessage(token, out _));
     }
 
     [Fact]
     public void Provider_lookup_does_not_reuse_another_providers_position()
     {
         var tracker = new MessageTracker();
-        tracker.ProcessMessage("provider-a", "orders", new EventSequenceToken(9), out tracker);
+        tracker.TryAcceptMessage("provider-a", "orders", new EventSequenceToken(9), out tracker);
 
         Assert.Null(tracker.LatestStream("provider-b", "orders"));
-        Assert.True(tracker.ProcessMessage("provider-b", "orders", new EventSequenceToken(1), out var next));
-        Assert.False(next.ProcessMessage("provider-a", "orders", new EventSequenceToken(9), out _));
+        Assert.True(tracker.TryAcceptMessage("provider-b", "orders", new EventSequenceToken(1), out var next));
+        Assert.False(next.TryAcceptMessage("provider-a", "orders", new EventSequenceToken(9), out _));
     }
 
     [Fact]
-    public void ProcessMessage_accepts_first_stream_cursor_and_tracks_latest_position()
+    public void TryAcceptMessage_accepts_first_stream_cursor_and_tracks_latest_position()
     {
         var streamId = StreamId.Create("orders", "one");
         var cursor = new StreamCursor("orders", new EventSequenceToken(7));
@@ -71,7 +71,7 @@ public sealed class MessageTrackerTests
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
 
-        var accepted = tracker.ProcessMessage(cursor, out var next);
+        var accepted = tracker.TryAcceptMessage(cursor, out var next);
 
         Assert.True(accepted);
         Assert.Null(tracker.LatestStream(streamId));
@@ -80,27 +80,27 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_accepts_stream_sequence_token_and_namespace()
+    public void TryAcceptMessage_accepts_stream_sequence_token_and_namespace()
     {
         var time = new ManualTimeProvider(new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero));
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
 
-        var accepted = tracker.ProcessMessage("orders", new EventSequenceToken(7), out var next);
+        var accepted = tracker.TryAcceptMessage("orders", new EventSequenceToken(7), out var next);
 
         Assert.True(accepted);
         Assert.Equal(new EventSequenceToken(7), next.LatestStreamSequenceToken("orders"));
     }
 
     [Fact]
-    public void ProcessMessage_accepts_stream_sequence_token_provider_and_namespace()
+    public void TryAcceptMessage_accepts_stream_sequence_token_provider_and_namespace()
     {
         var time = new ManualTimeProvider(new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero));
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
 
-        tracker.ProcessMessage("provider-a", "orders", new EventSequenceToken(7), out tracker);
-        tracker.ProcessMessage("provider-b", "orders", new EventSequenceToken(9), out tracker);
+        tracker.TryAcceptMessage("provider-a", "orders", new EventSequenceToken(7), out tracker);
+        tracker.TryAcceptMessage("provider-b", "orders", new EventSequenceToken(9), out tracker);
 
         Assert.Equal(new EventSequenceToken(7), tracker.LatestStreamSequenceToken("provider-a", "orders"));
         Assert.Equal(new EventSequenceToken(9), tracker.LatestStreamSequenceToken("provider-b", "orders"));
@@ -108,21 +108,21 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_with_stream_sequence_token_rejects_duplicate_for_namespace()
+    public void TryAcceptMessage_with_stream_sequence_token_rejects_duplicate_for_namespace()
     {
         var time = new ManualTimeProvider(new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero));
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage("orders", new EventSequenceToken(7), out tracker);
+        tracker.TryAcceptMessage("orders", new EventSequenceToken(7), out tracker);
 
-        var accepted = tracker.ProcessMessage("orders", new EventSequenceToken(7), out var next);
+        var accepted = tracker.TryAcceptMessage("orders", new EventSequenceToken(7), out var next);
 
         Assert.False(accepted);
         Assert.Same(tracker, next);
     }
 
     [Fact]
-    public void ProcessMessage_accepts_first_outbox_token_and_tracks_latest_position()
+    public void TryAcceptMessage_accepts_first_outbox_token_and_tracks_latest_position()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var sender = GrainId.Create("test/sender", "one");
@@ -131,7 +131,7 @@ public sealed class MessageTrackerTests
         tracker.RegisterTimeProvider(time);
         var token = new OutboxSequenceToken(1, sender, now, now);
 
-        var accepted = tracker.ProcessMessage(token, out var next);
+        var accepted = tracker.TryAcceptMessage(token, out var next);
 
         Assert.True(accepted);
         Assert.Null(tracker.LatestOutbox(sender));
@@ -150,7 +150,7 @@ public sealed class MessageTrackerTests
         tracker.RegisterTimeProvider(time);
         var token = new OutboxSequenceToken(1, sender, senderTime, senderTime);
 
-        tracker.ProcessMessage(token, out var next);
+        tracker.TryAcceptMessage(token, out var next);
 
         Assert.Equal(token, next.LatestOutbox(sender));
     }
@@ -164,8 +164,8 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
-        tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
 
         var evicted = tracker.Evict(now);
 
@@ -174,32 +174,32 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_rejects_stream_cursor_when_token_is_not_newer()
+    public void TryAcceptMessage_rejects_stream_cursor_when_token_is_not_newer()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var time = new ManualTimeProvider(now);
         var streamId = StreamId.Create("orders", "one");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
 
-        var accepted = tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out var next);
+        var accepted = tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out var next);
 
         Assert.False(accepted);
         Assert.Same(tracker, next);
     }
 
     [Fact]
-    public void ProcessMessage_accepts_stream_cursor_when_token_is_newer()
+    public void TryAcceptMessage_accepts_stream_cursor_when_token_is_newer()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var time = new ManualTimeProvider(now);
         var streamId = StreamId.Create("orders", "one");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
 
-        var accepted = tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(8)), out var next);
+        var accepted = tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(8)), out var next);
 
         Assert.True(accepted);
         Assert.Equal(new StreamCursor("orders", new EventSequenceToken(8)), next.LatestStream(streamId));
@@ -211,8 +211,8 @@ public sealed class MessageTrackerTests
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-b"), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-b"), out tracker);
 
         var latest = tracker.LatestStream("provider-a", "orders");
 
@@ -225,7 +225,7 @@ public sealed class MessageTrackerTests
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
 
         var latest = tracker.LatestStreamSequenceToken("orders");
 
@@ -238,7 +238,7 @@ public sealed class MessageTrackerTests
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
 
         var latest = tracker.LatestStream("provider-b", "orders");
 
@@ -251,8 +251,8 @@ public sealed class MessageTrackerTests
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-b"), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7), "provider-a"), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(9), "provider-b"), out tracker);
 
         var latest = tracker.LatestStreamSequenceToken("orders");
 
@@ -260,13 +260,13 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_accepts_null_stream_token_without_tracking_position()
+    public void TryAcceptMessage_accepts_null_stream_token_without_tracking_position()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
 
-        var accepted = tracker.ProcessMessage("orders", token: null, out var next);
+        var accepted = tracker.TryAcceptMessage("orders", token: null, out var next);
 
         Assert.True(accepted);
         Assert.Same(tracker, next);
@@ -275,32 +275,32 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_accepts_non_null_stream_token_after_null_initial_position()
+    public void TryAcceptMessage_accepts_non_null_stream_token_after_null_initial_position()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var time = new ManualTimeProvider(now);
         var streamId = StreamId.Create("orders", "one");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", null), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", null), out tracker);
 
-        var accepted = tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(1)), out var next);
+        var accepted = tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(1)), out var next);
 
         Assert.True(accepted);
         Assert.Equal(new StreamCursor("orders", new EventSequenceToken(1)), next.LatestStream(streamId));
     }
 
     [Fact]
-    public void ProcessMessage_accepts_null_stream_token_without_changing_tracked_position()
+    public void TryAcceptMessage_accepts_null_stream_token_without_changing_tracked_position()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var time = new ManualTimeProvider(now);
         var streamId = StreamId.Create("orders", "one");
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(1)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(1)), out tracker);
 
-        var accepted = tracker.ProcessMessage(new StreamCursor("orders", null), out var next);
+        var accepted = tracker.TryAcceptMessage(new StreamCursor("orders", null), out var next);
 
         Assert.True(accepted);
         Assert.Same(tracker, next);
@@ -308,23 +308,23 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_rejects_outbox_token_when_same_epoch_and_not_newer_sequence()
+    public void TryAcceptMessage_rejects_outbox_token_when_same_epoch_and_not_newer_sequence()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var sender = GrainId.Create("test/sender", "one");
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new OutboxSequenceToken(5, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(5, sender, now, now), out tracker);
 
-        var accepted = tracker.ProcessMessage(new OutboxSequenceToken(5, sender, now, now), out var next);
+        var accepted = tracker.TryAcceptMessage(new OutboxSequenceToken(5, sender, now, now), out var next);
 
         Assert.False(accepted);
         Assert.Same(tracker, next);
     }
 
     [Fact]
-    public void ProcessMessage_accepts_outbox_token_when_same_epoch_and_sequence_is_newer()
+    public void TryAcceptMessage_accepts_outbox_token_when_same_epoch_and_sequence_is_newer()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var sender = GrainId.Create("test/sender", "one");
@@ -332,10 +332,10 @@ public sealed class MessageTrackerTests
         var second = new OutboxSequenceToken(2, sender, now, now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(now));
-        tracker.ProcessMessage(first, out tracker);
+        tracker.TryAcceptMessage(first, out tracker);
 
-        var accepted = tracker.ProcessMessage(second, out var next);
-        var acceptedAgain = next.ProcessMessage(second, out var unchanged);
+        var accepted = tracker.TryAcceptMessage(second, out var next);
+        var acceptedAgain = next.TryAcceptMessage(second, out var unchanged);
 
         Assert.True(accepted);
         Assert.Equal(second, next.LatestOutbox(sender));
@@ -344,7 +344,7 @@ public sealed class MessageTrackerTests
     }
 
     [Fact]
-    public void ProcessMessage_rejects_outbox_token_when_epoch_is_stale()
+    public void TryAcceptMessage_rejects_outbox_token_when_epoch_is_stale()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var sender = GrainId.Create("test/sender", "one");
@@ -353,16 +353,16 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, newEpoch), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, newEpoch), out tracker);
 
-        var accepted = tracker.ProcessMessage(new OutboxSequenceToken(99, sender, now, oldEpoch), out var next);
+        var accepted = tracker.TryAcceptMessage(new OutboxSequenceToken(99, sender, now, oldEpoch), out var next);
 
         Assert.False(accepted);
         Assert.Same(tracker, next);
     }
 
     [Fact]
-    public void ProcessMessage_accepts_outbox_token_when_epoch_is_newer()
+    public void TryAcceptMessage_accepts_outbox_token_when_epoch_is_newer()
     {
         var now = new DateTimeOffset(2026, 5, 23, 12, 30, 0, TimeSpan.Zero);
         var sender = GrainId.Create("test/sender", "one");
@@ -371,9 +371,9 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new OutboxSequenceToken(10, sender, now, oldEpoch), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(10, sender, now, oldEpoch), out tracker);
 
-        var accepted = tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, newEpoch), out var next);
+        var accepted = tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, newEpoch), out var next);
 
         Assert.True(accepted);
         Assert.Equal(new OutboxSequenceToken(1, sender, now, newEpoch), next.LatestOutbox(sender));
@@ -388,8 +388,8 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
-        tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
 
         var evicted = tracker.EvictStreams(now);
 
@@ -406,8 +406,8 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
-        tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
 
         var evicted = tracker.EvictOutboxes(now);
 
@@ -423,7 +423,7 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
+        tracker.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out tracker);
 
         var notEvicted = tracker.Evict(streamId, now.AddTicks(-1));
         var evicted = tracker.Evict(streamId, now);
@@ -440,7 +440,7 @@ public sealed class MessageTrackerTests
         var time = new ManualTimeProvider(now);
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(time);
-        tracker.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
+        tracker.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out tracker);
 
         var notEvicted = tracker.Evict(sender, now.AddTicks(-1));
         var evicted = tracker.Evict(sender, now);
@@ -459,8 +459,8 @@ public sealed class MessageTrackerTests
         var right = new MessageTracker();
         left.RegisterTimeProvider(time);
         right.RegisterTimeProvider(time);
-        left.ProcessMessage(new StreamCursor("orders", new EventSequenceToken(7)), out left);
-        right.ProcessMessage(new OutboxSequenceToken(1, sender, now, now), out right);
+        left.TryAcceptMessage(new StreamCursor("orders", new EventSequenceToken(7)), out left);
+        right.TryAcceptMessage(new OutboxSequenceToken(1, sender, now, now), out right);
 
         Assert.NotEqual(left, right);
     }
@@ -518,7 +518,7 @@ public sealed class MessageTrackerTests
     {
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(received));
-        tracker.ProcessMessage(stream, out tracker);
+        tracker.TryAcceptMessage(stream, out tracker);
 
         return tracker;
     }
@@ -527,7 +527,7 @@ public sealed class MessageTrackerTests
     {
         var tracker = new MessageTracker();
         tracker.RegisterTimeProvider(new ManualTimeProvider(received));
-        tracker.ProcessMessage(outbox, out tracker);
+        tracker.TryAcceptMessage(outbox, out tracker);
 
         return tracker;
     }


### PR DESCRIPTION
Outbox callers can now initialize and enumerate payloads directly, inspect assigned IDs through `Envelopes`, and pass posted envelopes straight back to removal methods. Processor configuration no longer needs to copy the outbox into an array.

### Changes

- `Outbox<T>` implements `IReadOnlyList<T>` and supports `[]`, `[message]`, and payload spreads. Construction starts fresh sequence history and a fresh snapshot revision.
- `AddRange` batches payloads with a preallocated immutable-array builder when the input count is known. It preserves existing history, uses one timestamp per batch, and returns the original snapshot for an empty input. An explicit-timestamp overload is included.
- Public `ImmutableArray<OutboxMessageEnvelope<T>> Envelopes` exposes the stored snapshot without copying. New envelope-based `Remove` and `RemoveRange` overloads retain identity-based removal, including equal payloads and noncontiguous acknowledgement batches.
- `OutboxAccessor` returns a non-null `Outbox<T>` directly; acknowledgement and failure callbacks still receive envelopes.
- `ForStreamProvider(name, configure)` executes synchronous ordered registrations and returns the original processor for continued chaining. The previous overload remains available.

### Compatibility and design

This is a breaking public-interface change: enumeration and indexing now return payloads, and `OutboxAccessor` changes return type. The README includes migration examples. JSON shape, Orleans field IDs, revision-based recovery, and existing head-only single removal semantics are preserved. Collection expressions create fresh history; use `AddRange` to extend existing history and `Clear` to drain it. Payload objects must remain unmodified after enqueueing.

The design follows consumer feedback: retain an explicit public envelope view so callback values are discoverable, and avoid implementing two generic enumerable interfaces, which makes LINQ type inference ambiguous. Bare `RemoveRange([])` now needs a typed empty collection to select between ID and envelope overloads.

### Recovery regression found during coverage work

An aggregate containing a rejected storage attempt and an unclassified timeout previously skipped read-back recovery. The timeout can represent a write that already landed. The classifier now conservatively requires read-back proof whenever any inner failure has an uncertain outcome. A public `WriteAsync` regression test failed before this fix and passes afterwards.

### Validation

- Baseline: 284 tests passed.
- Full Release solution: 350 passed, zero failed or skipped, including the existing Orleans cluster, serialization/deep-copy, recovery, dispatch, and retry coverage.
- Behavioral red/green: temporarily resetting the batch sequence start to pending count caused both drained-history tests to fail (expected high-water mark 3, actual 2); restored implementation passes.
- Release `dotnet pack` succeeded for all three OM solution packages, with warnings treated as errors by the repository.
- No deployed-service acceptance testing was performed.

Commands run from `Egil.Orleans.Messaging`:

```text
dotnet test --solution Egil.Orleans.Messaging.slnx --configuration Release
dotnet pack Egil.Orleans.Messaging.slnx -c Release --no-restore --output /tmp/om-pack
```

Follow-up tests cover failed batch input, self-append, required persisted identity fields, null payloads, deduplication expiry/provider isolation, timeout/throttling recovery, and provider configuration throwing after an earlier registration. No property tests or synthetic storage responses were added to inflate coverage. A registration-loss mutation was caught by the new test (unexpected fallback delivery).

Local merged branch coverage with coverlet.console 10.0.1, excluding generated code and test assemblies:

| Package | Before follow-up | After |
|---|---:|---:|
| OM core | 77.51% | 83.88% |
| Azure Storage | 29.91% | 33.03% |
| Event Hubs | 69.23% | 69.23% |
| Combined | 70.80% | 75.93% |

The latest coverage run executed all 350 tests. Much of the remaining Azure gap is an error-code fallback bypassed by ordinary HTTP status handling. CI currently runs tests without collecting coverage; these are local measurements, not a new coverage gate.

Earlier review at `41b28df69ca354bf5e2061ae768dfc4de0bf9d16` covered the rename, documentation, recovery fix, and selected tests. Review remediation replaced eviction allocation-identity assertions with retained duplicate-rejection assertions.

### Reachable core branch follow-up

Commit `27e204c` adds 30 cases covering subscription conflict ownership, custom error callback containment, legacy resume positions, converter descriptor conflicts, persisted metadata validation, consumer tracing, and clock-skew metrics. Core gains 29 branches: **538/676 (79.59%) → 567/676 (83.88%)**, with production code and instrumentation exclusions unchanged.

Each added test method went through a focused incorrect-assertion red check and corrected green check. Self-review replaced simpler collision checks with original-handler delivery assertions. The full stable-SDK Release suite and merged instrumentation each passed all 337 cases. Stream callback tests use a real Orleans grain context and an existing hand-built stream boundary; diagnostics listeners isolate observations by source identity.

Compiler-impossible parser states and trivial properties were not targeted. The optional coalesced-empty scheduling case was not retained: the existing public harness would require timing-based absence checks or internal timer inspection to distinguish an unnecessary queued callback. No production seam was introduced for coverage.

### State-manager cancellation

`ReadAsync`, `WriteAsync`, and `ClearAsync` now accept optional cancellation tokens, forwarded through constructor registration, storage operations, and recovery reads. Pre-canceled requests do not touch storage or stamp write versions. Canceled recovery retains the previous visible snapshot and original operation error; callers re-read with a fresh token before another mutation. Confirmed successful writes and clears are adopted even when cancellation arrives concurrently. Provider cancellation remains cooperative.

Custom `IStateManager<T>` implementations must update their signatures; existing calls can omit the token after recompilation. XML documentation and README examples describe this contract and forward callback tokens into durable writes.

Commit `b30815e` was self-reviewed. All 350 Release tests and all three package builds pass; 11 cancellation regressions failed before propagation was implemented, and two success-race cases passed after incorrect cancellation expectations were corrected. Constructor registration uses a real Orleans grain test; interrupted storage/recovery uses a controllable persistent-state boundary. Core coverage remains 567/676 (83.88%), with unchanged exclusions. No live Azure cancellation acceptance test was performed. 

### Message acceptance naming

All four `MessageTracker.ProcessMessage` overloads are renamed to `TryAcceptMessage`, describing the acceptance decision and returned tracker without implying handler execution. Callers, test names, README examples, and API design documentation use the new name. Migration guidance notes the breaking rename and clarifies that tokenless stream messages are accepted without advancing tracking state. Behavior and serialization are unchanged.

Rename commit `4d2ac90` was self-reviewed; all 350 Release tests and all three package builds pass.
